### PR TITLE
Update go.mod/go.sum to use falcosecurity/plugin-sdk-go

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+make

--- a/plugins/cloudtrail/go.mod
+++ b/plugins/cloudtrail/go.mod
@@ -2,11 +2,9 @@ module github.com/falcosecurity/plugins/cloudtrail
 
 go 1.15
 
-replace github.com/falcosecurity/plugin-sdk-go => ../../../plugin-sdk-go
-
 require github.com/aws/aws-sdk-go v1.36.23
 
 require (
-	github.com/falcosecurity/plugin-sdk-go v0.0.2-plugin-system-api-additions
+	github.com/falcosecurity/plugin-sdk-go v0.0.0-20210920205424-14d6b71b4b65
 	github.com/valyala/fastjson v1.6.3
 )

--- a/plugins/cloudtrail/go.sum
+++ b/plugins/cloudtrail/go.sum
@@ -1,6 +1,8 @@
 github.com/aws/aws-sdk-go v1.36.23 h1:umM44ptMKImsUWLtjGBv/4Ut7Nd99DfqoZDkO0j0/Kc=
 github.com/aws/aws-sdk-go v1.36.23/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/falcosecurity/plugin-sdk-go v0.0.0-20210920205424-14d6b71b4b65 h1:M6oCWlAwjxRslNER84sHuKL85I9JFuUJAflubVK+jbg=
+github.com/falcosecurity/plugin-sdk-go v0.0.0-20210920205424-14d6b71b4b65/go.mod h1:9IdFIqRwJIFDfKnwTTM6S4mLITNfdjVl+5r4RY0TmRo=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=

--- a/plugins/dummy/go.mod
+++ b/plugins/dummy/go.mod
@@ -2,8 +2,6 @@ module github.com/falcosecurity/plugins/dummy
 
 go 1.15
 
-replace github.com/falcosecurity/plugin-sdk-go => ../../../plugin-sdk-go
-
 require (
-	github.com/falcosecurity/plugin-sdk-go v0.0.2-plugin-system-api-additions
+	github.com/falcosecurity/plugin-sdk-go v0.0.0-20210920205424-14d6b71b4b65
 )

--- a/plugins/dummy/go.sum
+++ b/plugins/dummy/go.sum
@@ -1,0 +1,2 @@
+github.com/falcosecurity/plugin-sdk-go v0.0.0-20210920205424-14d6b71b4b65 h1:M6oCWlAwjxRslNER84sHuKL85I9JFuUJAflubVK+jbg=
+github.com/falcosecurity/plugin-sdk-go v0.0.0-20210920205424-14d6b71b4b65/go.mod h1:9IdFIqRwJIFDfKnwTTM6S4mLITNfdjVl+5r4RY0TmRo=

--- a/plugins/json/go.mod
+++ b/plugins/json/go.mod
@@ -2,9 +2,7 @@ module github.com/falcosecurity/plugins/json
 
 go 1.15
 
-replace github.com/falcosecurity/plugin-sdk-go => ../../../plugin-sdk-go
-
 require (
-	github.com/falcosecurity/plugin-sdk-go v0.0.2-plugin-system-api-additions
+	github.com/falcosecurity/plugin-sdk-go v0.0.0-20210920205424-14d6b71b4b65
 	github.com/valyala/fastjson v1.6.3
 )

--- a/plugins/json/go.sum
+++ b/plugins/json/go.sum
@@ -1,0 +1,4 @@
+github.com/falcosecurity/plugin-sdk-go v0.0.0-20210920205424-14d6b71b4b65 h1:M6oCWlAwjxRslNER84sHuKL85I9JFuUJAflubVK+jbg=
+github.com/falcosecurity/plugin-sdk-go v0.0.0-20210920205424-14d6b71b4b65/go.mod h1:9IdFIqRwJIFDfKnwTTM6S4mLITNfdjVl+5r4RY0TmRo=
+github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
+github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=


### PR DESCRIPTION
This ensures the official version of plugin-sdk-go will be used.

Also add a minimal build.sh script that just invokes make.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>