### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/plugins/k8saudit/rules/k8s_audit_rules.yaml
+++ b/plugins/k8saudit/rules/k8s_audit_rules.yaml
@@ -194,8 +194,8 @@
     gke.gcr.io/gke-metadata-server,
     gke.gcr.io/kube-proxy,
     gke.gcr.io/netd-amd64,
-    k8s.gcr.io/ip-masq-agent-amd64,
-    k8s.gcr.io/prometheus-to-sd,
+    registry.k8s.io/ip-masq-agent-amd64,
+    registry.k8s.io/prometheus-to-sd,
     ]
 
 # Corresponds to K8s CIS Benchmark 1.7.4
@@ -339,17 +339,17 @@
     gke.gcr.io/addon-resizer,
     gke.gcr.io/heapster,
     gke.gcr.io/gke-metadata-server,
-    k8s.gcr.io/ip-masq-agent-amd64,
-    k8s.gcr.io/kube-apiserver,
+    registry.k8s.io/ip-masq-agent-amd64,
+    registry.k8s.io/kube-apiserver,
     gke.gcr.io/kube-proxy,
     gke.gcr.io/netd-amd64,
     gke.gcr.io/watcher-daemonset,
-    k8s.gcr.io/addon-resizer
-    k8s.gcr.io/prometheus-to-sd,
-    k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64,
-    k8s.gcr.io/k8s-dns-kube-dns-amd64,
-    k8s.gcr.io/k8s-dns-sidecar-amd64,
-    k8s.gcr.io/metrics-server-amd64,
+    registry.k8s.io/addon-resizer
+    registry.k8s.io/prometheus-to-sd,
+    registry.k8s.io/k8s-dns-dnsmasq-nanny-amd64,
+    registry.k8s.io/k8s-dns-kube-dns-amd64,
+    registry.k8s.io/k8s-dns-sidecar-amd64,
+    registry.k8s.io/metrics-server-amd64,
     kope/kube-apiserver-healthcheck,
     k8s_image_list
     ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**
/area registry

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR migrates the image registry from `k8s.gcr.io` to `registry.k8s.io`

**Which issue(s) this PR fixes**:
[Umbrella Issue] Migrate CNCF Ecosystem projects from k8s.gcr.io to registry.k8s.io

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes https://github.com/kubernetes/k8s.io/issues/4780

