### PR TITLE
refactor(registry): re-design plugin registry on top of new capabilities model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,12 +84,7 @@ check-registry: build/registry/registry
 update-readme: build/registry/registry
 	@build/registry/registry table ./registry.yaml \
 		--subfile=./README.md \
-		--subtag="<!-- REGISTRY:SOURCE-TABLE -->" \
-		--type=plugins-source
-	@build/registry/registry table ./registry.yaml \
-		--subfile=./README.md \
-		--subtag="<!-- REGISTRY:EXTRACTOR-TABLE -->" \
-		--type=plugins-extractor
+		--subtag="<!-- REGISTRY:TABLE -->"
 	@echo Readme has been updated successfully
 
 .PHONY: build/utils/version

--- a/README.md
+++ b/README.md
@@ -39,30 +39,22 @@ You can find the full registry specification here: *(coming soon...)*
 
 The tables below list all the plugins currently registered. The tables are automatically generated from the [registry.yaml](./registry.yaml) file.
 
-<!-- The text inside \<!-- REGISTRY:xxx --\> comments is auto-generated. These comments and the text between them should not be edited by hand -->
+<!-- The text inside \<!-- REGISTRY:xxx --\> comments is auto-generated.
+These comments and the text between them should not be edited by hand -->
+<!-- REGISTRY:TABLE -->
+| Name | Capabilities | Description
+| --- | --- | --- |
+| [k8saudit](https://github.com/falcosecurity/plugins/tree/master/plugins/k8saudit) | **Event Sourcing** <br/>ID: 1 <br/>`k8s_audit` <br/>**Field Extraction** <br/> `k8s_audit` | Read Kubernetes Audit Events and monitor Kubernetes Clusters  <br/><br/> Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
+| [cloudtrail](https://github.com/falcosecurity/plugins/tree/master/plugins/cloudtrail) | **Event Sourcing** <br/>ID: 2 <br/>`aws_cloudtrail` <br/>**Field Extraction** <br/> `aws_cloudtrail` | Reads Cloudtrail JSON logs from files/S3 and injects as events  <br/><br/> Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
+| [json](https://github.com/falcosecurity/plugins/tree/master/plugins/json) | **Field Extraction** <br/> *All Sources* | Extract values from any JSON payload  <br/><br/> Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
+| [dummy](https://github.com/falcosecurity/plugins/tree/master/plugins/dummy) | **Event Sourcing** <br/>ID: 3 <br/>`dummy` <br/>**Field Extraction** <br/> `dummy` | Reference plugin used to document interface  <br/><br/> Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
+| [dummy_c](https://github.com/falcosecurity/plugins/tree/master/plugins/dummy_c) | **Event Sourcing** <br/>ID: 4 <br/>`dummy_c` <br/>**Field Extraction** <br/> `dummy_c` | Like Dummy, but written in C++  <br/><br/> Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
+| [docker](https://github.com/Issif/docker-plugin) | **Event Sourcing** <br/>ID: 5 <br/>`docker` <br/>**Field Extraction** <br/> `docker` | Docker Events  <br/><br/> Authors: [Thomas Labarussias](https://github.org/Issif) <br/> License: Apache-2.0 |
+| [seccompagent](https://github.com/kinvolk/seccompagent) | **Event Sourcing** <br/>ID: 6 <br/>`seccompagent` <br/>**Field Extraction** <br/> `seccompagent` | Seccomp Agent Events  <br/><br/> Authors: [Alban Crequy](https://github.com/kinvolk/seccompagent) <br/> License: Apache-2.0 |
+| [okta](https://github.com/falcosecurity/plugins/tree/master/plugins/okta) | **Event Sourcing** <br/>ID: 7 <br/>`okta` <br/>**Field Extraction** <br/> `okta` | Okta Log Events  <br/><br/> Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
+| test | **Event Sourcing** <br/>ID: 999 <br/>`test` | This ID is reserved for source plugin development. Any plugin author can use this ID, but authors can expect events from other developers with this ID. After development is complete, the author should request an actual ID  <br/><br/> Authors: N/A <br/> License: N/A |
 
-#### Source Plugins
-<!-- REGISTRY:SOURCE-TABLE -->
-| ID | Name | Event Source | Description | Info |
-| --- | --- | --- | --- | --- |
-| 1 | [k8saudit](https://github.com/falcosecurity/plugins/tree/master/plugins/k8saudit) | `k8s_audit` | Read Kubernetes Audit Events and monitor Kubernetes Clusters | Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
-| 2 | [cloudtrail](https://github.com/falcosecurity/plugins/tree/master/plugins/cloudtrail) | `aws_cloudtrail` | Reads Cloudtrail JSON logs from files/S3 and injects as events | Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
-| 3 | [dummy](https://github.com/falcosecurity/plugins/tree/master/plugins/dummy) | `dummy` | Reference plugin used to document interface | Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
-| 4 | [dummy_c](https://github.com/falcosecurity/plugins/tree/master/plugins/dummy_c) | `dummy_c` | Like Dummy, but written in C++ | Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
-| 5 | [docker](https://github.com/Issif/docker-plugin) | `docker` | Docker Events | Authors: [Thomas Labarussias](https://github.org/Issif) <br/> License: Apache-2.0 |
-| 6 | [seccompagent](https://github.com/kinvolk/seccompagent) | `seccompagent` | Seccomp Agent Events | Authors: [Alban Crequy](https://github.com/kinvolk/seccompagent) <br/> License: Apache-2.0 |
-| 7 | [okta](https://github.com/falcosecurity/plugins/tree/master/plugins/okta) | `okta` | Okta Log Events | Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
-| 999 | test | `test` | This ID is reserved for source plugin development. Any plugin author can use this ID, but authors can expect events from other developers with this ID. After development is complete, the author should request an actual ID | Authors: N/A <br/> License: N/A |
-
-<!-- REGISTRY:SOURCE-TABLE -->
-
-#### Extractor Plugins
-<!-- REGISTRY:EXTRACTOR-TABLE -->
-| Name | Extract Event Sources | Description | Info |
-| --- | --- | --- | --- |
-| [json](https://github.com/falcosecurity/plugins/tree/master/plugins/json) | N/A | Extract values from any JSON payload | Authors: [The Falco Authors](https://falco.org/community) <br/> License: Apache-2.0 |
-
-<!-- REGISTRY:EXTRACTOR-TABLE -->
+<!-- REGISTRY:TABLE -->
 
 ## Hosted Plugins 
 

--- a/README.md
+++ b/README.md
@@ -13,24 +13,29 @@ The Registry contains metadata and information about every plugin known and reco
 
 ### Registering a new Plugin
 
-Registering your plugin inside the registry helps ensure that some technical constraints are respected, such as that a [given ID is used by exactly one source plugin](https://falco.org/docs/plugins/#plugin-event-ids) and allows source plugin authors and extractor plugin authors to [coordinate event source formats](https://falco.org/docs/plugins/#plugin-event-sources-and-interoperability). Moreover, this is a great way to share your plugin project with the community and engage with it, thus gaining new users and **increasing its visibility**. We encourage you to register your plugin in this registry before publishing it. You can add your plugins in this registry regardless of where its source code is hosted (there's a `url` field for this specifically).
+Registering your plugin inside the registry helps ensure that some technical constraints are respected, such as that a [given ID is used by exactly one plugin with event source capability](https://falco.org/docs/plugins/#plugin-event-ids) and allows plugin authors to [coordinate about event source formats](https://falco.org/docs/plugins/#plugin-event-sources-and-interoperability). Moreover, this is a great way to share your plugin project with the community and engage with it, thus gaining new users and **increasing its visibility**. We encourage you to register your plugin in this registry before publishing it. You can add your plugins in this registry regardless of where its source code is hosted (there's a `url` field for this specifically).
 
 The registration process involves adding an entry about your plugin inside the [registry.yaml](./registry.yaml) file by creating a Pull Request in this repository. Please be mindful of a few constraints that are automatically checked and required for your plugin to be accepted:
 
 - The `name` field is mandatory and must be **unique** across all the plugins in the registry
-- *(Source plugins only)* The `id` field is mandatory and must be **unique** across all the source plugins in the registry
-- The plugin `name` and `source` fields should match this [regular expression](https://en.wikipedia.org/wiki/Regular_expression): `^[a-z]+[a-z0-9_]*$`
+- *(Sourcing Capability Only)* The `id` field is mandatory and must be **unique** in the registry across all the plugins with event source capability
+- The plugin `name`, `source` *(Sourcing Capability Only)*, and `sources` *(Extraction Capability Only)* should match this [regular expression](https://en.wikipedia.org/wiki/Regular_expression): `^[a-z]+[a-z0-9_]*$`
 
-For reference, here's an example of a source plugin entry:
+For reference, here's an example of an entry for a plugin with both event sourcing and field extraction capabilities:
 ```yaml
-- id: 2
-  source: aws_cloudtrail
-  name: cloudtrail
+- name: cloudtrail
   description: ...
-  authors: The Falco Authors
-  contact: https://falco.org/community
+  authors: ...
+  contact: ...
   url: ...
-  license: Apache-2.0
+  license: ...
+  capabilities:
+    sourcing:
+      supported: true
+      id: 2
+      source: aws_cloudtrail
+    extraction:
+      supported: true
 ```
 
 You can find the full registry specification here: *(coming soon...)*

--- a/build/registry/registry.go
+++ b/build/registry/registry.go
@@ -46,7 +46,7 @@ func doCheck(fileName string) error {
 	return registry.Check()
 }
 
-func doTable(registryFile, subFile, subTag, contentType string) error {
+func doTable(registryFile, subFile, subTag string) error {
 	registry, err := loadRegistryFromFile(registryFile)
 	if err != nil {
 		return err
@@ -57,7 +57,7 @@ func doTable(registryFile, subFile, subTag, contentType string) error {
 		return err
 	}
 
-	table, err := registry.FormatMarkdownTable(contentType)
+	table, err := registry.FormatMarkdownTable()
 	if err != nil {
 		return err
 	}
@@ -97,23 +97,21 @@ func main() {
 
 	var tableSubFileName string
 	var tableSubTab string
-	var tableType string
 	tableCmd := &cobra.Command{
 		Use:   "table <filename>",
 		Short: "Format a plugin registry YAML file in a MarkDown table",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			return doTable(args[0], tableSubFileName, tableSubTab, tableType)
+			return doTable(args[0], tableSubFileName, tableSubTab)
 		},
 	}
 	tableFlags := tableCmd.Flags()
 	tableFlags.StringVar(&tableSubTab, "subtag", defaultTableSubTag, "A tag that delimits the start and the end of the text section to substitute with the generated table.")
 	tableFlags.StringVar(&tableSubFileName, "subfile", "", "If specified, the table will be written inside the file at this path, inserting it between the first two instances of the substitution tag.")
-	tableFlags.StringVar(&tableType, "type", sourcePluginsTableContentType, "The type of content to be included in the table")
 
 	rootCmd := &cobra.Command{
 		Use:     "registry",
-		Version: "0.1.0",
+		Version: "0.2.0",
 	}
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(tableCmd)

--- a/build/registry/types.go
+++ b/build/registry/types.go
@@ -22,36 +22,35 @@ import (
 	"github.com/go-yaml/yaml"
 )
 
-type Source struct {
-	ID          uint   `yaml:"id"`
-	Source      string `yaml:"source"`
-	Name        string `yaml:"name"`
-	Description string `yaml:"description"`
-	Authors     string `yaml:"authors"`
-	Contact     string `yaml:"contact"`
-	URL         string `yaml:"url"`
-	License     string `yaml:"license"`
-	Reserved    bool   `yaml:"reserved"`
+type SourcingCapability struct {
+	Supported bool   `yaml:"supported"`
+	ID        uint   `yaml:"id"`
+	Source    string `yaml:"source"`
 }
 
-type Extractor struct {
-	Sources     []string `yaml:"sources"`
-	Name        string   `yaml:"name"`
-	Description string   `yaml:"description"`
-	Authors     string   `yaml:"authors"`
-	Contact     string   `yaml:"contact"`
-	URL         string   `yaml:"url"`
-	License     string   `yaml:"license"`
-	Reserved    bool     `yaml:"reserved"`
+type ExtractionCapability struct {
+	Supported bool     `yaml:"supported"`
+	Sources   []string `yaml:"sources"`
 }
 
-type Plugins struct {
-	Source    []Source    `yaml:"source"`
-	Extractor []Extractor `yaml:"extractor"`
+type Capabilities struct {
+	Sourcing   SourcingCapability   `yaml:"sourcing"`
+	Extraction ExtractionCapability `yaml:"extraction"`
+}
+
+type Plugin struct {
+	Name         string       `yaml:"name"`
+	Description  string       `yaml:"description"`
+	Authors      string       `yaml:"authors"`
+	Contact      string       `yaml:"contact"`
+	URL          string       `yaml:"url"`
+	License      string       `yaml:"license"`
+	Reserved     bool         `yaml:"reserved"`
+	Capabilities Capabilities `yaml:"capabilities"`
 }
 
 type Registry struct {
-	Plugins         Plugins  `yaml:"plugins"`
+	Plugins         []Plugin `yaml:"plugins"`
 	ReservedSources []string `yaml:"reserved_sources"`
 }
 

--- a/registry.yaml
+++ b/registry.yaml
@@ -24,73 +24,111 @@ reserved_sources: [ "syscall", "internal", "plugins" ]
 #
 # License IDs refer to the SPDX License List at https://spdx.org/licenses
 plugins:
-  source:
-    - id: 1
-      source: k8s_audit
-      name: k8saudit
-      description: Read Kubernetes Audit Events and monitor Kubernetes Clusters
-      authors: The Falco Authors
-      contact: https://falco.org/community
-      url: https://github.com/falcosecurity/plugins/tree/master/plugins/k8saudit
-      license: Apache-2.0
-    - id: 2
-      source: aws_cloudtrail
-      name: cloudtrail
-      description: Reads Cloudtrail JSON logs from files/S3 and injects as events
-      authors: The Falco Authors
-      contact: https://falco.org/community
-      url: https://github.com/falcosecurity/plugins/tree/master/plugins/cloudtrail
-      license: Apache-2.0
-    - id: 3
-      source: dummy
-      name: dummy
-      description: Reference plugin used to document interface
-      authors: The Falco Authors
-      contact: https://falco.org/community
-      url: https://github.com/falcosecurity/plugins/tree/master/plugins/dummy
-      license: Apache-2.0
-    - id: 4
-      source: dummy_c
-      name: dummy_c
-      description: Like Dummy, but written in C++
-      authors: The Falco Authors
-      contact: https://falco.org/community
-      url: https://github.com/falcosecurity/plugins/tree/master/plugins/dummy_c
-      license: Apache-2.0
-    - id: 5
-      source: docker
-      name: docker
-      description: Docker Events
-      authors: Thomas Labarussias
-      contact: https://github.org/Issif
-      url: https://github.com/Issif/docker-plugin
-      license: Apache-2.0
-    - id: 6
-      source: seccompagent
-      name: seccompagent
-      description: Seccomp Agent Events
-      authors: Alban Crequy
-      contact: https://github.com/kinvolk/seccompagent
-      url: https://github.com/kinvolk/seccompagent
-      license: Apache-2.0
-    - id: 7
-      source: okta
-      name: okta
-      description: Okta Log Events
-      authors: The Falco Authors
-      contact: https://falco.org/community
-      url: https://github.com/falcosecurity/plugins/tree/master/plugins/okta 
-      license: Apache-2.0
-    - id: 999
-      source: test
-      name: test
-      description: This ID is reserved for source plugin development. Any plugin author can use this ID, but authors can expect events from other developers with this ID. After development is complete, the author should request an actual ID
-      reserved: true
-
-  extractor:
-    - name: json
-      description: Extract values from any JSON payload
-      authors: The Falco Authors
-      contact: https://falco.org/community
-      url: https://github.com/falcosecurity/plugins/tree/master/plugins/json
-      license: Apache-2.0
+  - name: k8saudit
+    description: Read Kubernetes Audit Events and monitor Kubernetes Clusters
+    authors: The Falco Authors
+    contact: https://falco.org/community
+    url: https://github.com/falcosecurity/plugins/tree/master/plugins/k8saudit
+    license: Apache-2.0
+    capabilities:
+      sourcing:
+        supported: true
+        id: 1
+        source: k8s_audit
+      extraction:
+        supported: true
+  - name: cloudtrail
+    description: Reads Cloudtrail JSON logs from files/S3 and injects as events
+    authors: The Falco Authors
+    contact: https://falco.org/community
+    url: https://github.com/falcosecurity/plugins/tree/master/plugins/cloudtrail
+    license: Apache-2.0
+    capabilities:
+      sourcing:
+        supported: true
+        id: 2
+        source: aws_cloudtrail
+      extraction:
+        supported: true
+  - name: json
+    description: Extract values from any JSON payload
+    authors: The Falco Authors
+    contact: https://falco.org/community
+    url: https://github.com/falcosecurity/plugins/tree/master/plugins/json
+    license: Apache-2.0
+    capabilities:
+      extraction:
+        supported: true
+  - name: dummy
+    description: Reference plugin used to document interface
+    authors: The Falco Authors
+    contact: https://falco.org/community
+    url: https://github.com/falcosecurity/plugins/tree/master/plugins/dummy
+    license: Apache-2.0
+    capabilities:
+      sourcing:
+        supported: true
+        id: 3
+        source: dummy
+      extraction:
+        supported: true
+  - name: dummy_c
+    description: Like Dummy, but written in C++
+    authors: The Falco Authors
+    contact: https://falco.org/community
+    url: https://github.com/falcosecurity/plugins/tree/master/plugins/dummy_c
+    license: Apache-2.0
+    capabilities:
+      sourcing:
+        supported: true
+        id: 4
+        source: dummy_c
+      extraction:
+        supported: true
+  - name: docker
+    description: Docker Events
+    authors: Thomas Labarussias
+    contact: https://github.org/Issif
+    url: https://github.com/Issif/docker-plugin
+    license: Apache-2.0
+    capabilities:
+      sourcing:
+        supported: true
+        id: 5
+        source: docker
+      extraction:
+        supported: true
+  - name: seccompagent
+    description: Seccomp Agent Events
+    authors: Alban Crequy
+    contact: https://github.com/kinvolk/seccompagent
+    url: https://github.com/kinvolk/seccompagent
+    license: Apache-2.0
+    capabilities:
+      sourcing:
+        supported: true
+        id: 6
+        source: seccompagent
+      extraction:
+        supported: true
+  - name: okta
+    description: Okta Log Events
+    authors: The Falco Authors
+    contact: https://falco.org/community
+    url: https://github.com/falcosecurity/plugins/tree/master/plugins/okta 
+    license: Apache-2.0
+    capabilities:
+      sourcing:
+        supported: true
+        id: 7
+        source: okta
+      extraction:
+        supported: true
+  - name: test
+    description: This ID is reserved for source plugin development. Any plugin author can use this ID, but authors can expect events from other developers with this ID. After development is complete, the author should request an actual ID
+    reserved: true
+    capabilities:
+      sourcing:
+        supported: true
+        id: 999
+        source: test


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

/area registry

/area documentation

**What this PR does / why we need it**:

Following up the progress of tracked in https://github.com/falcosecurity/falco/issues/1948, this PR refactors the plugin registry, the registry tool, and the readme, to reflect the recent changes of the plugin API that removed the notion of "plugin type".

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
