### PR TITLE
fix(plugins/github): correctly parse patch diffs 

### DIFF
--- a/plugins/github/pkg/github/github.go
+++ b/plugins/github/pkg/github/github.go
@@ -38,7 +38,7 @@ const (
 	PluginName                = "github"
 	PluginDescription         = "Reads github webhook events, by listening on a socket or by reading events from disk"
 	PluginContact             = "github.com/falcosecurity/plugins"
-	PluginVersion             = "0.3.0"
+	PluginVersion             = "0.3.1"
 	PluginEventSource         = "github"
 	ExtractEventSource        = "github"
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

The patch diff parsing function was fragile and rejected cases like `"@@ -0,0 +1 @@\n+sample line\n"`. This has been fixed by using regular expressions.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
