### PR TITLE
fix(registry): remove uniqueness constraint on source name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Registering your plugin inside the registry helps ensure that some technical con
 The registration process involves adding an entry about your plugin inside the [registry.yaml](./registry.yaml) file by creating a Pull Request in this repository. Please be mindful of a few constraints that are automatically checked and required for your plugin to be accepted:
 
 - The `name` field is mandatory and must be **unique** across all the plugins in the registry
-- *(Source plugins only)* The `id` and `source` fields are mandatory and must be **unique** across all the source plugins in the registry
+- *(Source plugins only)* The `id` field is mandatory and must be **unique** across all the source plugins in the registry
 - The plugin `name` and `source` fields should match this [regular expression](https://en.wikipedia.org/wiki/Regular_expression): `^[a-z]+[a-z0-9_]*$`
 
 For reference, here's an example of a source plugin entry:

--- a/build/registry/check.go
+++ b/build/registry/check.go
@@ -69,7 +69,6 @@ func (e *Extractor) Check() error {
 func (p *Plugins) Check(reserved []string) error {
 	ids := make(map[uint]bool)
 	names := make(map[string]bool)
-	sourceNames := make(map[string]bool)
 
 	for _, s := range p.Source {
 		if err := s.Check(reserved); err != nil {
@@ -81,12 +80,8 @@ func (p *Plugins) Check(reserved []string) error {
 		if _, ok := ids[s.ID]; ok {
 			return fmt.Errorf("source id is not unique: '%d'", s.ID)
 		}
-		if _, ok := sourceNames[s.Source]; ok {
-			return fmt.Errorf("source name is not unique: '%s'", s.Source)
-		}
 		names[s.Name] = true
 		ids[s.ID] = true
-		sourceNames[s.Source] = true
 	}
 
 	for _, e := range p.Extractor {


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind design

**Any specific area of the project related to this PR?**

/area registry

/area documentation

**What this PR does / why we need it**:

This removes the uniqueness constraint that we used to put on the source name of plugins. I makes sense for plugins with different IDs to share the same source name **if they share the same event data format**. This can allow different plugin implementations of the same event source to co-exist in the ecosystem (and in the registry).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
