### PR TITLE
fix(registry/index): do not add artifact name to keywords if already present

### DIFF
--- a/build/registry/pkg/distribution/index.go
+++ b/build/registry/pkg/distribution/index.go
@@ -48,7 +48,7 @@ func pluginToIndexEntry(p registry.Plugin, registry, repo string) *index.Entry {
 		Repository:  repo,
 		Description: p.Description,
 		Home:        p.URL,
-		Keywords:    append(p.Keywords, p.Name),
+		Keywords:    appendIfNotPresent(p.Keywords, p.Name),
 		License:     p.License,
 		Maintainers: p.Maintainers,
 		Sources:     []string{p.URL},
@@ -63,7 +63,7 @@ func pluginRulesToIndexEntry(p registry.Plugin, registry, repo string) *index.En
 		Repository:  repo,
 		Description: p.Description,
 		Home:        p.URL,
-		Keywords:    append(p.Keywords, p.Name+common.RulesArtifactSuffix),
+		Keywords:    appendIfNotPresent(p.Keywords, p.Name+common.RulesArtifactSuffix),
 		License:     p.License,
 		Maintainers: p.Maintainers,
 		Sources:     []string{p.RulesURL},
@@ -170,4 +170,17 @@ func ociRepo(ociEntries map[string]string, client remote.Client, ociRepoNamespac
 
 	ociEntries[artifactName] = ref
 	return nil
+}
+
+// Add new item to a slice if not present.
+func appendIfNotPresent(keywords []string, kw string) []string {
+	// If the keyword already exist do nothing.
+	for i := range keywords {
+		if keywords[i] == kw {
+			return keywords
+		}
+	}
+
+	// Add the keyword
+	return append(keywords, kw)
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

/area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
The artifact name is added to the list of keywords when generating the [index.yaml](https://falcosecurity.github.io/falcoctl/index.yaml) file. It could happen that the list of keywords in `registry.yaml` already contains the artifact name. This fix checks if the artifact name is contained in the keywords, if not adds it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
