### PR TITLE
Add additional known users to eks_allowed_k8s_users

### DIFF
--- a/plugins/k8saudit/rules/k8s_audit_rules.yaml
+++ b/plugins/k8saudit/rules/k8s_audit_rules.yaml
@@ -76,6 +76,7 @@
     "eks:pod-identity-mutating-webhook",
     "eks:cloud-controller-manager",
     "eks:vpc-resource-controller",
+    "eks:addon-manager",
     ]
 -
 - rule: Disallowed K8s User

--- a/plugins/k8saudit/rules/k8s_audit_rules.yaml
+++ b/plugins/k8saudit/rules/k8s_audit_rules.yaml
@@ -73,7 +73,9 @@
     "eks:authenticator",
     "eks:cluster-event-watcher",
     "eks:nodewatcher",
-    "eks:pod-identity-mutating-webhook"
+    "eks:pod-identity-mutating-webhook",
+    "eks:cloud-controller-manager",
+    "eks:vpc-resource-controller",
     ]
 -
 - rule: Disallowed K8s User


### PR DESCRIPTION
Signed-off-by: Tim Schwenke <tim@trallnag.com>

/kind feature

/area plugins

**What this PR does / why we need it**:

Adds two users `eks:vpc-resource-controller` and `eks:cloud-controller-manager` to `eks_allowed_k8s_users` list in `k8s_audit_rules.yaml`.

Needed because these users are standard users in EKS.

For more information see related issue.

**Which issue(s) this PR fixes**: 

Fixes #216 

The user `eks:vpc-resource-controller` is part of the official EKS add-on [VPC CNI](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html). For example mentioned here in this documentation: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html

The cluster role `eks:cloud-controller-manager` belongs to the AWS implementation / extension of the cloud controller and added automatically during provisioning of EKS clusters. For reference see this post on Stack Overflow: [link](https://stackoverflow.com/questions/73302295/ekscloud-controller-manager-cluster-role-in-eks-k8s)

Role `eks:addon-manager` is mentioned here: https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html