### PR TITLE
fix k8saudit rule EphemeralContainers Created

### DIFF
--- a/plugins/k8saudit/rules/k8s_audit_rules.yaml
+++ b/plugins/k8saudit/rules/k8s_audit_rules.yaml
@@ -295,7 +295,7 @@
 - rule: EphemeralContainers Created
   desc: >
     Detect any ephemeral container created
-  condition: kevt and pod_subresource and kmodify and ka.target.subresource in (ephemeralcontainers) and not user_known_pod_debug_activities
+  condition: kevt and pod_subresource and ka.target.subresource in (ephemeralcontainers) and not user_known_pod_debug_activities
   output: Ephemeral container is created in pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ephemeral_container_name=%jevt.value[/requestObject/ephemeralContainers/0/name] ephemeral_container_image=%jevt.value[/requestObject/ephemeralContainers/0/image])
   priority: NOTICE
   source: k8s_audit


### PR DESCRIPTION
Signed-off-by: Hi120ki <12624257+hi120ki@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

I'm using kubernetes on GKE, and deploy k8saudit based on admission controller.

In k8saudit detection, a rule `EphemeralContainers Created` is not works because of `kmodify` condition.
`kmodify` condition is

```yaml
- macro: kmodify
  condition: (ka.verb in (create,update,patch))
```

But when creating ephemeral container by `kubectl debug` command, `ka.verb` is null.

> When create Pod, kubernetes audit log records `methodName: "io.k8s.core.v1.pods.create"` and generate `ka.verb: create`.
> But when creating ephemeral container by `kubectl debug` command, kubernetes audit log records `methodName: "io.k8s.core.v1.pods.ephemeralcontainers.patch"` and `ka.verb` is null.

So, I delete condition `kmodify` and it works well.

I'm waiting for your comments on my proposed rules.

Thank you.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
