### PR TITLE
fix(plugin/k8saudit): Add missing comma to list entry in rule

### DIFF
--- a/plugins/k8saudit/rules/k8s_audit_rules.yaml
+++ b/plugins/k8saudit/rules/k8s_audit_rules.yaml
@@ -191,7 +191,7 @@
     gke.gcr.io/gke-metadata-server,
     gke.gcr.io/kube-proxy,
     gke.gcr.io/netd-amd64,
-    k8s.gcr.io/ip-masq-agent-amd64
+    k8s.gcr.io/ip-masq-agent-amd64,
     k8s.gcr.io/prometheus-to-sd,
     ]
 


### PR DESCRIPTION
Signed-off-by: Tim Schwenke <tim@trallnag.com>

/kind bug

/area plugins

**What this PR does / why we need it**:

There is a missing comma. This leads to two items in the list getting merged into one item.

**Which issue(s) this PR fixes**:

Fixes #217
