### PR TITLE
update(build/registry): adds URL plugin artifacts field in the registry

### DIFF
--- a/build/registry/table.go
+++ b/build/registry/table.go
@@ -43,33 +43,35 @@ func (r *Registry) FormatMarkdownTable(contentType string) (string, error) {
 
 	switch contentType {
 	case sourcePluginsTableContentType:
-		ret.WriteString("| ID | Name | Event Source | Description | Info |\n")
-		ret.WriteString("| --- | --- | --- | --- | --- |\n")
+		ret.WriteString("| ID | Name | Event Source | Description | Info | Artifacts |\n")
+		ret.WriteString("| --- | --- | --- | --- | --- | --- |\n")
 		for _, s := range r.Plugins.Source {
-			line := fmt.Sprintf("| %d | %s | `%s` | %s | Authors: %s <br/> License: %s |\n",
+			line := fmt.Sprintf("| %d | %s | `%s` | %s | Authors: %s <br/> License: %s | %s |\n",
 				s.ID,
-				formatWithURL(s.Name, s.URL),
+				formatWithURL(s.Name, s.SourcesURL),
 				wrapNotAvailable(s.Source),
 				wrapNotAvailable(s.Description),
 				formatWithURL(s.Authors, s.Contact),
 				wrapNotAvailable(s.License),
+				formatWithURL(s.ArtifactsURL, s.ArtifactsURL),
 			)
 			ret.WriteString(line)
 		}
 	case extractorPluginsTableContentType:
-		ret.WriteString("| Name | Extract Event Sources | Description | Info |\n")
-		ret.WriteString("| --- | --- | --- | --- |\n")
+		ret.WriteString("| Name | Extract Event Sources | Description | Info | Artifacts |\n")
+		ret.WriteString("| --- | --- | --- | --- | --- |\n")
 		for _, e := range r.Plugins.Extractor {
 			sources := make([]string, 0)
 			for _, s := range e.Sources {
 				sources = append(sources, fmt.Sprintf("`%s`", s))
 			}
-			line := fmt.Sprintf("| %s | %s | %s | Authors: %s <br/> License: %s |\n",
-				formatWithURL(e.Name, e.URL),
+			line := fmt.Sprintf("| %s | %s | %s | Authors: %s <br/> License: %s | %s |\n",
+				formatWithURL(e.Name, e.SourcesURL),
 				wrapNotAvailable(strings.Join(sources, ", ")),
 				wrapNotAvailable(e.Description),
 				formatWithURL(e.Authors, e.Contact),
 				wrapNotAvailable(e.License),
+				formatWithURL(e.ArtifactsURL, e.ArtifactsURL),
 			)
 			ret.WriteString(line)
 		}

--- a/build/registry/types.go
+++ b/build/registry/types.go
@@ -23,26 +23,28 @@ import (
 )
 
 type Source struct {
-	ID          uint   `yaml:"id"`
-	Source      string `yaml:"source"`
-	Name        string `yaml:"name"`
-	Description string `yaml:"description"`
-	Authors     string `yaml:"authors"`
-	Contact     string `yaml:"contact"`
-	URL         string `yaml:"url"`
-	License     string `yaml:"license"`
-	Reserved    bool   `yaml:"reserved"`
+	ID           uint   `yaml:"id"`
+	Source       string `yaml:"source"`
+	Name         string `yaml:"name"`
+	Description  string `yaml:"description"`
+	Authors      string `yaml:"authors"`
+	Contact      string `yaml:"contact"`
+	SourcesURL   string `yaml:"sources"`
+	ArtifactsURL string `yaml:"url"`
+	License      string `yaml:"license"`
+	Reserved     bool   `yaml:"reserved"`
 }
 
 type Extractor struct {
-	Sources     []string `yaml:"sources"`
-	Name        string   `yaml:"name"`
-	Description string   `yaml:"description"`
-	Authors     string   `yaml:"authors"`
-	Contact     string   `yaml:"contact"`
-	URL         string   `yaml:"url"`
-	License     string   `yaml:"license"`
-	Reserved    bool     `yaml:"reserved"`
+	Sources      []string `yaml:"source"`
+	Name         string   `yaml:"name"`
+	Description  string   `yaml:"description"`
+	Authors      string   `yaml:"authors"`
+	Contact      string   `yaml:"contact"`
+	SourcesURL   string   `yaml:"sources"`
+	ArtifactsURL string   `yaml:"url"`
+	License      string   `yaml:"license"`
+	Reserved     bool     `yaml:"reserved"`
 }
 
 type Plugins struct {

--- a/registry.yaml
+++ b/registry.yaml
@@ -36,7 +36,7 @@ plugins:
       description: Reads Cloudtrail JSON logs from files/S3 and injects as events
       authors: The Falco Authors
       contact: https://falco.org/community
-      url: https://github.com/falcosecurity/plugins/tree/master/plugins/cloudtrail
+      sources: https://github.com/falcosecurity/plugins/tree/master/plugins/cloudtrail
       license: Apache-2.0
     - id: 3
       source: dummy
@@ -44,7 +44,7 @@ plugins:
       description: Reference plugin used to document interface
       authors: The Falco Authors
       contact: https://falco.org/community
-      url: https://github.com/falcosecurity/plugins/tree/master/plugins/dummy
+      sources: https://github.com/falcosecurity/plugins/tree/master/plugins/dummy
       license: Apache-2.0
     - id: 4
       source: dummy_c
@@ -52,7 +52,7 @@ plugins:
       description: Like Dummy, but written in C++
       authors: The Falco Authors
       contact: https://falco.org/community
-      url: https://github.com/falcosecurity/plugins/tree/master/plugins/dummy_c
+      sources: https://github.com/falcosecurity/plugins/tree/master/plugins/dummy_c
       license: Apache-2.0
     - id: 5
       source: docker
@@ -60,7 +60,7 @@ plugins:
       description: Docker Events
       authors: Thomas Labarussias
       contact: https://github.org/Issif
-      url: https://github.com/Issif/docker-plugin
+      sources: https://github.com/Issif/docker-plugin
       license: Apache-2.0
     - id: 6
       source: seccompagent
@@ -68,7 +68,7 @@ plugins:
       description: Seccomp Agent Events
       authors: Alban Crequy
       contact: https://github.com/kinvolk/seccompagent
-      url: https://github.com/kinvolk/seccompagent
+      sources: https://github.com/kinvolk/seccompagent
       license: Apache-2.0
     - id: 999
       source: test
@@ -81,5 +81,5 @@ plugins:
       description: Extract values from any JSON payload
       authors: The Falco Authors
       contact: https://falco.org/community
-      url: https://github.com/falcosecurity/plugins/tree/master/plugins/json
+      sources: https://github.com/falcosecurity/plugins/tree/master/plugins/json
       license: Apache-2.0


### PR DESCRIPTION
Signed-off-by: Andrea Bonanno <andrea@bonanno.cloud>
Co-Authored-By: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

 /area registry

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR adds the `Artifacts` field in the plugin registry, so we can differentiate bewteen sources and artifacts URLs.
As the plugin registry is the only source of truth for officially recognized plugins, this change could be useful to keep track where each artifact is published, an useful info for future consumers.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
