### PR TITLE
fix(cloudtrail): properly read init config

### DIFF
--- a/plugins/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/cloudtrail.go
@@ -161,27 +161,28 @@ func (p *pluginContext) Init(cfg string) error {
 
 	log.Printf("[%s] Init, config=%s\n", PluginName, cfg)
 
-	// Allocate the context struct attach it to the state
-	pCtx := &pluginContext{
-		jdataEvtnum: math.MaxUint64,
-		sqsDelete:   true,
-	}
+	p.jdataEvtnum = math.MaxUint64
+	p.sqsDelete = true
+	p.s3DownloadConcurrency = defaultS3DownloadConcurrency
+	p.useAsync = false
 
 	if cfg != "" {
 		var initConfig pluginInitConfig
 		initConfig.SQSDelete = true
 		initConfig.S3DownloadConcurrency = defaultS3DownloadConcurrency
+		initConfig.UseAsync = false
 
 		err := json.Unmarshal([]byte(cfg), &initConfig)
 		if err != nil {
 			return err
 		}
-		pCtx.sqsDelete = initConfig.SQSDelete
-		pCtx.s3DownloadConcurrency = initConfig.S3DownloadConcurrency
-		pCtx.useAsync = initConfig.UseAsync
+
+		p.sqsDelete = initConfig.SQSDelete
+		p.s3DownloadConcurrency = initConfig.S3DownloadConcurrency
+		p.useAsync = initConfig.UseAsync
 	}
 
-	if pCtx.useAsync {
+	if p.useAsync {
 		extract.StartAsync(p)
 	}
 


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area source-plugins

/area extractor-plugins

**What this PR does / why we need it**:

This PR fixes the `cloudtrail` plugin, which currently fails to read the `init` configuration.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```