### PR TITLE
Fix off-by-one error in NextBatch

### DIFF
--- a/plugins/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/cloudtrail.go
@@ -211,8 +211,12 @@ func (o *openContext) NextBatch(pState sdk.PluginState, evts sdk.EventWriters) (
 	var n int
 	var err error
 	pCtx := pState.(*pluginContext)
-	for n = 0; err == nil && n < evts.Len(); n++ {
+	for n = 0; n < evts.Len(); n++ {
 		err = nextEvent(pCtx, o, evts.Get(n))
+
+		if err != nil {
+			break
+		}
 	}
 	return n, err
 }

--- a/plugins/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/cloudtrail.go
@@ -54,7 +54,7 @@ const (
 	PluginName                      = "cloudtrail"
 	PluginDescription               = "reads cloudtrail JSON data saved to file in the directory specified in the settings"
 	PluginContact                   = "github.com/falcosecurity/plugins/"
-	PluginVersion                   = "0.2.1"
+	PluginVersion                   = "0.2.2"
 	PluginEventSource               = "aws_cloudtrail"
 )
 


### PR DESCRIPTION
NextBatch is presented a long array of sdk.EventWriters and associates
events with them until the first error (which could include
eof/timeout).

If the last event results in an error, the loop would increment n,
then check the error, then return. n would be one bigger than
expected.

Fix this by checking for error + breaking inside the loop instead of
checking for error in the loop condition.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
