### PR TITLE
update(plugins/cloudtrail): Avoid duplicate event info

### DIFF
--- a/plugins/cloudtrail/pkg/cloudtrail/extract.go
+++ b/plugins/cloudtrail/pkg/cloudtrail/extract.go
@@ -152,7 +152,11 @@ func getEvtInfo(jdata *fastjson.Value) string {
 		return "<invalid cloudtrail event: eventName field missing>"
 	}
 
-	info = fmt.Sprintf("%v via %v %v%v %v", evtuser, evtsrcip, errsymbol, rwsymbol, evtname)
+	if (evtuser == evtsrcip) {
+		info = fmt.Sprintf("%v %v%v %v", evtuser, errsymbol, rwsymbol, evtname)
+	} else {
+		info = fmt.Sprintf("%v via %v %v%v %v", evtuser, evtsrcip, errsymbol, rwsymbol, evtname)
+	}
 
 	switch evtname {
 	case "PutBucketPublicAccessBlock":


### PR DESCRIPTION
If ct.user and ct.srcip are the same, just add ct.user to the event info string so that we return

    cloudtrail.amazonaws.com ← GetBucketAcl

instead of

    cloudtrail.amazonaws.com via cloudtrail.amazonaws.com ← GetBucketAcl

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

It avoids adding duplicate information to Cloudtrail's event information string.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
