### PR TITLE
refactor(ci/build): make LoadRegistryFromFile function reusable across commands

### DIFF
--- a/build/registry/cmd/registry/registry.go
+++ b/build/registry/cmd/registry/registry.go
@@ -38,17 +38,8 @@ const (
 	defaultTableSubTag = "<!-- REGISTRY -->"
 )
 
-func loadRegistryFromFile(fname string) (*registry.Registry, error) {
-	file, err := os.Open(fname)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-	return registry.Load(file)
-}
-
 func doCheck(fileName string) error {
-	registry, err := loadRegistryFromFile(fileName)
+	registry, err := registry.LoadRegistryFromFile(fileName)
 	if err != nil {
 		return err
 	}
@@ -56,7 +47,7 @@ func doCheck(fileName string) error {
 }
 
 func doTable(registryFile, subFile, subTag string) error {
-	r, err := loadRegistryFromFile(registryFile)
+	r, err := registry.LoadRegistryFromFile(registryFile)
 	if err != nil {
 		return err
 	}
@@ -104,7 +95,7 @@ func doUpdateIndex(registryFile, indexFile string) error {
 		return fmt.Errorf("environment variable with key %q not found, please set it before running this tool", oci.RegistryOCI)
 	}
 
-	registryEntries, err := loadRegistryFromFile(registryFile)
+	registryEntries, err := registry.LoadRegistryFromFile(registryFile)
 	if err != nil {
 		return err
 	}

--- a/build/registry/pkg/registry/load.go
+++ b/build/registry/pkg/registry/load.go
@@ -18,11 +18,22 @@ package registry
 
 import (
 	"io"
+	"os"
 )
 
-// Load reads from a io.Reader and uses the content to populate and
+// LoadRegistryFromFile loads the registry from a file on disk.
+func LoadRegistryFromFile(fname string) (*Registry, error) {
+	file, err := os.Open(fname)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return load(file)
+}
+
+// load reads from a io.Reader and uses the content to populate and
 // return a new instance of Registry
-func Load(r io.Reader) (*Registry, error) {
+func load(r io.Reader) (*Registry, error) {
 	registry := &Registry{}
 	return registry, registry.Decode(r)
 }

--- a/build/registry/pkg/registry/oci/oci.go
+++ b/build/registry/pkg/registry/oci/oci.go
@@ -76,16 +76,6 @@ func lookupConfig() (*config, error) {
 	return cfg, nil
 }
 
-// TODO(alacuku): Duplicated code, need to refactor some code that exists in the main package.
-func loadRegistryFromFile(fname string) (*registry.Registry, error) {
-	file, err := os.Open(fname)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-	return registry.Load(file)
-}
-
 // refFromPluginEntry returns an OCI reference for a plugin entry in the registry.yaml file.
 func refFromPluginEntry(cfg *config, plugin *registry.Plugin, rulesFile bool) string {
 	var namespace string
@@ -165,9 +155,7 @@ func latestVersionArtifact(ctx context.Context, ref string, ociClient *auth.Clie
 
 // TODO(alacuku): duplicated code, in common with the "version" tool
 func git(args ...string) (output []string, err error) {
-	// fmt.Println("git ", strings.Join(args, " "))
 	stdout, err := exec.Command("git", args...).Output()
-	// fmt.Println(string(stdout))
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return nil, fmt.Errorf("unable to list tags %q: %v", exitErr.Stderr, err)
@@ -278,7 +266,7 @@ func DoUpdateOCIRegistry(ctx context.Context, registryFile string) error {
 		Password: cfg.registryToken,
 	})
 
-	reg, err := loadRegistryFromFile(registryFile)
+	reg, err := registry.LoadRegistryFromFile(registryFile)
 	if err != nil {
 		return fmt.Errorf("an error occurred while loading registry entries from file %q: %v", registryFile, err)
 	}


### PR DESCRIPTION
…s commands

Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

/area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Make `LoadRegistryFromFile()` function reusable and remove duplicated code from `oci command`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
