### PR TITLE
fix(plugins/json): fix quoting and escaping in string-based json.value

### DIFF
--- a/plugins/json/json.go
+++ b/plugins/json/json.go
@@ -130,7 +130,16 @@ func (m *MyPlugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
 		if val == nil {
 			return fmt.Errorf("json key not found: %s", arg)
 		}
-		req.SetValue(string(val.MarshalTo(nil)))
+
+		if val.Type() == fastjson.TypeString {
+			str, err := val.StringBytes()
+			if err != nil {
+				return err
+			}
+			req.SetValue(string(str))
+		} else {
+			req.SetValue(string(val.MarshalTo(nil)))
+		}
 	case 4: // jevt.obj
 		fallthrough
 	case 1: // json.obj

--- a/plugins/json/json.go
+++ b/plugins/json/json.go
@@ -40,7 +40,7 @@ const (
 	PluginName               = "json"
 	PluginDescription        = "implements extracting arbitrary fields from inputs formatted as JSON"
 	PluginContact            = "github.com/falcosecurity/plugins/"
-	PluginVersion            = "0.2.1"
+	PluginVersion            = "0.2.2"
 )
 
 type MyPlugin struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

This fixes the issue of #56. The `json` plugin relied on the `fastjson.MarshalTo` function, which unwillingly added the `"` quotes around strings and caused the Falco rules to not match string values properly.

**Which issue(s) this PR fixes**:

Fixes #56

**Special notes for your reviewer**:
