### PR TITLE
fix(ci): build temporary plugins required for release-time validation

### DIFF
--- a/.github/compare-rule-files.sh
+++ b/.github/compare-rule-files.sh
@@ -13,6 +13,11 @@ set -e pipefail
 rm -f $RESULT_FILE
 touch $RESULT_FILE
 
+cur_branch=`git rev-parse HEAD`
+echo Current branch is \"$cur_branch\"
+echo Checking version for rules file \"$RULES_FILE\"...
+cp $RULES_FILE tmp_rule_file.yaml
+
 git checkout tags/$LATEST_TAG
 chmod +x $CHECKER_TOOL
 $CHECKER_TOOL \

--- a/.github/compare-rule-files.sh
+++ b/.github/compare-rule-files.sh
@@ -6,31 +6,14 @@ PLUGIN_NAME=$3
 RESULT_FILE=$4
 CHECKER_TOOL=$5
 FALCO_DOCKER_IMAGE=$6
+LATEST_TAG=$7
 
 set -e pipefail
 
 rm -f $RESULT_FILE
 touch $RESULT_FILE
 
-cur_branch=`git rev-parse HEAD`
-echo Current branch is \"$cur_branch\"
-echo Checking version for rules file \"$RULES_FILE\"...
-cp $RULES_FILE tmp_rule_file.yaml
-
-set +e pipefail
-echo Searching tag with prefix prefix \"$PLUGIN_NAME-\"...
-latest_tag=`git describe --match="$PLUGIN_NAME-*.*.*" --exclude="$PLUGIN_NAME-*.*.*-*" --abbrev=0 --tags $(git rev-list --tags="$PLUGIN_NAME-*.*.*" --max-count=1)`
-set -e pipefail
-
-if [ -z "$latest_tag" ]
-then
-    echo Not previous tag has been found
-    exit 0
-else
-    echo Most recent tag found is \"$latest_tag\"
-fi
-
-git checkout tags/$latest_tag
+git checkout tags/$LATEST_TAG
 chmod +x $CHECKER_TOOL
 $CHECKER_TOOL \
     compare \
@@ -42,7 +25,7 @@ $CHECKER_TOOL \
 git switch --detach $cur_branch
 
 echo '##' $(basename $RULES_FILE) >> $RESULT_FILE
-echo Comparing \`$cur_branch\` with latest tag \`$latest_tag\` >> $RESULT_FILE
+echo Comparing \`$cur_branch\` with latest tag \`$LATEST_TAG\` >> $RESULT_FILE
 echo "" >> $RESULT_FILE
 if [ -s tmp_res.txt ]
 then

--- a/.github/get-latest-plugin-version.sh
+++ b/.github/get-latest-plugin-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+PLUGIN=$1
+
+set +e pipefail
+echo Searching tag with prefix prefix \"${PLUGIN}-\"...
+git fetch --tags origin
+latest_tag=`git describe --match="${PLUGIN}-*.*.*" --exclude="${PLUGIN}-*.*.*-*" --abbrev=0 --tags $(git rev-list --tags="${PLUGIN}-*.*.*" --max-count=1)`
+set -e pipefail
+
+latest_ver="0.0.0"
+if [ -z "$latest_tag" ]
+then
+  echo Not previous tag has been found
+else
+  echo Most recent tag found is \"$latest_tag\"
+  latest_ver=$(echo $latest_tag | cut -d '-' -f 2-)
+fi
+
+echo Setting plugin version for "${PLUGIN}" to $latest_ver
+echo "version=$latest_ver" >> $GITHUB_OUTPUT
+echo "ref=${PLUGIN}-$latest_ver" >> $GITHUB_OUTPUT

--- a/.github/setup-plugin-config-rules.sh
+++ b/.github/setup-plugin-config-rules.sh
@@ -1,18 +1,22 @@
 #!/bin/bash
 
 PLUGIN=$1
-CONFIG_FILE=$2
-RULES_DIR=$3
+
+# set expected paths for plugins' config and rules files
+rules_dir="$GITHUB_WORKSPACE/plugins/${PLUGIN}/rules"
+config_file="$GITHUB_WORKSPACE/plugins/${PLUGIN}/falco.yaml"
+
+# set paths into env vars
+echo "PLUGIN_RULES_DIR=${rules_dir}" >> "$GITHUB_ENV"
+echo "PLUGIN_CONFIG_FILE=${config_file}" >> "$GITHUB_ENV"
 
 # craft a default falco.yaml if no custom one is available
-config_file=$CONFIG_FILE
 if [ ! -f "$config_file" ]; then
   # we assume that the current plugin is always a dependency
   deps="$PLUGIN"
 
   # we collect all plugin dependencies across all plugin rulesets
   # todo(jasondellaluce): find a way to avoid ignoring alternatives
-  rules_dir=$RULES_DIR
   if [ -d "$rules_dir" ]; then
     echo Extracting plugin dependencies from rules files...
     rules_files=$(ls $rules_dir/*)

--- a/.github/setup-plugin-config-rules.sh
+++ b/.github/setup-plugin-config-rules.sh
@@ -6,9 +6,9 @@ PLUGIN=$1
 rules_dir="$GITHUB_WORKSPACE/plugins/${PLUGIN}/rules"
 config_file="$GITHUB_WORKSPACE/plugins/${PLUGIN}/falco.yaml"
 
-# set paths into env vars
-echo "PLUGIN_RULES_DIR=${rules_dir}" >> "$GITHUB_ENV"
-echo "PLUGIN_CONFIG_FILE=${config_file}" >> "$GITHUB_ENV"
+# set paths into step outputs
+echo "rules_dir=${rules_dir}" >> "$GITHUB_OUTPUT"
+echo "config_file=${config_file}" >> "$GITHUB_OUTPUT"
 
 # craft a default falco.yaml if no custom one is available
 if [ ! -f "$config_file" ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
   build-plugins:
     uses: ./.github/workflows/reusable_build_packages.yaml
     with:
-      makecommand: make packages
+      makecommand: make packages -j4
       suffix: ${{ github.event.number }}
     secrets: inherit
 

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -14,7 +14,7 @@ jobs:
   build-plugins-dev:
     uses: falcosecurity/plugins/.github/workflows/reusable_build_packages.yaml@master
     with:
-      makecommand: make packages
+      makecommand: make packages -j4
       suffix: dev
     secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     needs: extract-info
     uses: falcosecurity/plugins/.github/workflows/reusable_build_packages.yaml@master
     with:
-      makecommand: make release/${{ needs.extract-info.outputs.package }}
+      makecommand: make release/${{ needs.extract-info.outputs.package }} -j4
       suffix: stable
     secrets: inherit
 

--- a/.github/workflows/reusable_get_changed_plugins.yaml
+++ b/.github/workflows/reusable_get_changed_plugins.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Get changed files
         id: changed-plugins
         if: github.event_name == 'pull_request'
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.2.0
         with:
           format: space-delimited
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable_validate_plugins.yaml
+++ b/.github/workflows/reusable_validate_plugins.yaml
@@ -59,6 +59,9 @@ jobs:
           arch=${{ inputs.arch }}
           loaded_plugins="$(cat ${{ steps.get-config.outputs.config_file }} | grep '\- name: ' | cut -d ':' -f 2 | xargs)"
 
+          sudo mkdir -p /etc/falco/falco
+          sudo mkdir -p /usr/share/falco/plugins
+
           for plugin_name in $loaded_plugins; do
               echo Installing locally-built plugin "$plugin_name"...
           
@@ -76,9 +79,7 @@ jobs:
                   echo Extracting archive "$archive"...
                   mkdir -p tmpdir && pushd tmpdir
                   tar -xvf $archive
-                  sudo mkdir -p /etc/falco/falco
                   sudo cp -r *.yaml /etc/falco/falco || true
-                  sudo mkdir -p /usr/share/falco/plugins
                   sudo cp -r *.so /usr/share/falco/plugins || true
                   popd && rm -fr tmpdir
               done
@@ -164,6 +165,8 @@ jobs:
             exit 0
           fi
 
+          sudo mkdir -p /usr/share/falco/plugins
+
           rules_files=$(ls ${{ steps.get-config.outputs.rules_dir }}/*)
           for rules_file in $rules_files; do
             deps=$(cat $rules_file | yq -r '.[].required_plugin_versions | select(. != null and . != "")[] | [.name + ":" + .version] | @csv')
@@ -189,13 +192,12 @@ jobs:
                   echo Installed plugin "${plugin_name}" at version "${plugin_ver}"
                   has_updates=1
                 else
-                  echo Can't pull plugin "${plugin_name}" at version "${plugin_ver}"
+                  echo Can\'t pull plugin "${plugin_name}" at version "${plugin_ver}"
                   echo Attempt installing locally-built plugin "${plugin_name}"...
                   for archive in $(ls /tmp/plugins-${{ inputs.arch }}/${plugin_name}-*); do
                     echo Extracting archive "$archive"...
                     mkdir -p tmpdir && pushd tmpdir
                     tar -xvf $archive
-                    sudo mkdir -p /usr/share/falco/plugins
                     sudo cp -r *.so /usr/share/falco/plugins || true
                     popd && rm -fr tmpdir
                   done

--- a/.github/workflows/reusable_validate_plugins.yaml
+++ b/.github/workflows/reusable_validate_plugins.yaml
@@ -40,6 +40,7 @@ jobs:
         run: pip install yq
 
       - name: Setup plugin config and rules
+        id: get-config
         run: ./.github/setup-plugin-config-rules.sh ${{ inputs.plugin }}
 
       - name: Download rules tool
@@ -56,7 +57,7 @@ jobs:
       - name: Install plugin and rules
         run: |
           arch=${{ inputs.arch }}
-          loaded_plugins="$(cat $PLUGIN_CONFIG_FILE | grep '\- name: ' | cut -d ':' -f 2 | xargs)"
+          loaded_plugins="$(cat ${{ steps.get-config.outputs.config_file }} | grep '\- name: ' | cut -d ':' -f 2 | xargs)"
 
           for plugin_name in $loaded_plugins; do
               echo Installing locally-built plugin "$plugin_name"...
@@ -88,17 +89,17 @@ jobs:
           # craft an empty rules file if none is available.
           # this ensures that the plugin gets still loaded even if it has no rules.
           rules_files=""
-          if [ ! -d "$PLUGIN_RULES_DIR" ]; then
+          if [ ! -d "${{ steps.get-config.outputs.rules_dir }}" ]; then
             touch tmp_rules.yaml
             rules_files="./tmp_rules.yaml"
           else
-            rules_files=$(ls $PLUGIN_RULES_DIR/*)
+            rules_files=$(ls ${{ steps.get-config.outputs.rules_dir }}/*)
           fi
 
           ./.github/validate-rules.sh \
             "${{ inputs.falco-image }}" \
             "${{ inputs.rules-checker }}" \
-            "$PLUGIN_CONFIG_FILE" \
+            "${{ steps.get-config.outputs.config_file }}" \
             "$rules_files"
 
   # todo(jasondellaluce): support aarch64 too
@@ -113,6 +114,7 @@ jobs:
         run: pip install yq
       
       - name: Setup plugin config and rules
+        id: get-config
         run: ./.github/setup-plugin-config-rules.sh ${{ inputs.plugin }}
 
       - name: Download plugins
@@ -158,11 +160,11 @@ jobs:
         run: |
           set -e pipefail
 
-          if [ ! -d "$PLUGIN_RULES_DIR" ]; then
+          if [ ! -d "${{ steps.get-config.outputs.rules_dir }}" ]; then
             exit 0
           fi
 
-          rules_files=$(ls $PLUGIN_RULES_DIR/*)
+          rules_files=$(ls ${{ steps.get-config.outputs.rules_dir }}/*)
           for rules_file in $rules_files; do
             deps=$(cat $rules_file | yq -r '.[].required_plugin_versions | select(. != null and . != "")[] | [.name + ":" + .version] | @csv')
 
@@ -205,7 +207,7 @@ jobs:
               ./.github/validate-rules.sh \
                 "${{ inputs.falco-image }}" \
                 "${{ inputs.rules-checker }}" \
-                "$PLUGIN_CONFIG_FILE" \
+                "${{ steps.get-config.outputs.config_file }}" \
                 "$rules_file"
             done 
           done

--- a/.github/workflows/reusable_validate_plugins.yaml
+++ b/.github/workflows/reusable_validate_plugins.yaml
@@ -55,28 +55,36 @@ jobs:
 
       - name: Install plugin and rules
         run: |
-          loaded_plugins="$(cat $PLUGIN_CONFIG_FILE | grep '\- name: ' | cut -d ':' -f 2 | xargs)"
+          arch=${{ inputs.arch }}
+          loaded_plugins="$(cat $PLUGIN_CONFIG_FILE | grep '\- name: ' | cut -d ':' -f 2 | xargs)"            
           
           sudo mkdir -p /etc/falco/falco
           sudo mkdir -p /usr/share/falco/plugins
-
-          mkdir -p tmp
-          pushd tmp
           for plugin_name in $loaded_plugins; do
-            echo Installing locally-built plugin "$plugin_name"...
-            for archive in $(ls /tmp/plugins-${{ inputs.arch }}/${plugin_name}-*); do
-              echo Extracting archive "$archive"...
-              tar -xvf $archive
-              sudo cp -r *.so /usr/share/falco/plugins || true
-              sudo cp -r *.yaml /etc/falco/falco || true
-            done
+              echo Installing locally-built plugin "$plugin_name"...
+          
+              # at release time we only build the released plugin, so it's possible
+              # that validation requires a plugin that we haven't built locally.
+              # in those cases, we build it on-the-fly perform validation with it.
+              packages=$(ls /tmp/plugins-${arch}/${plugin_name}-*)
+              if [ -z "$packages" ]; then
+                  echo Building plugin "$plugin_name" temporary packages...
+                  make package/$plugin_name -j4
+                  packages=$(ls $(pwd)/output/${plugin_name}-*)
+              fi
+          
+              for archive in $packages; do
+                  echo Extracting archive "$archive"...
+                  mkdir -p tmpdir && pushd tmpdir
+                  tar -xvf $archive
+                  sudo cp -r *.so /usr/share/falco/plugins || true
+                  sudo cp -r *.yaml /etc/falco/falco || true
+                  popd && rm -fr tmpdir
+              done
           done
-          popd
-          rm -fr tmp
 
       - name: Validate plugin and rules
         run: |
-          
           # craft an empty rules file if none is available.
           # this ensures that the plugin gets still loaded even if it has no rules.
           rules_files=""

--- a/.github/workflows/reusable_validate_plugins.yaml
+++ b/.github/workflows/reusable_validate_plugins.yaml
@@ -1,4 +1,4 @@
-# This is a reusable workflow used by master CI
+# This is a reusable workflow used by master and release CI
 on:
   workflow_call:
     inputs:
@@ -27,7 +27,7 @@ on:
         required: true
         type: string
 
-jobs:  
+jobs:
   # todo(jasondellaluce): support aarch64 too
   validate-local:
     if: inputs.arch == 'x86_64'
@@ -101,8 +101,8 @@ jobs:
             "$PLUGIN_CONFIG_FILE" \
             "$rules_files"
 
+  # todo(jasondellaluce): support aarch64 too
   validate-falcoctl:
-    # todo(jasondellaluce): support aarch64 too
     if: inputs.arch == 'x86_64'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/reusable_validate_plugins.yaml
+++ b/.github/workflows/reusable_validate_plugins.yaml
@@ -29,24 +29,18 @@ on:
 
 jobs:  
   # todo(jasondellaluce): support aarch64 too
-  validate-plugin-and-rules:
+  validate-local:
     if: inputs.arch == 'x86_64'
-    env:
-      RULES_DIR: ${{ github.workspace }}/plugins/${{ inputs.plugin }}/rules
-      CONFIG_FILE: ${{ github.workspace }}/plugins/${{ inputs.plugin }}/falco.yaml
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Install system dependencies
-        run:
-          pip install yq
+        run: pip install yq
 
-      - name: Download falcoctl
-        run: |
-          curl --fail -LS "https://github.com/falcosecurity/falcoctl/releases/download/v${{ inputs.falcoctl-version }}/falcoctl_${{ inputs.falcoctl-version }}_linux_${{ inputs.arch == 'x86_64' && 'amd64' || 'arm64' }}.tar.gz" | tar -xz
-          sudo install -o root -g root -m 0755 falcoctl /usr/local/bin/falcoctl
+      - name: Setup plugin config and rules
+        run: ./.github/setup-plugin-config-rules.sh ${{ inputs.plugin }}
 
       - name: Download rules tool
         uses: actions/download-artifact@v3
@@ -58,18 +52,10 @@ jobs:
         with:
           name: ${{ inputs.plugins-artifact }}
           path: /tmp/plugins-${{ inputs.arch }}
-      
-      - name: Get config file
-        run: |
-          ./.github/get-config-file.sh \
-            ${{ inputs.plugin }} \
-            ${{ env.CONFIG_FILE }} \
-            ${{ env.RULES_DIR }}
 
-      - name: Install plugin and rules (local artifacts)
+      - name: Install plugin and rules
         run: |
-          config_file=$CONFIG_FILE
-          loaded_plugins="$(cat $config_file | grep '\- name: ' | cut -d ':' -f 2 | xargs)"
+          loaded_plugins="$(cat $PLUGIN_CONFIG_FILE | grep '\- name: ' | cut -d ':' -f 2 | xargs)"
           
           sudo mkdir -p /etc/falco/falco
           sudo mkdir -p /usr/share/falco/plugins
@@ -88,27 +74,49 @@ jobs:
           popd
           rm -fr tmp
 
-      - name: Validate plugin and rules (local artifacts)
+      - name: Validate plugin and rules
         run: |
-          config_file=$CONFIG_FILE
-          rules_dir=$RULES_DIR
           
           # craft an empty rules file if none is available.
           # this ensures that the plugin gets still loaded even if it has no rules.
           rules_files=""
-          if [ ! -d "$rules_dir" ]; then
+          if [ ! -d "$PLUGIN_RULES_DIR" ]; then
             touch tmp_rules.yaml
             rules_files="./tmp_rules.yaml"
           else
-            rules_files=$(ls $rules_dir/*)
+            rules_files=$(ls $PLUGIN_RULES_DIR/*)
           fi
 
           ./.github/validate-rules.sh \
             "${{ inputs.falco-image }}" \
             "${{ inputs.rules-checker }}" \
-            "$config_file" \
+            "$PLUGIN_CONFIG_FILE" \
             "$rules_files"
 
+  validate-falcoctl:
+    # todo(jasondellaluce): support aarch64 too
+    if: inputs.arch == 'x86_64'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install system dependencies
+        run: pip install yq
+      
+      - name: Setup plugin config and rules
+        run: ./.github/setup-plugin-config-rules.sh ${{ inputs.plugin }}
+
+      - name: Download rules tool
+        uses: actions/download-artifact@v3
+        with:
+          name: rules-tool.tar.gz
+
+      - name: Download falcoctl
+        run: |
+          curl --fail -LS "https://github.com/falcosecurity/falcoctl/releases/download/v${{ inputs.falcoctl-version }}/falcoctl_${{ inputs.falcoctl-version }}_linux_${{ inputs.arch == 'x86_64' && 'amd64' || 'arm64' }}.tar.gz" | tar -xz
+          sudo install -o root -g root -m 0755 falcoctl /usr/local/bin/falcoctl
+  
       # note(jsondellaluce): exploring the set of all dependencies including their
       # alternatives and all the possible combinations of different versions would
       # result in a combinatorial explosion. As such, we take the simple route
@@ -132,17 +140,15 @@ jobs:
       # todo(jasondellaluce): improve this by attempting more cases
       # todo(jasondellaluce): if we skip one minor version (e.g. bump from v0.1.0
       # to v0.3.0), this algorithm would stop before finishing the exploration
-      - name: Validate plugin and rules (falcoctl artifacts)
+      - name: Validate plugin and rules
         run: |
           set -e pipefail
-          config_file=$CONFIG_FILE
-          rules_dir=$RULES_DIR
 
-          if [ ! -d "$rules_dir" ]; then
+          if [ ! -d "$PLUGIN_RULES_DIR" ]; then
             exit 0
           fi
 
-          rules_files=$(ls $rules_dir/*)
+          rules_files=$(ls $PLUGIN_RULES_DIR/*)
           for rules_file in $rules_files; do
             deps=$(cat $rules_file | yq -r '.[].required_plugin_versions | select(. != null and . != "")[] | [.name + ":" + .version] | @csv')
 
@@ -174,7 +180,7 @@ jobs:
               ./.github/validate-rules.sh \
                 "${{ inputs.falco-image }}" \
                 "${{ inputs.rules-checker }}" \
-                "$config_file" \
+                "$PLUGIN_CONFIG_FILE" \
                 "$rules_file"
             done 
           done

--- a/.github/workflows/reusable_validate_plugins.yaml
+++ b/.github/workflows/reusable_validate_plugins.yaml
@@ -56,10 +56,8 @@ jobs:
       - name: Install plugin and rules
         run: |
           arch=${{ inputs.arch }}
-          loaded_plugins="$(cat $PLUGIN_CONFIG_FILE | grep '\- name: ' | cut -d ':' -f 2 | xargs)"            
-          
-          sudo mkdir -p /etc/falco/falco
-          sudo mkdir -p /usr/share/falco/plugins
+          loaded_plugins="$(cat $PLUGIN_CONFIG_FILE | grep '\- name: ' | cut -d ':' -f 2 | xargs)"
+
           for plugin_name in $loaded_plugins; do
               echo Installing locally-built plugin "$plugin_name"...
           
@@ -77,8 +75,10 @@ jobs:
                   echo Extracting archive "$archive"...
                   mkdir -p tmpdir && pushd tmpdir
                   tar -xvf $archive
-                  sudo cp -r *.so /usr/share/falco/plugins || true
+                  sudo mkdir -p /etc/falco/falco
                   sudo cp -r *.yaml /etc/falco/falco || true
+                  sudo mkdir -p /usr/share/falco/plugins
+                  sudo cp -r *.so /usr/share/falco/plugins || true
                   popd && rm -fr tmpdir
               done
           done
@@ -114,6 +114,12 @@ jobs:
       
       - name: Setup plugin config and rules
         run: ./.github/setup-plugin-config-rules.sh ${{ inputs.plugin }}
+
+      - name: Download plugins
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.plugins-artifact }}
+          path: /tmp/plugins-${{ inputs.arch }}
 
       - name: Download rules tool
         uses: actions/download-artifact@v3
@@ -180,6 +186,17 @@ jobs:
                 if [ $? -eq 0 ]; then
                   echo Installed plugin "${plugin_name}" at version "${plugin_ver}"
                   has_updates=1
+                else
+                  echo Can't pull plugin "${plugin_name}" at version "${plugin_ver}"
+                  echo Attempt installing locally-built plugin "${plugin_name}"...
+                  for archive in $(ls /tmp/plugins-${{ inputs.arch }}/${plugin_name}-*); do
+                    echo Extracting archive "$archive"...
+                    mkdir -p tmpdir && pushd tmpdir
+                    tar -xvf $archive
+                    sudo mkdir -p /usr/share/falco/plugins
+                    sudo cp -r *.so /usr/share/falco/plugins || true
+                    popd && rm -fr tmpdir
+                  done
                 fi
                 set -e pipefail
               done

--- a/.github/workflows/rules.yaml
+++ b/.github/workflows/rules.yaml
@@ -42,6 +42,7 @@ jobs:
         run: pip install yq
 
       - name: Setup plugin config and rules
+        id: get-config
         run: ./.github/setup-plugin-config-rules.sh ${{ matrix.plugin }}
 
       - name: Get latest tag
@@ -57,14 +58,14 @@ jobs:
         id: compare
         if: steps.get-tag.outputs.version != '0.0.0'
         run: |
-          rules_dir=$PLUGIN_RULES_DIR
+          rules_dir=${{ steps.get-config.outputs.rules_dir }}
 
           if [ -d "$rules_dir" ]; then
             rules_files=$(ls $rules_dir/*)
             for rules_file in $rules_files; do
               ./.github/compare-rule-files.sh \
                   "$rules_file" \
-                  $PLUGIN_CONFIG_FILE \
+                  ${{ steps.get-config.outputs.config_file }} \
                   ${{ matrix.plugin }} \
                   rule_result.txt \
                   ./rules-checker \

--- a/.github/workflows/rules.yaml
+++ b/.github/workflows/rules.yaml
@@ -38,14 +38,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Get all git tags
-        run: git fetch --tags origin
-      
       - name: Install system dependencies
         run: pip install yq
 
       - name: Setup plugin config and rules
         run: ./.github/setup-plugin-config-rules.sh ${{ matrix.plugin }}
+
+      - name: Get latest tag
+        id: get-tag
+        run: ./.github/get-latest-plugin-version.sh ${{ matrix.plugin }}
 
       - name: Download rules tool
         uses: actions/download-artifact@v3
@@ -54,6 +55,7 @@ jobs:
 
       - name: Compare changed files with previous versions
         id: compare
+        if: steps.get-tag.outputs.version != '0.0.0'
         run: |
           rules_dir=$PLUGIN_RULES_DIR
 
@@ -66,7 +68,8 @@ jobs:
                   ${{ matrix.plugin }} \
                   rule_result.txt \
                   ./rules-checker \
-                  "falcosecurity/falco-no-driver:$FALCO_VERSION"
+                  "falcosecurity/falco-no-driver:$FALCO_VERSION" \
+                  ${{ steps.get-tag.outputs.ref }}
 
               if [ -s rule_result.txt ]; then
                 if [ ! -s result.txt ]; then

--- a/.github/workflows/rules.yaml
+++ b/.github/workflows/rules.yaml
@@ -34,9 +34,6 @@ jobs:
       matrix:
         plugin: ${{ fromJson(needs.get-changed-plugins.outputs.changed-plugins) }}
     runs-on: ubuntu-latest
-    env:
-      RULES_DIR: ${{ github.workspace }}/plugins/${{ matrix.plugin }}/rules
-      CONFIG_FILE: ${{ github.workspace }}/plugins/${{ matrix.plugin }}/falco.yaml
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -45,32 +42,27 @@ jobs:
         run: git fetch --tags origin
       
       - name: Install system dependencies
-        run:
-          pip install yq
+        run: pip install yq
+
+      - name: Setup plugin config and rules
+        run: ./.github/setup-plugin-config-rules.sh ${{ matrix.plugin }}
 
       - name: Download rules tool
         uses: actions/download-artifact@v3
         with:
           name: rules-tool.tar.gz
-      
-      - name: Get config file
-        run: |
-          ./.github/get-config-file.sh \
-            ${{ matrix.plugin }} \
-            ${{ env.CONFIG_FILE }} \
-            ${{ env.RULES_DIR }}
 
       - name: Compare changed files with previous versions
         id: compare
         run: |
-          rules_dir=$RULES_DIR
+          rules_dir=$PLUGIN_RULES_DIR
 
           if [ -d "$rules_dir" ]; then
             rules_files=$(ls $rules_dir/*)
             for rules_file in $rules_files; do
               ./.github/compare-rule-files.sh \
                   "$rules_file" \
-                  $CONFIG_FILE \
+                  $PLUGIN_CONFIG_FILE \
                   ${{ matrix.plugin }} \
                   rule_result.txt \
                   ./rules-checker \

--- a/plugins/cloudtrail/rules/aws_cloudtrail_rules.yaml
+++ b/plugins/cloudtrail/rules/aws_cloudtrail_rules.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 The Falco Authors.
+# Copyright (C) 2023 The Falco Authors.
 #
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/plugins/gcpaudit/pkg/gcpaudit/gcpaudit.go
+++ b/plugins/gcpaudit/pkg/gcpaudit/gcpaudit.go
@@ -1,10 +1,6 @@
 package gcpaudit
 
 import (
-
-	// "io/ioutil"
-	// "fmt"
-	// "github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
 	"context"
 
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins"

--- a/plugins/gcpaudit/rules/gcp_auditlog_rules.yaml
+++ b/plugins/gcpaudit/rules/gcp_auditlog_rules.yaml
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2023 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 - required_engine_version: 11
 
 - required_plugin_versions:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Our release workflow might fail when validating the locally-built plugins due to potentially-required plugins being missing. This happens because at release time we only build the released plugin, whereas validation might require more than one locally-built plugin.

For example, when releasing `k8saudit` we build only that plugin in release mode, however when validating with local packages we need Falco to load both `k8saudit` and `json` (because the k8s audit ruleset requires `json` too), and so we need to build a dev package for `json` on the fly.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
