### PR TITLE
refactor(Makefile): load plugins list in a dynamic way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ KERNEL=$(shell uname -s | tr A-Z a-z)
 ARCH=$(shell uname -m)
 PACKAGE_DIR=falcosecurity-plugins-${PLUGINS_VERSION}-${KERNEL}-${ARCH}
 
-plugins = cloudtrail dummy dummy_c json
+plugins = $(shell ls -d plugins/*/ | cut -f2 -d'/' | xargs)
 pluginsclean = $(addsuffix clean,$(plugins))
 
 all: plugin_info.h $(plugins)


### PR DESCRIPTION
Signed-off-by: Michele Zuccala <michele@zuccala.com>

**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:
This PR changes the way Makefile loads plugins - from a static list to a dynamic enumeration of the folders inside `./plugins/`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```