### PR TITLE
fix(oci/CI): set arm architecture as "arm64" in manifests files

### DIFF
--- a/build/registry/pkg/oci/const.go
+++ b/build/registry/pkg/oci/const.go
@@ -46,5 +46,8 @@ const (
 	// Architectures as used in the names of the archives uploaded in the S3 bucket.
 	x86_arch_s3    = "x86_64"
 	arm_aarch64_s3 = "aarch64"
+	// Architectures as used in the OCI manifests. We translate the archs from S3 notation to the OCI one.
+	amd64OCI       = "amd64"
+	arm64OCI       = "arm64"
 	archive_suffix = ".tar.gz"
 )

--- a/build/registry/pkg/oci/oci.go
+++ b/build/registry/pkg/oci/oci.go
@@ -105,11 +105,12 @@ func s3ArtifactNamePrefix(plugin *registry.Plugin, version string, rulesFile boo
 func platformFromS3Key(key string) string {
 	if strings.Contains(key, x86_arch_s3) {
 		// Instead of "x86_64" we return "amd64" the one to be used in the oci artifact.
-		return "linux/amd64"
+		return fmt.Sprintf("linux/%s", amd64OCI)
 	}
 
 	if strings.Contains(key, arm_aarch64_s3) {
-		return "linux/aarch64"
+		// Instead of "aarch64" we return "arm64" the one to be used in the oci artifact.
+		return fmt.Sprintf("linux/%s", arm64OCI)
 	}
 
 	// Return empty string if it does not contain one of the expected architectures.


### PR DESCRIPTION
Use "arm64" as architecture for plugins build for the arm platform instead of "aarch64".

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

/area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Use "arm64" as architecture for plugins build for the arm platform instead of "aarch64".

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
