### PR TITLE
docs(README.md): update plugin registry table

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The tables below list all the plugins currently registered. The tables are autom
 | 4 | [dummy_c](https://github.com/falcosecurity/plugins/tree/master/plugins/dummy_c) | `dummy_c` | Like Dummy, but written in C++ | Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
 | 5 | [docker](https://github.com/Issif/docker-plugin) | `docker` | Docker Events | Authors: [Thomas Labarussias](https://github.org/Issif) <br/> License: Apache-2.0 |
 | 6 | [seccompagent](https://github.com/kinvolk/seccompagent) | `seccompagent` | Seccomp Agent Events | Authors: [Alban Crequy](https://github.com/kinvolk/seccompagent) <br/> License: Apache-2.0 |
+| 7 | [okta](https://github.com/falcosecurity/plugins/tree/master/plugins/okta) | `okta` | Okta Log Events | Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
 | 999 | test | `test` | This ID is reserved for source plugin development. Any plugin author can use this ID, but authors can expect events from other developers with this ID. After development is complete, the author should request an actual ID | Authors: N/A <br/> License: N/A |
 
 <!-- REGISTRY:SOURCE-TABLE -->


### PR DESCRIPTION
Updating README.md (automatically generated with build/registry). Made using the [build-plugins-update-readme-postsubmit](https://github.com/falcosecurity/test-infra/blob/master/config/jobs/build-plugins/build-plugins.yaml) ProwJob. Do not edit this PR.

/kind documentation

/area documentation