### PR TITLE
feat(plugins/k8saudit): include query params in health check url macros

### DIFF
--- a/plugins/k8saudit/rules/k8s_audit_rules.yaml
+++ b/plugins/k8saudit/rules/k8s_audit_rules.yaml
@@ -145,13 +145,13 @@
   condition: ka.target.resource=secrets
 
 - macro: health_endpoint
-  condition: ka.uri=/healthz
+  condition: ka.uri=/healthz or ka.uri startswith /healthz?
 
 - macro: live_endpoint
-  condition: ka.uri=/livez
+  condition: ka.uri=/livez or ka.uri startswith /livez?
 
 - macro: ready_endpoint
-  condition: ka.uri=/readyz
+  condition: ka.uri=/readyz or ka.uri startswith /readyz?
 
 - rule: Create Disallowed Pod
   desc: >


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

/area plugins

**What this PR does / why we need it**:

Extends macros that match call to Kubernetes control plane health check endpoints to include query parameters. This is supported by Kubernetes officially, see [link](https://kubernetes.io/docs/reference/using-api/health-checks/).

**Which issue(s) this PR fixes**:

Fixes #241
