### PR TITLE
update(.github): remove release note from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,15 +56,3 @@ If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issu
 Fixes #
 
 **Special notes for your reviewer**:
-
-**Does this PR introduce a user-facing change?**:
-
-<!--
-If no, just write "NONE" in the release-note block below.
-If yes, a release note is required:
-Enter your extended release note in the block below.
--->
-
-```release-note
-
-```


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

This removes the release note block from the PR template, as it's not required anymore due to the changes of https://github.com/falcosecurity/test-infra/pull/604

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
