### PR TITLE
fix(plugins/k8saudit): return non-nil error from NextBatch with closed channel

### DIFF
--- a/plugins/k8saudit/pkg/k8saudit/k8saudit.go
+++ b/plugins/k8saudit/pkg/k8saudit/k8saudit.go
@@ -53,7 +53,7 @@ func (k *Plugin) Info() *plugins.Info {
 		Name:        pluginName,
 		Description: "Read Kubernetes Audit Events and monitor Kubernetes Clusters",
 		Contact:     "github.com/falcosecurity/plugins",
-		Version:     "0.2.0",
+		Version:     "0.2.1",
 		EventSource: "k8s_audit",
 	}
 }

--- a/plugins/k8saudit/pkg/k8saudit/source.go
+++ b/plugins/k8saudit/pkg/k8saudit/source.go
@@ -211,7 +211,10 @@ func (k *Plugin) openEventSource(ctx context.Context, eventChan <-chan []byte, e
 				}
 			case <-ctx.Done():
 				return
-			case err := <-errorChan:
+			case err, ok := <-errorChan:
+				if !ok {
+					return
+				}
 				newErrorChan <- err
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

When the event source gets closed by the plugin due to lack of new events (this only happens when reading json events from file right now), the error returned by `NextBatch` was non-deterministically either `nil` or `sdk.ErrEOF`. In the current implementation of the plugin framework, returning empty event batches with `nil` error is interpreted as an unsafe corner case which causes a libscap-level failure. As a consequence, some Falco tests became flaky due to the program exit code being 1 or 0 with non-determinism. 

The root cause of this issue is the k8saudit plugin, which incorrectly handled a closing channel, thus returning a `nil` error instead of `sdk.ErrEOF`.

The `k8saudit` plugin version has been bumped to `v0.2.1` to include this patch.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

If merged, the `k8saudit` plugin will need to be re-tagged and released with patch version bump to `v0.2.1`.
