### PR TITLE
fix(cloudtrail): support plain text json logs on S3

### DIFF
--- a/plugins/cloudtrail/README.md
+++ b/plugins/cloudtrail/README.md
@@ -117,7 +117,7 @@ We describe each of these below.
 
 When using `s3://<S3 Bucket Name>/[<Optional Prefix>]`, the plugin will scan the bucket a single time for all objects. Characters up to the first slash/end of string will be used as the S3 bucket name, and any remaining characters will be treated as a key prefix. After reading all objects, the plugin will return EOF.
 
-All objects below the bucket, or below the bucket + prefix, will be considered cloudtrail logs. Any object ending in .json.gz will be decompressed first. The plugin expects the logs to be compressed.
+All objects below the bucket, or below the bucket + prefix, will be considered cloudtrail logs. Any object ending in .json.gz will be decompressed first.
 
 For example, if a bucket `my-s3-bucket` contained cloudtrail logs below a prefix `AWSLogs/411571310278/CloudTrail/us-west-1/2021/09/23/`, Using an open params of `s3://my-s3-bucket/AWSLogs/411571310278/CloudTrail/us-west-1/2021/09/23/` would configure the plugin to read all files below `AWSLogs/411571310278/CloudTrail/us-west-1/2021/09/23/` as cloudtrail logs and then return EOF. No other files in the bucket will be read.
 

--- a/plugins/cloudtrail/pkg/cloudtrail/source.go
+++ b/plugins/cloudtrail/pkg/cloudtrail/source.go
@@ -180,7 +180,7 @@ func openS3(pCtx *Plugin, oCtx *PluginInstance, input string) error {
 				continue
 			}
 
-			var fi fileInfo = fileInfo{name: *path, isCompressed: true}
+			var fi fileInfo = fileInfo{name: *path, isCompressed: isCompressed}
 			oCtx.files = append(oCtx.files, fi)
 		}
 		return true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Recently a behavior in the cloudtrail plugin ( https://github.com/falcosecurity/plugins/pull/94 ) has been documented as a limitation. Specifically, we couldn't parse `json` files on S3 but only `json.gz`. This is actually a bug that can be easily fixed by setting `isCompressed` correctly.

No version bump for plugins is required at this time.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
