### PR TITLE
cleanup(OWNERS): remove inactive approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,13 +2,6 @@ approvers:
   - mstemm
   - leogr
   - jasondellaluce
-reviewers:
-  - ldegio
-  - leodido
-  - fntlnz
-  - mstemm
-  - leogr
-  - jasondellaluce
 emeritus_approvers:
   - ldegio
   - leodido

--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,4 @@
 approvers:
-  - ldegio
-  - leodido
-  - fntlnz
   - mstemm
   - leogr
   - jasondellaluce
@@ -12,3 +9,7 @@ reviewers:
   - mstemm
   - leogr
   - jasondellaluce
+emeritus_approvers:
+  - ldegio
+  - leodido
+  - fntlnz


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area documentation

**What this PR does / why we need it**:

For https://github.com/falcosecurity/evolution/issues/157, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from `approvers` to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
