### PR TITLE
update(plugins): bump version of cloudtrail, json, okta, and dummy

### DIFF
--- a/plugins/cloudtrail/pkg/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/pkg/cloudtrail/cloudtrail.go
@@ -46,7 +46,7 @@ const (
 	PluginName               = "cloudtrail"
 	PluginDescription        = "reads cloudtrail JSON data saved to file in the directory specified in the settings"
 	PluginContact            = "github.com/falcosecurity/plugins/"
-	PluginVersion            = "0.2.5"
+	PluginVersion            = "0.3.0"
 	PluginEventSource        = "aws_cloudtrail"
 )
 

--- a/plugins/cloudtrail/rules/aws_cloudtrail_rules.yaml
+++ b/plugins/cloudtrail/rules/aws_cloudtrail_rules.yaml
@@ -15,11 +15,9 @@
 # limitations under the License.
 #
 
-# All rules files related to plugins should require engine version 10
+# All rules files related to plugins should require at least engine version 10
 - required_engine_version: 10
 
-# These rules can be read by cloudtrail plugin version 0.1.0, or
-# anything semver-compatible.
 - required_plugin_versions:
   - name: cloudtrail
     version: 0.2.3

--- a/plugins/dummy/pkg/dummy/dummy.go
+++ b/plugins/dummy/pkg/dummy/dummy.go
@@ -35,7 +35,7 @@ const (
 	PluginName               = "dummy"
 	PluginDescription        = "Reference plugin for educational purposes"
 	PluginContact            = "github.com/falcosecurity/plugins"
-	PluginVersion            = "0.2.1"
+	PluginVersion            = "0.3.0"
 	PluginEventSource        = "dummy"
 )
 

--- a/plugins/json/pkg/json/json.go
+++ b/plugins/json/pkg/json/json.go
@@ -37,7 +37,7 @@ const (
 	PluginName        = "json"
 	PluginDescription = "implements extracting arbitrary fields from inputs formatted as JSON"
 	PluginContact     = "github.com/falcosecurity/plugins/"
-	PluginVersion     = "0.2.2"
+	PluginVersion     = "0.3.0"
 )
 
 type Plugin struct {

--- a/plugins/k8saudit/rules/k8s_audit_rules.yaml
+++ b/plugins/k8saudit/rules/k8s_audit_rules.yaml
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-- required_engine_version: 11
+
+- required_engine_version: 12
 
 - required_plugin_versions:
   - name: k8saudit
     version: 0.1.0
   - name: json
-    version: 0.2.2
+    version: 0.3.0
 
 # Like always_true/always_false, but works with k8s audit events
 - macro: k8s_audit_always_true

--- a/plugins/okta/pkg/okta/okta.go
+++ b/plugins/okta/pkg/okta/okta.go
@@ -131,7 +131,7 @@ func (oktaPlugin *Plugin) Info() *plugins.Info {
 		Name:        "okta",
 		Description: "Okta Log Events",
 		Contact:     "github.com/falcosecurity/plugins/",
-		Version:     "0.1.0",
+		Version:     "0.2.0",
 		EventSource: "okta",
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

This bumps the version of the following plugins: cloudtrail, json, okta, and dummy. These new versions are release candidates to be bundled in Falco 0.32. In all of them, the version increased the minor due to the breaking changes introduced in the plugin API and propagated to the newly-released Plugin SDK Go v0.3.0.

There are no breaking changes in the plugin's code or their UX that motivates a major version bump.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
