### PR TITLE
fix(plugins/k8saudit): prevent panics while shutting down webserver

### DIFF
--- a/plugins/k8saudit/pkg/k8saudit/source.go
+++ b/plugins/k8saudit/pkg/k8saudit/source.go
@@ -105,6 +105,14 @@ func (k *Plugin) OpenWebServer(address, endpoint string, ssl bool) (source.Insta
 	// event-parser goroutine
 	m := http.NewServeMux()
 	s := &http.Server{Addr: address, Handler: m}
+	sendBody := func(b []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				k.logger.Println("request dropped while shutting down server ")
+			}
+		}()
+		serverEvtChan <- b
+	}
 	m.HandleFunc(endpoint, func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != "POST" {
 			http.Error(w, fmt.Sprintf("%s method not allowed", req.Method), http.StatusMethodNotAllowed)
@@ -123,7 +131,7 @@ func (k *Plugin) OpenWebServer(address, endpoint string, ssl bool) (source.Insta
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		serverEvtChan <- bytes
+		sendBody(bytes)
 	})
 	go func() {
 		defer close(serverEvtChan)


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

As in #183, the k8saudit plugin's webserver panics when an event capture is forcefully closed. This happens due to the `serverEvtChan` channel being closed before all events have finished being pushed. However, this issue comes from the limited control that we have on the webserver's behavior. Essentially, when we shutdown the server we wait for all open connections to be closed, but we have no control on the ones that are waiting to push data into the channel. This can be fixed in different ways, but the less troublesome one is to isolate the data sending function and recover from panics, which are expected to happen only in the shutting down phase when there's high load and the channel buffer fills-up.

**Which issue(s) this PR fixes**:

Fixes #183

**Special notes for your reviewer**:
