### PR TITLE
update(.github): add registry kind in PR template and unify plugins area

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,9 +31,9 @@ Please remove the leading whitespace before the `/kind <>` you uncommented.
 
 > Uncomment one (or more) `/area <>` lines:
 
-> /area source-plugins
+> /area plugins
 
-> /area extractor-plugins
+> /area registry
 
 > /area build
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

Given the recent changes in this repository, this removes the PR template as follows:
- Remove `source-plugins` and `extractor-plugins` area labels, unifying them in a single `plugins` area
- Add an area label for `registry`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
