### PR TITLE
Don't return event numbers in plugin_next()

### DIFF
--- a/plugins/dummy/dummy.go
+++ b/plugins/dummy/dummy.go
@@ -74,11 +74,10 @@ type instanceState struct {
 	// The number of events to return before EOF
 	maxEvents uint64
 
-	// A count of events returned. This is put in every event as
-	// the evtnum property.
+	// A count of events returned. Used to count against maxEvents.
 	counter uint64
 
-	// A semi-random numeric value, derived from the counter and
+	// A semi-random numeric value, derived from this value and
 	// jitter. This is put in every event as the data property.
 	sample uint64
 }
@@ -282,8 +281,10 @@ func Next(pState unsafe.Pointer, iState unsafe.Pointer) (*sdk.PluginEvent, int32
 	// It is not mandatory to set the Timestamp of the event (it
 	// would be filled in by the framework if set to uint_max),
 	// but it's a good practice.
+	//
+	// Also note that the Evtnum is not set, as event numbers are
+	// assigned by the plugin framework.
 	evt := &sdk.PluginEvent{
-		Evtnum:    is.counter,
 		Data:      []byte(str),
 		Timestamp: uint64(time.Now().Unix()) * 1000000000,
 	}

--- a/plugins/dummy_c/dummy.cpp
+++ b/plugins/dummy_c/dummy.cpp
@@ -65,11 +65,10 @@ typedef struct instance_state
 	// The number of events to return before EOF
 	uint64_t max_events;
 
-	// A count of events returned. This is put in every event as
-	// the evtnum property.
+	// A count of events returned. Used to count against maxEvents.
 	uint64_t counter;
 
-	// A semi-random numeric value, derived from the counter and
+	// A semi-random numeric value, derived from this value and
 	// jitter. This is put in every event as the data property.
 	uint64_t sample;
 } instance_state;
@@ -279,7 +278,8 @@ int32_t plugin_next(ss_plugin_t* s, ss_instance_t* i, ss_plugin_event **evt)
 
 	struct ss_plugin_event *ret = (struct ss_plugin_event *) malloc(sizeof(ss_plugin_event));
 
-	ret->evtnum = istate->counter;
+	// Note that evtnum is not set, as event numbers are
+	// assigned by the plugin framework.
 	ret->data = (uint8_t *) strdup(payload.c_str());
 	ret->datalen = payload.size();
 


### PR DESCRIPTION
Event numbers are assigned by the plugin framework, not plugins, so
don't set them when returning values in plugin_next().

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area source-plugins

> /area extractor-plugins

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->

```release-note
Don't fill in event numbers in plugin_next(), they're allocated by the plugin framework.
```