### PR TITLE
update(cloudtrail): Always fill in ct.info and add ct.managementevent

### DIFF
--- a/plugins/cloudtrail/extract.go
+++ b/plugins/cloudtrail/extract.go
@@ -24,6 +24,11 @@ import (
 	"github.com/valyala/fastjson"
 )
 
+// AWS CloudTrail log event reference:
+// https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference.html
+// AWS CloudTrail record contents:
+// https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-record-contents.html
+
 var supportedFields = []sdk.FieldEntry{
 	{Type: "string", Name: "ct.id", Display: "Event ID", Desc: "the unique ID of the cloudtrail event (eventID in the json)."},
 	{Type: "string", Name: "ct.error", Display: "Error Code", Desc: "The error code from the event. Will be \"<NA>\" (e.g. the NULL/empty/none value) if there was no error."},
@@ -54,6 +59,7 @@ var supportedFields = []sdk.FieldEntry{
 	{Type: "string", Name: "ct.srcip", Display: "Source IP", Desc: "the IP address generating the event (sourceIPAddress in the json).", Properties: []string{"conversation"}},
 	{Type: "string", Name: "ct.useragent", Display: "User Agent", Desc: "the user agent generating the event (userAgent in the json)."},
 	{Type: "string", Name: "ct.info", Display: "Info", Desc: "summary information about the event. This varies depending on the event type and, for some events, it contains event-specific details.", Properties: []string{"info"}},
+	{Type: "string", Name: "ct.managementevent", Display: "Management Event", Desc: "'true' if the event is a management event (AwsApiCall, AwsConsoleAction, AwsConsoleSignIn, or AwsServiceEvent), 'false' otherwise."},
 	{Type: "string", Name: "ct.readonly", Display: "Read Only", Desc: "'true' if the event only reads information (e.g. DescribeInstances), 'false' if the event modifies the state (e.g. RunInstances, CreateLoadBalancer...)."},
 	{Type: "string", Name: "s3.uri", Display: "Key URI", Desc: "the s3 URI (s3://<bucket>/<key>).", Properties: []string{"conversation"}},
 	{Type: "string", Name: "s3.bucket", Display: "Bucket Name", Desc: "the bucket name for s3 events.", Properties: []string{"conversation"}},
@@ -376,6 +382,13 @@ func getfieldStr(jdata *fastjson.Value, field string) (bool, string) {
 		}
 	case "ct.info":
 		res = getEvtInfo(jdata)
+	case "ct.managementevent":
+		ro := jdata.GetBool("managementEvent")
+		if ro {
+			res = "true"
+		} else {
+			res = "false"
+		}
 	case "ct.readonly":
 		ro := jdata.GetBool("readOnly")
 		if ro {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This ensures that the cloudtrail plugin always fills in the ct.info field. The the user, source IP, and event type are filled in by default, along with extra information for some event types. Reads are denoted with left arrows, writes are denoted with right arrows, and errors are denoted with exclamation marks. Examples:

user1 via 54.5.4.3 ← DescribeDBInstances
AWSServiceRoleForECS via ecs.amazonaws.com → DeleteNetworkInterface
user3 via 23.1.2.3 !← GetBucketLocation Size=302 Bucket=mybucket
user4 via 54.6.7.8 !→ CreateLogStream

This also adds the ct.managementevent field for managmentEvents

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
