### PR TITLE
feat(build/registry): add config layer to artifacts when pushing to registry

### DIFF
--- a/build/registry/go.mod
+++ b/build/registry/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.34
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.11
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/falcosecurity/falcoctl v0.2.0-rc1.0.20221221093301-fe5e90c8061b
+	github.com/falcosecurity/falcoctl v0.2.0-rc1.0.20230103133910-a8cf20acc6aa
 	github.com/spf13/cobra v1.5.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog/v2 v2.60.1

--- a/build/registry/go.sum
+++ b/build/registry/go.sum
@@ -196,6 +196,10 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwC
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/falcosecurity/falcoctl v0.2.0-rc1.0.20221221093301-fe5e90c8061b h1:HTUm9EoVG8S5q/AUWR3ZUkaDbuf8tVcWdNLbyBObKqg=
 github.com/falcosecurity/falcoctl v0.2.0-rc1.0.20221221093301-fe5e90c8061b/go.mod h1:gfYo0lLyEYkA0D1v8pBbELIxQRRvCbnaziF8S3Ltu3A=
+github.com/falcosecurity/falcoctl v0.2.0-rc1.0.20221222151702-aa4d4ca04684 h1:i61Z8bmpX7hpP3//BtJwyU4gLihQilIm/3Iv1PpPmms=
+github.com/falcosecurity/falcoctl v0.2.0-rc1.0.20221222151702-aa4d4ca04684/go.mod h1:gfYo0lLyEYkA0D1v8pBbELIxQRRvCbnaziF8S3Ltu3A=
+github.com/falcosecurity/falcoctl v0.2.0-rc1.0.20230103133910-a8cf20acc6aa h1:nvVuSwL36H7hFglXhBy3ig+eZwRyfeIMh7eI56gMJAU=
+github.com/falcosecurity/falcoctl v0.2.0-rc1.0.20230103133910-a8cf20acc6aa/go.mod h1:gfYo0lLyEYkA0D1v8pBbELIxQRRvCbnaziF8S3Ltu3A=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=

--- a/build/registry/pkg/common/consts.go
+++ b/build/registry/pkg/common/consts.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022 The Falco Authors.
+Copyright (C) 2023 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,4 +18,10 @@ package common
 
 const (
 	RulesArtifactSuffix = "-rules"
+	// EngineVersionKey is the name given to all the engine requirements.
+	// The same name used by Falco when outputting the engine version.
+	EngineVersionKey = "engine_version"
+	// PluginAPIVersion is the name givet to the plugin api version requirements.
+	// The same name used by Falco when outputting the plugin api version
+	PluginAPIVersion = "plugin_api_version"
 )

--- a/build/registry/pkg/common/extract.go
+++ b/build/registry/pkg/common/extract.go
@@ -1,0 +1,98 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExtractTarGz extracts a *.tar.gz compressed archive and moves its content to destDir.
+// Returns a slice containing the full path of the extracted files.
+func ExtractTarGz(fileName, destDir string) ([]string, error) {
+	var files []string
+
+	gzipStream, err := os.Open(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open file %q: %w", fileName, err)
+	}
+
+	uncompressedStream, err := gzip.NewReader(gzipStream)
+	if err != nil {
+		return nil, err
+	}
+
+	tarReader := tar.NewReader(uncompressedStream)
+
+	for {
+		header, err := tarReader.Next()
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			return nil, fmt.Errorf("unexepected dir inside the archive, expected to find only files without any tree structure")
+		case tar.TypeReg:
+			f := filepath.Join(destDir, filepath.Clean(header.Name))
+			if !strings.HasPrefix(f, filepath.Clean(destDir)+string(os.PathSeparator)) {
+				return nil, fmt.Errorf("illegal file path: %q", f)
+			}
+			outFile, err := os.Create(filepath.Clean(f))
+			if err != nil {
+				return nil, err
+			}
+			if err = copyInChunks(outFile, tarReader); err != nil {
+				return nil, err
+			}
+			if err = outFile.Close(); err != nil {
+				return nil, err
+			}
+			files = append(files, f)
+
+		default:
+			return nil, fmt.Errorf("extractTarGz: uknown type: %b in %s", header.Typeflag, header.Name)
+		}
+	}
+
+	return files, nil
+}
+
+func copyInChunks(dst io.Writer, src io.Reader) error {
+	for {
+		_, err := io.CopyN(dst, src, 1024)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+	}
+
+	return nil
+}

--- a/build/registry/pkg/oci/configLayer.go
+++ b/build/registry/pkg/oci/configLayer.go
@@ -1,0 +1,120 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/falcosecurity/falcoctl/pkg/oci"
+	"github.com/falcosecurity/plugins/build/registry/pkg/common"
+)
+
+// rulesFileConfig generates the artifact configuration for a rulesfile starting form the tar.gz archive,
+// its name and version.
+func rulesfileConfig(name, version, filePath string) (*oci.ArtifactConfig, error) {
+	// Create temp dir.
+	tmpDir, err := os.MkdirTemp("", "registry-oci-")
+	if err != nil {
+		return nil, fmt.Errorf("unable to create temporary dir while preparing to extract rulesfile %q: %v", filePath, err)
+	}
+	defer os.RemoveAll(tmpDir)
+	files, err := common.ExtractTarGz(filePath, tmpDir)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &oci.ArtifactConfig{
+		Name:         name,
+		Version:      version,
+		Dependencies: nil,
+		Requirements: nil,
+	}
+
+	for _, file := range files {
+		// Get the requirements for the given file.
+		req, err := rulesfileRequirement(file)
+		if err != nil && !errors.Is(err, ErrReqNotFound) {
+			return nil, err
+		}
+		// If found add it to the requirements list.
+		if err == nil {
+			_ = cfg.SetRequirement(req.Name, req.Version)
+		}
+
+		deps, err := rulesfileDependencies(file)
+		if err != nil && !errors.Is(err, ErrDepNotFound) {
+			return nil, err
+		}
+		// If found add it to the dependencies list.
+		if err == nil {
+			for _, d := range deps {
+				_ = cfg.SetDependency(d.Name, d.Version, d.Alternatives)
+			}
+		}
+	}
+
+	if cfg.Dependencies == nil || cfg.Requirements == nil {
+		return nil, fmt.Errorf("no dependencies or requirements found for rulesfile %q", filePath)
+	}
+
+	return cfg, nil
+}
+
+func pluginConfig(name, version, filePath string) (*oci.ArtifactConfig, error) {
+	// Create temp dir.
+	tmpDir, err := os.MkdirTemp("", "registry-oci-")
+	if err != nil {
+		return nil, fmt.Errorf("unable to create temporary dir while preparing to extract plugin %q: %v", filePath, err)
+	}
+	defer os.RemoveAll(tmpDir)
+	files, err := common.ExtractTarGz(filePath, tmpDir)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &oci.ArtifactConfig{
+		Name:         name,
+		Version:      version,
+		Dependencies: nil,
+		Requirements: nil,
+	}
+
+	for _, file := range files {
+		// skip files that are not a shared library such as README files.
+		if !strings.HasSuffix(file, ".so") {
+			continue
+		}
+		// Get the requirement for the given file.
+		req, err := pluginRequirement(file)
+		if err != nil && !errors.Is(err, ErrReqNotFound) {
+			return nil, err
+		}
+		// If found add it to the requirements list.
+		if err == nil {
+			_ = cfg.SetRequirement(req.Name, req.Version)
+		}
+	}
+
+	if cfg.Requirements == nil {
+		return nil, fmt.Errorf("no requirements found for plugin %q", filePath)
+	}
+
+	return cfg, nil
+}

--- a/build/registry/pkg/oci/dependencies.go
+++ b/build/registry/pkg/oci/dependencies.go
@@ -1,0 +1,82 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/falcosecurity/falcoctl/pkg/oci"
+	"gopkg.in/yaml.v3"
+)
+
+const depsKey = "- required_plugin_versions"
+
+// ErrDepNotFound error when the dependencies are not found in the rulesfile.
+var ErrDepNotFound = errors.New("dependencies not found")
+
+// rulesfileDependencies given a rulesfile in yaml format it scans it nad extracts its dependencies.
+func rulesfileDependencies(fileName string) ([]oci.ArtifactDependency, error) {
+	var start bool
+	var buf []byte
+	var deps []oci.ArtifactDependency
+
+	// Open the file.
+	file, err := os.Open(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open file %q: %v", fileName, file)
+	}
+
+	// Prepare the file to be read line by line.
+	fileScanner := bufio.NewScanner(file)
+	fileScanner.Split(bufio.ScanLines)
+
+	// Is appended to each line when inserted in the buffer.
+	newLine := []byte("\n")
+
+	// Falco rulesfiles are a list of dictionaries. We only want the "required plugin versions" by the ruleset. We do
+	// not want to load all the file in memory, so we scan it line by line. When we reach the interested section we save
+	// each line in a buffer, and after that we unmarshal it to a proper data structure.
+	for fileScanner.Scan() {
+		// If we have already found the section of interest, and we get a new item of the list then we stop.
+		if start {
+			if strings.HasPrefix(fileScanner.Text(), "-") {
+				break
+			} else {
+				buf = append(buf, fileScanner.Bytes()...)
+				buf = append(buf, newLine...)
+			}
+		} else {
+			if strings.HasPrefix(fileScanner.Text(), depsKey) {
+				start = true
+			}
+		}
+	}
+
+	if !start {
+		return nil, fmt.Errorf("dependencies for rulesfile %q: %w", fileName, ErrDepNotFound)
+	}
+
+	if err := yaml.Unmarshal(buf, &deps); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal the required plugins versions: %w", err)
+	}
+
+	return deps, nil
+}

--- a/build/registry/pkg/oci/requirements.go
+++ b/build/registry/pkg/oci/requirements.go
@@ -1,0 +1,126 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"github.com/blang/semver"
+	"github.com/falcosecurity/falcoctl/pkg/oci"
+	"github.com/falcosecurity/plugins/build/registry/pkg/common"
+	"os"
+	"strings"
+)
+
+/*
+#cgo linux LDFLAGS: -ldl
+#include <dlfcn.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <stdio.h>
+
+static uintptr_t pluginOpen(const char* path, char** err) {
+	void* h = dlopen(path, RTLD_NOW|RTLD_GLOBAL);
+	if (h == NULL) {
+		*err = (char*)dlerror();
+	}
+	return (uintptr_t)h;
+}
+
+static char * get_required_api_version(uintptr_t h, char ** err) {
+	void* s = dlsym((void*)h, "plugin_get_required_api_version");
+	if (s == NULL) {
+		*err = (char*)dlerror();
+        return NULL;
+	}
+	typedef char* (*fptr)();
+    fptr f = (fptr)s;
+    return f();
+}
+*/
+import "C"
+
+const (
+	rulesEngineAnchor = "- required_engine_version"
+)
+
+// ErrReqNotFound error when the requirements are not found in the rulesfile.
+var ErrReqNotFound = errors.New("requirements not found")
+
+// rulesfileRequirement given a rulesfile in yaml format it scans it and extracts its requirements.
+func rulesfileRequirement(filePath string) (*oci.ArtifactRequirement, error) {
+	var requirement string
+	// Open the file.
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open file %q: %v", filePath, file)
+	}
+
+	defer file.Close()
+
+	// Prepare the file to be read line by line.
+	fileScanner := bufio.NewScanner(file)
+	fileScanner.Split(bufio.ScanLines)
+
+	for fileScanner.Scan() {
+		if strings.HasPrefix(fileScanner.Text(), rulesEngineAnchor) {
+			requirement = fileScanner.Text()
+			break
+		}
+	}
+
+	if requirement == "" {
+		return nil, fmt.Errorf("requirements for rulesfile %q: %w", filePath, ErrReqNotFound)
+	}
+
+	// Split the requirement and parse the version to semVer.
+	tokens := strings.Split(fileScanner.Text(), ":")
+	reqVer, err := semver.ParseTolerant(tokens[1])
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse to semVer the version requirement %q", tokens[1])
+	}
+
+	return &oci.ArtifactRequirement{
+		Name:    common.EngineVersionKey,
+		Version: reqVer.String(),
+	}, nil
+}
+
+// pluginRequirement given a plugin as a shared library it loads it and gets the api version
+// required by the plugin.
+func pluginRequirement(filePath string) (*oci.ArtifactRequirement, error) {
+	cPath := C.CString(filePath)
+	var cErr *C.char
+
+	handler := C.pluginOpen(cPath, &cErr)
+	if handler == 0 {
+		return nil, fmt.Errorf("unable to open plugin %q: %s", filePath, C.GoString(cErr))
+	}
+
+	cAPIVer := C.get_required_api_version(handler, &cErr)
+	if cAPIVer == nil {
+		return nil, fmt.Errorf("unable to get the required api version: %s", C.GoString(cErr))
+	}
+
+	return &oci.ArtifactRequirement{
+		Name:    common.PluginAPIVersion,
+		Version: C.GoString(cAPIVer),
+	}, nil
+}


### PR DESCRIPTION
 
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

/area registry

/area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
The CI before pushing the artifacts to the remote registry it correctly configures the `config` layer by adding dependencies and requirements. 

The `rulesfiles` could depend on `plugins` meaning that they need a specific version of a plugin in order to be consumed. At the same time they require that the  Falco `engine version` needs to satisfy the minimum version specified in the `rulesfile`.   The `config` layer of the `k8saudit` ruleset artifact:
```yaml
{
  "name": "k8saudit-rules",
  "version": "0.4.1",
  "dependencies": [
    {
      "name": "json",
      "version": "0.3.0"
    },
    {
      "name": "k8saudit",
      "version": "0.1.0",
      "alternatives": [
        {
          "name": "k8saudit-eks",
          "version": "0.1.0"
        }
      ]
    }
  ],
  "requirements": [
    {
      "name": "engine_version",
      "version": "15.0.0"
    }
  ]
}
```

On the other hand the `plugins` require that the Falco instance loading them satisfies the `plugin_api_version`. The following snippet show the `config` layer for the `k8saudit` plugins:
```yaml
{
  "name": "k8saudit",
  "version": "0.4.1",
  "requirements": [
    {
      "name": "plugin_api_version",
      "version": "2.0.0"
    }
  ]
}
```

The `config` layer is used by the `falcoctl` to manage dependencies and requirements when installing/updating artifacts falcosecurity/falcoctl#205


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
