### PR TITLE
fix(plugins/k8saudit): Recursively parse the files in a directory

### DIFF
--- a/plugins/k8saudit/pkg/k8saudit/source.go
+++ b/plugins/k8saudit/pkg/k8saudit/source.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"path/filepath"
 
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins/source"

--- a/plugins/k8saudit/pkg/k8saudit/source.go
+++ b/plugins/k8saudit/pkg/k8saudit/source.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"sort"
 
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins/source"
@@ -74,7 +75,7 @@ func (k *Plugin) Open(params string) (source.Instance, error) {
 		})
 
 		// open all files as reader
-		results := []io.Reader
+		results := []io.Reader{}
 		for _, f := range files {
 			if !f.IsDir() {
 				auditFile, err := os.Open(f.Name())

--- a/plugins/k8saudit/pkg/k8saudit/source.go
+++ b/plugins/k8saudit/pkg/k8saudit/source.go
@@ -58,7 +58,7 @@ func (k *Plugin) Open(params string) (source.Instance, error) {
 			return nil, err
 		}
 		if !fileInfo.IsDir() {
-			file, err += os.Open(trimmed)
+			file, err := os.Open(trimmed)
 			if err != nil {
 				return nil, err
 			}
@@ -78,11 +78,12 @@ func (k *Plugin) Open(params string) (source.Instance, error) {
 		results := []io.Reader{}
 		for _, f := range files {
 			if !f.IsDir() {
-				auditFile, err := os.Open(f.Name())
+				auditFile, err := os.Open(trimmed + "/" + f.Name())
 				if err != nil {
 					return nil, err
 				}
 				results = append(results, auditFile)
+				results = append(results, strings.NewReader("\n"))
 			}
 		}
 

--- a/plugins/k8saudit/pkg/k8saudit/source.go
+++ b/plugins/k8saudit/pkg/k8saudit/source.go
@@ -52,26 +52,17 @@ func (k *Plugin) Open(params string) (source.Instance, error) {
 		return k.OpenWebServer(u.Host, u.Path, true)
 	case "": // by default, fallback to opening a filepath
 		trimmed := strings.TrimSpace(params)
-		// string contains a file extension => it is a single file
-		if strings.Contains(trimmed, ".") {
-			file, err := os.Open(trimmed)
-			if err != nil {
-				return nil, err
-			}
-			return k.OpenReader(file)
-		} else {
-			filepath.Walk(trimmed, func(path string, info os.FileInfo, err error) error {
-				if ! info.IsDir() {
-					auditFile := filepath.Join(trimmed, info.Name())
-					file, err := os.Open(auditFile)
-					if err != nil {
-						return nil, err
-					}
-					k.OpenReader(file)
+		filepath.Walk(trimmed, func(path string, info os.FileInfo, err error) error {
+			if ! info.IsDir() {
+				auditFile := filepath.Join(trimmed, info.Name())
+				file, err := os.Open(auditFile)
+				if err != nil {
+					return nil, err
 				}
-				return nil, err
-			})
-		}
+				k.OpenReader(file)
+			}
+			return nil, err
+		})
 	}
 
 	return nil, fmt.Errorf(`scheme "%s" is not supported`, u.Scheme)

--- a/plugins/k8saudit/pkg/k8saudit/source.go
+++ b/plugins/k8saudit/pkg/k8saudit/source.go
@@ -50,18 +50,23 @@ func (k *Plugin) Open(params string) (source.Instance, error) {
 	case "https":
 		return k.OpenWebServer(u.Host, u.Path, true)
 	case "": // by default, fallback to opening a filepath
+		trimmed := strings.TrimSpace(params)
 		// string contains a file extension => it is a single file
-		if strings.Contains(params, ".") {
-			file, err := os.Open(params)
+		if strings.Contains(trimmed, ".") {
+			file, err := os.Open(trimmed)
 			if err != nil {
 				return nil, err
 			}
 			return k.OpenReader(file)
 		} else {
-			filepath.Walk(params, func(path string, info os.FileInfo, err error) error {
+			filepath.Walk(trimmed, func(path string, info os.FileInfo, err error) error {
 				if ! info.IsDir() {
-					// auditFile := info.Name()
-					k.OpenReader(info)
+					auditFile := filepath.Join(trimmed, info.Name())
+					file, err := os.Open(auditFile)
+					if err != nil {
+						return nil, err
+					}
+					k.OpenReader(file)
 				}
 				return nil, err
 			})

--- a/plugins/k8saudit/pkg/k8saudit/source.go
+++ b/plugins/k8saudit/pkg/k8saudit/source.go
@@ -59,7 +59,11 @@ func (k *Plugin) Open(params string) (source.Instance, error) {
 		trimmed := strings.TrimSpace(params)
 
 		if strings.HasSuffix(trimmed, ".log") {
-			return k.OpenReader(trimmed)
+			file, err := os.Open(trimmed)
+			if err != nil {
+				return nil, err
+			}
+			return k.OpenReader(file)
 		}
 
 		files, err := ioutil.ReadDir(trimmed)


### PR DESCRIPTION
/kind bug
/area plugins

**What this PR does / why we need it**:
Currently, the plugin tries to open any string which is provided to open_params. This succeeds for filepaths but fails if it is point to a directory. 

This PR adds the logic to check if the input string refers to a single file or to a directory.

**Which issue(s) this PR fixes**:

Fixes #182 

**Special notes for your reviewer**:
It would be cool if this can be tagged with hacktoberfest