### PR TITLE
fix(build/registry): add plugin name as a keyword in index

### DIFF
--- a/build/registry/pkg/distribution/index.go
+++ b/build/registry/pkg/distribution/index.go
@@ -48,7 +48,7 @@ func pluginToIndexEntry(p registry.Plugin, registry, repo string) *index.Entry {
 		Repository:  repo,
 		Description: p.Description,
 		Home:        p.URL,
-		Keywords:    p.Keywords,
+		Keywords:    append(p.Keywords, p.Name),
 		License:     p.License,
 		Maintainers: p.Maintainers,
 		Sources:     []string{p.URL},


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area registry

**What this PR does / why we need it**:

Including the plugin name in the index keywords improves the UX `falcoctl artifact search`, since we also do it for rules already. For example, `falcoctl artifact search cloud` will currently only match the `cloudtrail-rules` artifact, whereas I would expect `cloudtrail` to be a match too.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
