### PR TITLE
refactor(plugins/k8saudit): make evt size and batch size configurable with official terminology

### DIFF
--- a/plugins/k8saudit/pkg/k8saudit/config.go
+++ b/plugins/k8saudit/pkg/k8saudit/config.go
@@ -17,15 +17,24 @@ limitations under the License.
 package k8saudit
 
 type PluginConfig struct {
-	SSLCertificate string `json:"sslCertificate" jsonschema:"description=The SSL Certificate to be used with the HTTPS Webhook endpoint (Default: /etc/falco/falco.pem)"`
-	MaxEventBytes  uint64 `json:"maxEventBytes"  jsonschema:"description=Max size in bytes for an event JSON payload (Default: 12582912)"`
-	UseAsync       bool   `json:"useAsync" jsonschema:"description=If true then async extraction optimization is enabled (Default: true)"`
+	SSLCertificate      string `json:"sslCertificate"       jsonschema:"description=The SSL Certificate to be used with the HTTPS Webhook endpoint (Default: /etc/falco/falco.pem)"`
+	UseAsync            bool   `json:"useAsync"             jsonschema:"description=If true then async extraction optimization is enabled (Default: true)"`
+	WebhookMaxBatchSize uint64 `json:"webhookMaxBatchSize"  jsonschema:"description=Maximum size of incoming webhook POST request bodies (Default: 12582912)"`
+	WebhookMaxEventSize uint64 `json:"webhookMaxEventSize"  jsonschema:"description=Maximum size of single audit events (Default: 131072)"`
 }
 
 // Resets sets the configuration to its default values
 func (k *PluginConfig) Reset() {
-	// based on values from: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
-	k.MaxEventBytes = 12 * 1024 * 1024
 	k.SSLCertificate = "/etc/falco/falco.pem"
 	k.UseAsync = true
+
+	// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+	// The K8S docs state states the following:
+	//   --audit-webhook-truncate-max-batch-size int     Default: 10485760
+	//   --audit-webhook-truncate-max-event-size int     Default: 102400
+	// The following values have been chosen by increasing by ~20% the default
+	// values of the K8S docs, so that WebhookMaxBatchSize is 12MB and
+	// WebhookMaxEventSize is 128KB in order to have a degree of redundancy
+	k.WebhookMaxBatchSize = 12 * 1024 * 1024
+	k.WebhookMaxEventSize = 128 * 1024
 }


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind documentation

/kind feature

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

This PR updates the k8saudit plugin and allows configuring the event size of each event. This solves a problem where the plugin terminates with `io.ErrShortWrite` due to the underlying allocated event batch being too small for the event coming from the webhook backend. Accordingly, the max event and batch size have been renamed in the init config to resemble the terminology of the k8s docs(--audit-webhook-truncate-max-batch-size, --audit-webhook-truncate-max-event-size): https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
