### PR TITLE
fix(plugin/cloudtrail): manage cloudtrail empty file.

### DIFF
--- a/plugins/cloudtrail/source.go
+++ b/plugins/cloudtrail/source.go
@@ -321,7 +321,7 @@ func nextEvent(pCtx *pluginContext, oCtx *openContext, evt sdk.EventWriter) erro
 	var err error
 
 	// Only open the next file once we're sure that the content of the previous one has been full consumed
-	if oCtx.evtJSONListPos == len(oCtx.evtJSONStrings) {
+	if oCtx.evtJSONListPos >= len(oCtx.evtJSONStrings) {
 		// Open the next file and bring its content into memeory
 		if oCtx.curFileNum >= uint32(len(oCtx.files)) {
 
@@ -400,7 +400,6 @@ func nextEvent(pCtx *pluginContext, oCtx *openContext, evt sdk.EventWriter) erro
 		oCtx.evtJSONListPos++
 	} else {
 		// Json not int the expected format. Just skip this event.
-		oCtx.evtJSONListPos++
 		return sdk.ErrTimeout
 	}
 	// All cloudtrail events should have a time. If it's missing


### PR DESCRIPTION
Signed-off-by: Andrea Terzolo <andrea.terzolo@polito.it>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

Cloudtrail empty files cause problems in reading events. The format is the following:

```json
{
    "Records": []
}
```

Reading an empty file, the variable `len(oCtx.evtJSONStrings)` is always `0` so at line [403](https://github.com/falcosecurity/plugins/blob/4695796c8eba65a49a2a94581346aae2298aec25/plugins/cloudtrail/source.go#L403) we increment the `oCtx.evtJSONListPos`, but when we try to extract the next event from this file the `oCtx.evtJSONListPos` will be greater than `len(oCtx.evtJSONStrings)`. [This if statement](https://github.com/falcosecurity/plugins/blob/4695796c8eba65a49a2a94581346aae2298aec25/plugins/cloudtrail/source.go#L324) will never be true and we will keep trying to extract events from an empty file, preventing the plugin from behaving properly. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

I also removed the increment at line [403](https://github.com/falcosecurity/plugins/blob/4695796c8eba65a49a2a94581346aae2298aec25/plugins/cloudtrail/source.go#L403), although not necessary with the `>=` condition. It seems strange to me incrementing the counter as if we moved when indeed the file is empty, but that's just my opinion.