### PR TITLE
refactor(plugins/k8saudit): re-implement k8saudit event source using the SDK Go prebuilts

### DIFF
--- a/plugins/k8saudit/go.mod
+++ b/plugins/k8saudit/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b
-	github.com/falcosecurity/plugin-sdk-go v0.4.0
+	github.com/falcosecurity/plugin-sdk-go v0.4.1-0.20220613161145-42bf90c6de7f
 	github.com/valyala/fastjson v1.6.3
 )

--- a/plugins/k8saudit/go.sum
+++ b/plugins/k8saudit/go.sum
@@ -2,8 +2,8 @@ github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b h1:doCpXjVwu
 github.com/alecthomas/jsonschema v0.0.0-20220216202328-9eeeec9d044b/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/falcosecurity/plugin-sdk-go v0.4.0 h1:gsRgA75JNJ73HzBYMkVnKz/Rze14cEg5IKrpdEO1zKM=
-github.com/falcosecurity/plugin-sdk-go v0.4.0/go.mod h1:9IdFIqRwJIFDfKnwTTM6S4mLITNfdjVl+5r4RY0TmRo=
+github.com/falcosecurity/plugin-sdk-go v0.4.1-0.20220613161145-42bf90c6de7f h1:FTF2CzQkNtTgwARiP+d65ruzqND0o+Kn6ZFtPfTxwJY=
+github.com/falcosecurity/plugin-sdk-go v0.4.1-0.20220613161145-42bf90c6de7f/go.mod h1:9IdFIqRwJIFDfKnwTTM6S4mLITNfdjVl+5r4RY0TmRo=
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind design

/kind feature

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

This PR refactors the `k8saudit` plugin to leverage the new prebuilt-implementation of `source.Instance` provided by the SDK Go since merging https://github.com/falcosecurity/plugin-sdk-go/pull/50. This is a first experiment of this approach, which could be used by other plugins once we are confident of its benefits.

Visible benefits so far:
- Smaller and more readable code
- The termination condition of the event source is more clear and regulated by only one channel
- Performance should be better since now we reuse a `fastjson.Parser` instead of reallocating one for each event batch
- Reading events from file should be faster, as it involves less goroutines than before
- Code has been made more modular and documented so that flavors of the plugin can be developed on top of it (e.g. support for managed K8S environments). Also, file-reading mode is now based on the `io.ReadCloser` interface for better reusability

**Special notes for your reviewer**:

Locally, this passed all k8audit regression test of Falco: https://github.com/falcosecurity/falco/blob/85f91a3ec44b9cd81f8d678f0375fe77194b4e00/test/falco_k8s_audit_tests.yaml