### PR TITLE
add Launch Excessively Capable Pod into k8saudit rule

### DIFF
--- a/plugins/k8saudit/rules/k8s_audit_rules.yaml
+++ b/plugins/k8saudit/rules/k8s_audit_rules.yaml
@@ -741,3 +741,31 @@
   priority: WARNING
   source: k8s_audit
   tags: [k8s]
+
+- list: excessively_capable_list
+  items: [
+    CAP_SYS_ADMIN,
+    CAP_SYS_MODULE,
+    CAP_SYS_RAWIO,
+    CAP_SYS_PTRACE,
+    CAP_SYS_BOOT,
+    CAP_SYSLOG,
+    CAP_DAC_READ_SEARCH,
+    CAP_NET_ADMIN,
+    CAP_BPF
+    ]
+
+- list: falco_capable_images
+  items: []
+
+- rule: Launch Excessively Capable Pod
+  desc: >
+    Detect an attempt to start a pod with an excessively capable
+  condition: >
+    kevt and pod and kcreate and ka.req.pod.containers.add_capabilities intersects (excessively_capable_list)
+    and not ka.req.pod.containers.image.repository in (falco_privileged_images)
+    and not ka.req.pod.containers.image.repository in (falco_capable_images)
+  output: Pod started with an excessively capable (user=%ka.user.name pod=%ka.resp.name resource=%ka.target.resource ns=%ka.target.namespace images=%ka.req.pod.containers.image)
+  priority: WARNING
+  source: k8s_audit
+  tags: [k8s]


### PR DESCRIPTION
Signed-off-by: Hi120ki <12624257+hi120ki@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

In k8saudit, we can get pod's capabilities from `ka.req.pod.containers.add_capabilities` field.
This capabilities lead container escape and other attacks, so we need detect these capabilities are added.

And this rule leads false positive by privileged pod and ignore it by `falco_privileged_images` list.
In some case we have to add capabilities to pod, then I added `falco_capable_images` list (now this is empty) to add allow items.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
