### PR TITLE
update(plugins/cloudtrail): bump plugin version to 0.2.3

### DIFF
--- a/plugins/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/cloudtrail.go
@@ -54,7 +54,7 @@ const (
 	PluginName                      = "cloudtrail"
 	PluginDescription               = "reads cloudtrail JSON data saved to file in the directory specified in the settings"
 	PluginContact                   = "github.com/falcosecurity/plugins/"
-	PluginVersion                   = "0.2.2"
+	PluginVersion                   = "0.2.3"
 	PluginEventSource               = "aws_cloudtrail"
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

This completes https://github.com/falcosecurity/plugins/pull/60, in which the `cloudtrail` plugin version was not bumped.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
