### PR TITLE
build: do not include README.md in packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ package/%: clean/% % build/utils/version
 	@./build/utils/version --path $(PLUGIN_PATH) $(PRE_RELEASE)
 	mkdir -p $(OUTPUT_DIR)/$(PLUGIN_NAME)
 	cp -r $(PLUGIN_PATH) $(OUTPUT_DIR)/$(PLUGIN_NAME)/
-	cp -r plugins/$(PLUGIN_NAME)/README.md $(OUTPUT_DIR)/$(PLUGIN_NAME)/ || :
 	tar -zcvf $(OUTPUT_DIR)/$(PLUGIN_NAME)-$(PLUGIN_VERSION)-${PLATFORM}-${ARCH}.tar.gz -C ${OUTPUT_DIR}/$(PLUGIN_NAME) $$(ls -A ${OUTPUT_DIR}/$(PLUGIN_NAME))
 	rm -rf $(OUTPUT_DIR)/$(PLUGIN_NAME)
 	@echo "$(PLUGIN_NAME) package built"


### PR DESCRIPTION
**What type of PR is this?**


/kind cleanup

/kind design



<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area build


**What this PR does / why we need it**:

This is required because some tools (ie. falcoctl or other custom scripts) may use the `.tar.gz` to install a plugin into the default location (ie, `/usr/share/falco/plugins`. In such cases, the README.md file should be not installed.
Removing it from the packages will avoid the need of implementing custom logic for that across different tools.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
