### PR TITLE
fix(plugins/k8saudit): drop events larger than max evt size 

### DIFF
--- a/plugins/k8saudit/pkg/k8saudit/config.go
+++ b/plugins/k8saudit/pkg/k8saudit/config.go
@@ -16,25 +16,25 @@ limitations under the License.
 
 package k8saudit
 
+import "github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+
 type PluginConfig struct {
 	SSLCertificate      string `json:"sslCertificate"       jsonschema:"description=The SSL Certificate to be used with the HTTPS Webhook endpoint (Default: /etc/falco/falco.pem)"`
 	UseAsync            bool   `json:"useAsync"             jsonschema:"description=If true then async extraction optimization is enabled (Default: true)"`
+	MaxEventSize        uint64 `json:"maxEventSize"         jsonschema:"description=Maximum size of single audit event (Default: 262144)"`
 	WebhookMaxBatchSize uint64 `json:"webhookMaxBatchSize"  jsonschema:"description=Maximum size of incoming webhook POST request bodies (Default: 12582912)"`
-	WebhookMaxEventSize uint64 `json:"webhookMaxEventSize"  jsonschema:"description=Maximum size of single audit events (Default: 131072)"`
 }
 
 // Resets sets the configuration to its default values
 func (k *PluginConfig) Reset() {
 	k.SSLCertificate = "/etc/falco/falco.pem"
 	k.UseAsync = true
+	k.MaxEventSize = uint64(sdk.DefaultEvtSize)
 
 	// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
 	// The K8S docs state states the following:
 	//   --audit-webhook-truncate-max-batch-size int     Default: 10485760
-	//   --audit-webhook-truncate-max-event-size int     Default: 102400
 	// The following values have been chosen by increasing by ~20% the default
-	// values of the K8S docs, so that WebhookMaxBatchSize is 12MB and
-	// WebhookMaxEventSize is 128KB in order to have a degree of redundancy
+	// values of the K8S docs
 	k.WebhookMaxBatchSize = 12 * 1024 * 1024
-	k.WebhookMaxEventSize = 128 * 1024
 }


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

This fixes an issue with the k8saudit plugin. The K8S API server occasionally sends large JSON events, which can cause Falco to exit with error due to the allocated plugin event batch being too short to write an event. We make this non-blocking by checking the event size prior writing it into the batch, and dropping it with a logged message in case it is too large.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
