### PR TITLE
Use an initial version of 0.1.0 for plugins/plugin api

### DIFF
--- a/plugins/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/cloudtrail.go
@@ -60,13 +60,13 @@ import (
 
 // Plugin info
 const (
-	PluginRequiredApiVersion = "1.0.0"
+	PluginRequiredApiVersion = "0.1.0"
 	PluginID          uint32 = 2
 	PluginName               = "cloudtrail"
 	PluginFilterName         = "ct"
 	PluginDescription        = "reads cloudtrail JSON data saved to file in the directory specified in the settings"
 	PluginContact            = "github.com/leogr/plugins/"
-	PluginVersion = "0.0.1"
+	PluginVersion            = "0.1.0"
 	PluginEventSource        = "aws_cloudtrail"
 )
 

--- a/plugins/dummy/dummy.go
+++ b/plugins/dummy/dummy.go
@@ -37,12 +37,12 @@ import (
 
 // Plugin consts
 const (
-	PluginRequiredApiVersion        = "1.0.0"
+	PluginRequiredApiVersion        = "0.1.0"
 	PluginID                 uint32 = 3
 	PluginName                      = "dummy"
 	PluginDescription               = "Reference plugin for educational purposes"
 	PluginContact                   = "github.com/falcosecurity/plugins"
-	PluginVersion                   = "1.0.0"
+	PluginVersion                   = "0.1.0"
 	PluginEventSource               = "dummy"
 )
 

--- a/plugins/dummy_c/dummy.cpp
+++ b/plugins/dummy_c/dummy.cpp
@@ -27,13 +27,13 @@ limitations under the License.
 
 using json = nlohmann::json;
 
-static const char *pl_required_api_version = "1.0.0";
+static const char *pl_required_api_version = "0.1.0";
 static uint32_t    pl_type                 = TYPE_SOURCE_PLUGIN;
 static uint32_t    pl_id                   = 4;
 static const char *pl_name                 = "dummy_c";
 static const char *pl_desc                 = "Reference plugin for educational purposes";
 static const char *pl_contact              = "github.com/falcosecurity/plugins";
-static const char *pl_version              = "1.0.0";
+static const char *pl_version              = "0.1.0";
 static const char *pl_event_source         = "dummy";
 static const char *pl_fields               = R"(
 [{"type": "uint64", "name": "dummy.divisible", "argRequired": true, "desc": "Return 1 if the value is divisible by the provided divisor, 0 otherwise"},

--- a/plugins/json/json.go
+++ b/plugins/json/json.go
@@ -41,11 +41,11 @@ import (
 
 // Plugin info
 const (
-	PluginRequiredApiVersion = "1.0.0"
+	PluginRequiredApiVersion = "0.1.0"
 	PluginName               = "json"
 	PluginDescription        = "implements extracting arbitrary fields from inputs formatted as JSON"
 	PluginContact            = "github.com/leogr/plugins/"
-	PluginVersion = "0.0.1"
+	PluginVersion            = "0.1.0"
 )
 
 const verbose bool = false


### PR DESCRIPTION
Instead of starting with a bold 1.0.0 for the initial plugins api
version, we're going to start with a more reasonable 0.1.0. While
we're at it, let's use an initial version of 0.1.0 for all plugin
versions.

After this, the plugin versions will progress independently from each
other and from the api version.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area source-plugins

/area extractor-plugins

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->

```release-note
NONE
```