### PR TITLE
fix(sdk/cpp): catch errors during plugin initialization

### DIFF
--- a/plugins/dummy_c/dummy.cpp
+++ b/plugins/dummy_c/dummy.cpp
@@ -113,7 +113,7 @@ void dummy_plugin::get_info(falcosecurity::plugin_info &info)
 
 ss_plugin_rc dummy_plugin::init(const char *config)
 {
-	m_config = config;
+	m_config = config != NULL ? config : "";
 
 	// Config is optional. In this case defaults are used.
 	if(m_config == "" || m_config == "{}")
@@ -128,8 +128,7 @@ ss_plugin_rc dummy_plugin::init(const char *config)
 	}
 	catch (std::exception &e)
 	{
-		// No need to call set_last_error() here as the plugin
-		// struct doesn't exist to the framework yet.
+		set_last_error(e.what());
 		return SS_PLUGIN_FAILURE;
 	}
 
@@ -137,8 +136,7 @@ ss_plugin_rc dummy_plugin::init(const char *config)
 
 	if(it == obj.end())
 	{
-		// No need to call set_last_error() here as the plugin
-		// struct doesn't exist to the framework yet.
+		set_last_error("jitter not defined");
 		return SS_PLUGIN_FAILURE;
 	}
 

--- a/sdk/cpp/falcosecurity_plugin.h
+++ b/sdk/cpp/falcosecurity_plugin.h
@@ -213,9 +213,8 @@ public:
 
 	// Initialize this plugin. config is the init config as
 	// defined by the plugin. Returns SS_PLUGIN_SUCCESS on
-	// success, SS_PLUGIN_FAILURE on failure. There isn't any need
-	// to set an error string via set_last_error() as the Plugin
-	// API doesn't pass back error strings from plugin_init.
+	// success, SS_PLUGIN_FAILURE on failure. In case of failure,
+	// an error string can be set via set_last_error().
 	virtual ss_plugin_rc init(const char* config) = 0;
 
 	// Destroy this plugin. The plugin object will be destroyed
@@ -474,9 +473,11 @@ ss_plugin_t* plugin_init(const char* config, ss_plugin_rc* rc)  \
   \
 	*rc = plugin->init(config);  \
   \
-	if(*rc != SS_PLUGIN_SUCCESS)  \
+	if(*rc != SS_PLUGIN_SUCCESS &&	\
+		(plugin->plugin_get_last_error() == NULL || strlen(plugin->plugin_get_last_error()) == 0))	\
 	{  \
-		delete plugin;  \
+		delete plugin;	\
+		plugin = NULL;	\
 	}  \
   \
 	return plugin;  \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area source-plugins

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR alignes the cpp SDK and the `dummy_c` plugin to the changes of https://github.com/falcosecurity/libs/pull/168, thus supporting catching errors during plugin initialization.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(sdk/cpp): catch errors during plugin initialization
```