### PR TITLE
build: adding release utils for plugin distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ $(plugins-packages): all build/utils/version
 	$(eval PLUGIN_PATH := plugins/$(PLUGIN_NAME)/lib$(PLUGIN_NAME).so)
 	$(eval PLUGIN_VERSION := $(shell ./build/utils/version --path $(PLUGIN_PATH) --pre-release | tail -n 1))
 	echo $(PLUGIN_VERSION)
+
+# re-run command to stop in case of non-zero exit code 
+	@./build/utils/version --path $(PLUGIN_PATH) --pre-release > /dev/null
+
 	mkdir -p $(OUTPUT_DIR)/$(PLUGIN_NAME)
 	cp -r $(PLUGIN_PATH) $(OUTPUT_DIR)/$(PLUGIN_NAME)/
 	cp -r plugins/$(PLUGIN_NAME)/README.md $(OUTPUT_DIR)/$(PLUGIN_NAME)/

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ plugin_info.h:
 
 .PHONY: build/utils/version
 build/utils/version:
-	cd build/utils && $(GO) build -o version version.go
+	@cd build/utils && make
 
 .PHONY: clean/build/utils/version
 clean/build/utils/version:
-	rm -f build/utils/version
+	@cd build/utils && make clean

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(plugins):
 	cd plugins/$@ && make
 
 .PHONY: clean
-clean: clean/plugin_info.h $(plugins-clean) clean/packages
+clean: clean/plugin_info.h $(plugins-clean) clean/packages clean/build/utils/version
 
 .PHONY: clean/plugin_info.h
 clean/plugin_info.h:
@@ -62,3 +62,11 @@ $(plugins-packages): all
 .PHONY: plugin_info.h
 plugin_info.h:
 	$(CURL) -Lso $@ https://raw.githubusercontent.com/falcosecurity/libs/${FALCOSECURITY_LIBS_REVISION}/userspace/libscap/plugin_info.h
+
+.PHONY: build/utils/version
+build/utils/version:
+	cd build/utils && $(GO) build -o version version.go
+
+.PHONY: clean/build/utils/version
+clean/build/utils/version:
+	rm -f build/utils/version

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ CURL = curl
 
 FALCOSECURITY_LIBS_REVISION=e25e44b3ba4cb90ba9ac75bf747978e41fb6b221
 
+DEBUG = 1
 OUTPUT_DIR := output
 SOURCE_DIR := plugins
 ARCH ?=$(shell uname -m)
@@ -31,7 +32,7 @@ all: plugin_info.h $(plugins)
 
 .PHONY: $(plugins)
 $(plugins):
-	cd plugins/$@ && make
+	cd plugins/$@ && make DEBUG=$(DEBUG)
 
 .PHONY: clean
 clean: clean/plugin_info.h $(plugins-clean) clean/packages clean/build/utils/version
@@ -67,6 +68,7 @@ $(plugins-packages): all build/utils/version
 	cp -r plugins/$(PLUGIN_NAME)/README.md $(OUTPUT_DIR)/$(PLUGIN_NAME)/
 	tar -zcvf $(OUTPUT_DIR)/$(PLUGIN_NAME)-$(PLUGIN_VERSION)-${ARCH}.tar.gz -C ${OUTPUT_DIR}/$(PLUGIN_NAME) .
 
+release/%: DEBUG=0
 release/%: plugin_info.h clean/% % build/utils/version
 	$(eval PLUGIN_NAME := $(shell basename $@))
 	$(eval PLUGIN_PATH := plugins/$(PLUGIN_NAME)/lib$(PLUGIN_NAME).so)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ FALCOSECURITY_LIBS_REVISION=e25e44b3ba4cb90ba9ac75bf747978e41fb6b221
 
 OUTPUT_DIR := output
 SOURCE_DIR := plugins
-PLUGINS_VERSION ?= $(shell git describe --always --tags)
 ARCH ?=$(shell uname -m)
 
 plugins = $(shell ls -d ${SOURCE_DIR}/*/ | cut -f2 -d'/' | xargs)
@@ -52,12 +51,15 @@ $(plugins-clean):
 packages: clean/packages $(plugins-clean) $(plugins-packages)
 
 .PHONY: $(plugins-packages)
-$(plugins-packages): all
+$(plugins-packages): all build/utils/version
 	$(eval PLUGIN_NAME := $(shell basename $@))
+	$(eval PLUGIN_PATH := plugins/$(PLUGIN_NAME)/lib$(PLUGIN_NAME).so)
+	$(eval PLUGIN_VERSION := $(shell ./build/utils/version --path $(PLUGIN_PATH) --pre-release | tail -n 1))
+	echo $(PLUGIN_VERSION)
 	mkdir -p $(OUTPUT_DIR)/$(PLUGIN_NAME)
-	cp -r plugins/$(PLUGIN_NAME)/*.so $(OUTPUT_DIR)/$(PLUGIN_NAME)/
+	cp -r $(PLUGIN_PATH) $(OUTPUT_DIR)/$(PLUGIN_NAME)/
 	cp -r plugins/$(PLUGIN_NAME)/README.md $(OUTPUT_DIR)/$(PLUGIN_NAME)/
-	tar -zcvf $(OUTPUT_DIR)/$(PLUGIN_NAME)-${PLUGINS_VERSION}-${ARCH}.tar.gz -C ${OUTPUT_DIR}/$(PLUGIN_NAME) .
+	tar -zcvf $(OUTPUT_DIR)/$(PLUGIN_NAME)-$(PLUGIN_VERSION)-${ARCH}.tar.gz -C ${OUTPUT_DIR}/$(PLUGIN_NAME) .
 
 .PHONY: plugin_info.h
 plugin_info.h:

--- a/build/utils/.gitignore
+++ b/build/utils/.gitignore
@@ -1,0 +1,1 @@
+version

--- a/build/utils/Makefile
+++ b/build/utils/Makefile
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+SHELL=/bin/bash -o pipefail
+
+GO ?= go
+
+all: version
+
+clean:
+	@rm -f version
+
+version: version.go
+	@$(GO) build -o version version.go

--- a/build/utils/go.mod
+++ b/build/utils/go.mod
@@ -1,0 +1,5 @@
+module github.com/falcosecurity/plugins/build/utils
+
+go 1.17
+
+require github.com/spf13/pflag v1.0.5

--- a/build/utils/go.sum
+++ b/build/utils/go.sum
@@ -1,0 +1,2 @@
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/build/utils/version.go
+++ b/build/utils/version.go
@@ -1,0 +1,180 @@
+//go:build (linux && cgo) || (darwin && cgo) || (freebsd && cgo)
+// +build linux,cgo darwin,cgo freebsd,cgo
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+/*
+#cgo linux LDFLAGS: -ldl
+#include <dlfcn.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <stdio.h>
+
+static uintptr_t pluginOpen(const char* path, char** err) {
+	void* h = dlopen(path, RTLD_NOW|RTLD_GLOBAL);
+	if (h == NULL) {
+		*err = (char*)dlerror();
+	}
+	return (uintptr_t)h;
+}
+
+static char* get_name(uintptr_t h, char** err) {
+	void* s = dlsym((void*)h, "plugin_get_name");
+	if (s == NULL) {
+		*err = (char*)dlerror();
+        return NULL;
+	}
+	typedef char* (*fptr)();
+    fptr f = (fptr)s;
+    return f();
+}
+
+static char* get_version(uintptr_t h, char** err) {
+	void* s = dlsym((void*)h, "plugin_get_version");
+	if (s == NULL) {
+		*err = (char*)dlerror();
+        return NULL;
+	}
+	typedef char* (*fptr)();
+    fptr f = (fptr)s;
+    return f();
+}
+
+*/
+import "C"
+
+func pluginInfo(path string) (name, version string, err error) {
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return
+	}
+
+	cPath := C.CString(path)
+	var cErr *C.char
+
+	h := C.pluginOpen(cPath, &cErr)
+	if h == 0 {
+		err = errors.New("cannot open " + path + ": " + C.GoString(cErr))
+		return
+	}
+
+	cName := C.get_name(h, &cErr)
+	if cName == nil {
+		err = errors.New("cannot get name of " + path + ": " + C.GoString(cErr))
+		return
+	}
+
+	cVer := C.get_version(h, &cErr)
+	if cVer == nil {
+		err = errors.New("cannot get version of " + path + ": " + C.GoString(cErr))
+		return
+	}
+
+	return C.GoString(cName), C.GoString(cVer), nil
+}
+
+func git(args ...string) (output []string, err error) {
+	fmt.Println("git ", strings.Join(args, " "))
+	stdout, err := exec.Command("git", args...).Output()
+	fmt.Println(string(stdout))
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, errors.New("git (" + exitErr.String() + "): " + string(exitErr.Stderr))
+		}
+		return nil, err
+	}
+
+	return strings.Split(string(stdout), "\n"), nil
+}
+
+func fail(err error) {
+	fmt.Printf("error: %s\n", err)
+	os.Exit(1)
+}
+
+func main() {
+	var path string
+	var pre bool
+	pflag.StringVar(&path, "path", "", "path to the .so file")
+	pflag.BoolVar(&pre, "pre-release", false, "if set, output a pre-release version")
+	pflag.Parse()
+
+	name, version, err := pluginInfo(path)
+	if err != nil {
+		fail(err)
+	}
+
+	// fmt.Println(name)
+	// fmt.Println(version)
+
+	if pre {
+		// pre-releases MUST adhere to x.y.z-a.b.c-n+hash format, given:
+		// - x.y.z is the plugin declared version
+		// - a.b.c is the latest released version of the plugin (git tagged)
+		// - n is the numeber of commits since the latest released version
+		// - hash is the git commit id (abbrev to 7 digits)
+
+		// get last tag
+		tags, err := git("describe", "--tags", "--abbrev=0", "--match", name+`-*`)
+		if err != nil {
+			fail(err)
+		}
+		if len(tags) == 0 {
+			fail(errors.New("no git tag found for: " + name))
+		}
+		lastTag := tags[0]
+		lastVer := strings.Replace(lastTag, name+"-", "", 1)
+
+		// get number of commits since the last tag
+		counts, err := git("rev-list", lastTag+"..", "--count")
+		if err != nil {
+			fail(err)
+		}
+		count := 0
+		if len(counts) > 0 {
+			count, _ = strconv.Atoi(counts[0])
+		}
+
+		refs, err := git("rev-parse", "--short=7", "HEAD")
+		if err != nil {
+			fail(err)
+		}
+		if len(refs) == 0 {
+			fail(errors.New("no commit id found"))
+		}
+		commitId := refs[0]
+
+		fmt.Printf("%s-%s-%d+%s\n", version, lastVer, count, commitId)
+
+	} else {
+		// stable versions MUST have a precise tag matching plugin name and version
+		expectedTag := name + "-" + version
+		tags, err := git("--no-pager", "tag", "--points-at", "HEAD")
+		if err != nil {
+			fail(err)
+		}
+		for _, tag := range tags {
+			if tag == expectedTag {
+				fmt.Println(version)
+				return
+			}
+		}
+
+		fail(errors.New("no git tag found: " + expectedTag))
+	}
+
+}

--- a/build/utils/version.go
+++ b/build/utils/version.go
@@ -128,25 +128,27 @@ func main() {
 		// - n is the numeber of commits since the latest released version
 		// - hash is the git commit id (abbrev to 7 digits)
 
+		lastVer := "0.0.0" // fallback value
+		var n int
+		var hash string
+
 		// get last tag
 		tags, err := git("describe", "--tags", "--abbrev=0", "--match", name+`-*`)
-		if err != nil {
-			fail(err)
-		}
-		if len(tags) == 0 {
-			fail(errors.New("no git tag found for: " + name))
-		}
-		lastTag := tags[0]
-		lastVer := strings.Replace(lastTag, name+"-", "", 1)
+		if err == nil {
+			if len(tags) == 0 {
+				fail(errors.New("no git tag found for: " + name))
+			}
+			lastTag := tags[0]
+			lastVer = strings.Replace(lastTag, name+"-", "", 1)
 
-		// get number of commits since the last tag
-		counts, err := git("rev-list", lastTag+"..", "--count")
-		if err != nil {
-			fail(err)
-		}
-		count := 0
-		if len(counts) > 0 {
-			count, _ = strconv.Atoi(counts[0])
+			// get number of commits since the last tag
+			counts, err := git("rev-list", lastTag+"..", "--count")
+			if err != nil {
+				fail(err)
+			}
+			if len(counts) > 0 {
+				n, _ = strconv.Atoi(counts[0])
+			}
 		}
 
 		refs, err := git("rev-parse", "--short=7", "HEAD")
@@ -156,9 +158,9 @@ func main() {
 		if len(refs) == 0 {
 			fail(errors.New("no commit id found"))
 		}
-		commitId := refs[0]
+		hash = refs[0]
 
-		fmt.Printf("%s-%s-%d+%s\n", version, lastVer, count, commitId)
+		fmt.Printf("%s-%s-%d+%s\n", version, lastVer, n, hash)
 
 	} else {
 		// stable versions MUST have a precise tag matching plugin name and version

--- a/plugins/cloudtrail/Makefile
+++ b/plugins/cloudtrail/Makefile
@@ -12,14 +12,21 @@
 #
 
 SHELL=/bin/bash -o pipefail
-
 GO ?= go
 
-all: libcloudtrail.so
+NAME := cloudtrail
+OUTPUT := lib$(NAME).so
+
+ifeq ($(DEBUG), 1)
+    GODEBUGFLAGS= GODEBUG=cgocheck=2
+else
+    GODEBUGFLAGS= GODEBUG=cgocheck=0
+endif
+
+all: $(OUTPUT)
 
 clean:
-	rm -f *.so *.h
+	@rm -f *.so *.h
 
-libcloudtrail.so: cloudtrail.go extract.go source.go
-	GODEBUG=cgocheck=2 $(GO) build -buildmode=c-shared -o libcloudtrail.so *.go
-
+$(OUTPUT): *.go
+	@$(GODEBUGFLAGS) $(GO) build -buildmode=c-shared -o $(OUTPUT)

--- a/plugins/dummy/Makefile
+++ b/plugins/dummy/Makefile
@@ -12,14 +12,21 @@
 #
 
 SHELL=/bin/bash -o pipefail
-
 GO ?= go
 
-all: libdummy.so
+NAME := dummy
+OUTPUT := lib$(NAME).so
+
+ifeq ($(DEBUG), 1)
+    GODEBUGFLAGS= GODEBUG=cgocheck=2
+else
+    GODEBUGFLAGS= GODEBUG=cgocheck=0
+endif
+
+all: $(OUTPUT)
 
 clean:
-	rm -f *.so *.h
+	@rm -f *.so *.h
 
-libdummy.so: dummy.go
-	GODEBUG=cgocheck=2 $(GO) build -buildmode=c-shared -o libdummy.so *.go
-
+$(OUTPUT): *.go
+	@$(GODEBUGFLAGS) $(GO) build -buildmode=c-shared -o $(OUTPUT)

--- a/plugins/json/Makefile
+++ b/plugins/json/Makefile
@@ -12,14 +12,21 @@
 #
 
 SHELL=/bin/bash -o pipefail
-
 GO ?= go
 
-all: libjson.so
+NAME := json
+OUTPUT := lib$(NAME).so
+
+ifeq ($(DEBUG), 1)
+    GODEBUGFLAGS= GODEBUG=cgocheck=2
+else
+    GODEBUGFLAGS= GODEBUG=cgocheck=0
+endif
+
+all: $(OUTPUT)
 
 clean:
-	rm -f *.h *.so
+	@rm -f *.so *.h
 
-libjson.so: json.go
-	GODEBUG=cgocheck=2 $(GO) build -buildmode=c-shared -o libjson.so *.go
-
+$(OUTPUT): *.go
+	@$(GODEBUGFLAGS) $(GO) build -buildmode=c-shared -o $(OUTPUT)

--- a/release.md
+++ b/release.md
@@ -1,0 +1,27 @@
+# Release Process
+
+Our release process is automated by several [Prow jobs](https://github.com/falcosecurity/test-infra/blob/master/config/jobs/build-plugins/build-plugins.yaml). 
+
+The process publishes two types of artifacts:
+- **dev** builds: the process is fully automated, and it is triggered when changes are merged into `master` branch
+- **stable** builds: the process is automated, but it needs to be manually triggered by tagging a plugin with a release version (see the [section](#Stable-builds) below)
+
+Artifacts will be published at https://download.falco.org/?prefix=plugins/.
+
+
+## Stable build
+
+Since the *plugins* repository is a [monorepo](https://en.wikipedia.org/wiki/Monorepo), we introduced a special convention for tagging release versions, so that we can differentiate among plugins. Git tag MUST respect the following format:
+
+*name*-*version*
+
+Where *name* is the plugin name (must match a folder under [./plugins](./plugins)) and *version* is the plugin version to be released (must match the version string declared by the plugin).
+
+
+## Initiating a plugin release (stable build)
+
+When we release, we do the following process:
+
+1. When changes are introduced to a plugin (i.e. a PR gets merged) and its version has been bumped, we choose the git tag based on the above convention
+2. A person with repository rights [creates a new release](https://github.com/falcosecurity/plugins/releases) from the GitHub UI
+3. Once the CI has done its job, the tag is live on [Github](https://github.com/falcosecurity/plugins/releases), and the plugin package is published at [download.falco.org](https://download.falco.org/?prefix=plugins/stable)


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>
Co-authored-by: Leonardo Grasso <me@leonardograsso.com>

**What type of PR is this?**

/kind design

/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This updates the Makefile to support building plugins for release purposes, and adds a tool to automatically compute a SemVer-compatible version number that will be used by the CI to build/publish both pre-release and release packages.

**Which issue(s) this PR fixes**:

Fixes #19 
Fixes #35

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
build: adding release utils for plugin distribution
```