### PR TITLE
Add a ct.error field to extract errors

### DIFF
--- a/plugins/cloudtrail/README.md
+++ b/plugins/cloudtrail/README.md
@@ -21,6 +21,7 @@ Here is the current set of supported fields:
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | ct.id | string | the unique ID of the cloudtrail event (eventID in the json).
+| ct.error | string | The error code from the event. Will be "" if there was no error.
 | ct.time | string | the timestamp of the cloudtrail event (eventTime in the json).
 | ct.src | string | the source of the cloudtrail event (eventSource in the json, without the '.amazonaws.com' trailer).
 | ct.name | string | the name of the cloudtrail event (eventName in the json).

--- a/plugins/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/cloudtrail.go
@@ -257,6 +257,7 @@ func plugin_get_event_source() *C.char {
 func plugin_get_fields() *C.char {
 	flds := []sdk.FieldEntry{
 		{Type: "string", Name: "ct.id", Display: "Event ID", Desc: "the unique ID of the cloudtrail event (eventID in the json)."},
+		{Type: "string", Name: "ct.error", Display: "Error Code", Desc: "The error code from the event. Will be \"\" if there was no error."},
 		{Type: "string", Name: "ct.time", Display: "Timestamp", Desc: "the timestamp of the cloudtrail event (eventTime in the json).", Properties: "hidden"},
 		{Type: "string", Name: "ct.src", Display: "AWS Service", Desc: "the source of the cloudtrail event (eventSource in the json, without the '.amazonaws.com' trailer)."},
 		{Type: "string", Name: "ct.name", Display: "Event Name", Desc: "the name of the cloudtrail event (eventName in the json)."},
@@ -875,6 +876,8 @@ func getfieldStr(jdata *fastjson.Value, field string) (bool, string) {
 	switch field {
 	case "ct.id":
 		res = string(jdata.GetStringBytes("eventID"))
+	case "ct.error":
+		res = string(jdata.GetStringBytes("errorCode"))
 	case "ct.time":
 		res = string(jdata.GetStringBytes("eventTime"))
 	case "ct.src":


### PR DESCRIPTION
More useful than extracting using json/jevt plugins.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area source-plugins

> /area extractor-plugins

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->

```release-note
Add ct.error field to cloudtrail plugin.
```