### PR TITLE
update(plugins/cloudtrail): More friendly error messages

### DIFF
--- a/plugins/cloudtrail/go.mod
+++ b/plugins/cloudtrail/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.18.5
 	github.com/falcosecurity/plugin-sdk-go v0.6.0
 	github.com/valyala/fastjson v1.6.3
+	github.com/aws/smithy-go v1.13.3
 )


### PR DESCRIPTION
Try to construct error messages from smithy.APIError and smithy.OperationError, which gives us access to human-readable strings.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This helps to ensure that the cloudtrail plugin produces human-readable error messages.

Examples:

Expired token:

Old:
> cloudtrail plugin error: failed to list objects: operation error S3: ListObjectsV2, https response error StatusCode: 400, RequestID: Q2TAHZQ6FCC0FT7S, HostID: UAjqUknjoV/6UT1UuxJTxy0h6BSXOoapPOUsPLaD7o+ay0eDG2gSGnVA+O1P62qz279GM66lTSc=, api error ExpiredT

New:
> cloudtrail plugin error: ExpiredToken: The provided token has expired.

Invalid profile:

Old:
> cloudtrail plugin error: failed to list objects: operation error S3: ListObjectsV2, failed to resolve service endpoint, an AWS region is required, but was not found

New:
> cloudtrail plugin error: ListObjectsV2: failed to resolve service endpoint, an AWS region is required, but was not found

Invalid region (luna-1):

Old:
> cloudtrail plugin error: failed to list objects: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get "https://aws-cloudtrail-logs-123456789012-abcd

New:
> cloudtrail plugin error: S3: exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get "https://aws-cloudtrail-logs-123456789012-abcd.s3.luna-1.amazonaws.com/?list-type=2&prefix=AWSLogs%2


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
