### PR TITLE
Cloudtrail: Handle floating point values.

### DIFF
--- a/plugins/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/cloudtrail.go
@@ -54,7 +54,7 @@ const (
 	PluginName                      = "cloudtrail"
 	PluginDescription               = "reads cloudtrail JSON data saved to file in the directory specified in the settings"
 	PluginContact                   = "github.com/falcosecurity/plugins/"
-	PluginVersion                   = "0.2.4"
+	PluginVersion                   = "0.2.5"
 	PluginEventSource               = "aws_cloudtrail"
 )
 

--- a/plugins/cloudtrail/extract.go
+++ b/plugins/cloudtrail/extract.go
@@ -466,6 +466,19 @@ func getfieldStr(jdata *fastjson.Value, field string) (bool, string) {
 	return true, res
 }
 
+func getvalueU64(jvalue *fastjson.Value) uint64 {
+	// Values are sometimes floats, e.g. "bytesTransferredOut": 33.0
+	u64, err := jvalue.Uint64()
+	if err == nil {
+		return u64
+	}
+	f64, err := jvalue.Float64()
+	if err == nil {
+		return uint64(f64)
+	}
+	return 0
+}
+
 func getfieldU64(jdata *fastjson.Value, field string) (bool, uint64) {
 	// Go should do binary search here:
 	// https://github.com/golang/go/blob/8ee9bca2729ead81da6bf5a18b87767ff396d1b7/src/cmd/compile/internal/gc/swt.go#L375
@@ -474,25 +487,25 @@ func getfieldU64(jdata *fastjson.Value, field string) (bool, uint64) {
 		var tot uint64 = 0
 		in := jdata.Get("additionalEventData", "bytesTransferredIn")
 		if in != nil {
-			tot = tot + in.GetUint64()
+			tot = tot + getvalueU64(in)
 		}
 		out := jdata.Get("additionalEventData", "bytesTransferredOut")
 		if out != nil {
-			tot = tot + out.GetUint64()
+			tot = tot + getvalueU64(out)
 		}
 		return (in != nil || out != nil), tot
 	case "s3.bytes.in":
 		var tot uint64 = 0
 		in := jdata.Get("additionalEventData", "bytesTransferredIn")
 		if in != nil {
-			tot = tot + in.GetUint64()
+			tot = tot + getvalueU64(in)
 		}
 		return (in != nil), tot
 	case "s3.bytes.out":
 		var tot uint64 = 0
 		out := jdata.Get("additionalEventData", "bytesTransferredOut")
 		if out != nil {
-			tot = tot + out.GetUint64()
+			tot = tot + getvalueU64(out)
 		}
 		return (out != nil), tot
 	case "s3.cnt.get":


### PR DESCRIPTION
Many of the events in a Cloudtrail scap here have floating point
bytesTransferred{In,Out} values, e.g.

"additionalEventData": {
  "SignatureVersion": "SigV4",
  "CipherSuite": "ECDHE-RSA-AES128-GCM-SHA256",
  "bytesTransferredIn": 0.0,
  "AuthenticationMethod": "AuthHeader",
  "x-amz-id-2": "Y/9E1+wcb4G90kzKPJ9K66wa+AIGssOLXHWQ7isdbcNc2OzUGBTYH4I7zjeZ3AR2zjn0oTuLZI4=",
  "bytesTransferredOut": 33.0
  }

This is arguably a bug with Cloudtrail, but here we are. Try parsing
them as Uint64 first, then fall back to Float64.

Signed-off-by: Gerald Combs <gerald@wireshark.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

We were parsing S3 byte values using fastjson's GetUint64. Unfortunately, [that will return 0](https://github.com/valyala/fastjson/blob/6dae91c8e11a7fa6a257a550b75cba53ab81693e/fastfloat/parse.go#L82) if we try to feed it a floating point value, and Cloudtrail's byte values can be encoded as floats.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
