### PR TITLE
build: refactor Makefile package target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
+.DS_Store
+output/
 plugins/*/*.so
 plugins/*/lib*.h
 plugins/dummy_c/nlohmann
 plugin_info.h
-


### PR DESCRIPTION
Signed-off-by: Michele Zuccala <michele@zuccala.com>

**What type of PR is this?**
/kind feature

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
This PR refactors the way Makefile package target are handled. The main goal is to prepare .tar.gz packages ready to be uploaded to S3 by the CI.

**Special notes for your reviewer**:
All the `packages` targets will probably need to be reviewed as soon as we define a final policy for plugins versioning (e.g. plugins will self-declare their own version vs we use repo's git tag to define it).

**Does this PR introduce a user-facing change?**:
```release-note
build: refactor Makefile package target
```