### PR TITLE
fix(oci-tool/output): porperly populate the map entries when reading from file

### DIFF
--- a/build/oci/pkg/output/output.go
+++ b/build/oci/pkg/output/output.go
@@ -54,7 +54,8 @@ func (e *Entries) EntryByName(name string) *Entry {
 func (e *Entries) Upsert(entry *Entry) {
 	for k, en := range e.Entries {
 		if en.Name == entry.Name {
-			e.Entries[k] = en
+			e.Entries[k] = entry
+			e.entryByName[entry.Name] = entry
 			return
 		}
 	}


### PR DESCRIPTION
Co-authored-by: Lorenzo Susini <susinilorenzo1@gmail.com>
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

/area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix the read from file in the `output` package under the oci-tool.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
