### PR TITLE
update(ci/release.yaml): setup per-plugin release concurrency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ on:
 
 # Checks if any concurrent jobs is running for release CI and eventually cancel it.
 concurrency:
-  group: ci-release
-  cancel-in-progress: false
+  group: ci-release-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   extract-info:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

The concurrency of release jobs should be grouped by plugin (represented by their tag's git ref, at release time), instead of being grouped all together.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
