### PR TITLE
fix(plugins/k8saudit): fix webserver host resolution

### DIFF
--- a/plugins/k8saudit/README.md
+++ b/plugins/k8saudit/README.md
@@ -113,7 +113,7 @@ load_plugins: [k8saudit, json]
 **Open Parameters**:
 - `http://<host>:<port>/<endpoint>`: Opens an event stream by listening on a HTTP webserver
 - `https://<host>:<port>/<endpoint>`: Opens an event stream by listening on a HTTPS webserver
-- `file://<path>`: Opens an event stream by reading the events from a `<path>` on the local filesystem
+- `no scheme`: Opens an event stream by reading the events from a file on the local filesystem. The params string is interpreted as a filepath
 
 
 ### Rules


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

This fixes a bug on the k8saudit plugin that prevented its webserver to be started on arbitrary hosts. Previously, the host of open parameters such as `http://...` or `https://...` was resolved by using a regex due to code leftover from the initial development phase. This PR fixes this by using `url.Parse` to retrieve the same info.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
