### PR TITLE
fix(plugins): avoid using gocheck=2

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -37,7 +37,7 @@ NAME := <YOUR-PLUGIN-NAME-HERE>
 OUTPUT := lib$(NAME).so
 
 ifeq ($(DEBUG), 1)
-    GODEBUGFLAGS= GODEBUG=cgocheck=2
+    GODEBUGFLAGS= GODEBUG=cgocheck=1
 else
     GODEBUGFLAGS= GODEBUG=cgocheck=0
 endif

--- a/plugins/cloudtrail/Makefile
+++ b/plugins/cloudtrail/Makefile
@@ -18,7 +18,7 @@ NAME := cloudtrail
 OUTPUT := lib$(NAME).so
 
 ifeq ($(DEBUG), 1)
-    GODEBUGFLAGS= GODEBUG=cgocheck=2
+    GODEBUGFLAGS= GODEBUG=cgocheck=1
 else
     GODEBUGFLAGS= GODEBUG=cgocheck=0
 endif

--- a/plugins/cloudtrail/README.md
+++ b/plugins/cloudtrail/README.md
@@ -19,52 +19,52 @@ The event source for cloudtrail events is `aws_cloudtrail`.
 Here is the current set of supported fields:
 
 <!-- README-PLUGIN-FIELDS -->
-|             NAME             |   TYPE   | ARG  | DESCRIPTION                                                                                                                                              |
-|------------------------------|----------|------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ct.id`                      | `string` | None | the unique ID of the cloudtrail event (eventID in the json).                                                                                             |
-| `ct.error`                   | `string` | None | The error code from the event. Will be "<NA>" (e.g. the NULL/empty/none value) if there was no error.                                                    |
-| `ct.time`                    | `string` | None | the timestamp of the cloudtrail event (eventTime in the json).                                                                                           |
-| `ct.src`                     | `string` | None | the source of the cloudtrail event (eventSource in the json).                                                                                            |
-| `ct.shortsrc`                | `string` | None | the source of the cloudtrail event (eventSource in the json, without the '.amazonaws.com' trailer).                                                      |
-| `ct.name`                    | `string` | None | the name of the cloudtrail event (eventName in the json).                                                                                                |
-| `ct.user`                    | `string` | None | the user of the cloudtrail event (userIdentity.userName in the json).                                                                                    |
-| `ct.user.accountid`          | `string` | None | the account id of the user of the cloudtrail event.                                                                                                      |
-| `ct.user.identitytype`       | `string` | None | the kind of user identity (e.g. Root, IAMUser,AWSService, etc.)                                                                                          |
-| `ct.user.principalid`        | `string` | None | A unique identifier for the user that made the request.                                                                                                  |
-| `ct.user.arn`                | `string` | None | the Amazon Resource Name (ARN) of the user that made the request.                                                                                        |
-| `ct.region`                  | `string` | None | the region of the cloudtrail event (awsRegion in the json).                                                                                              |
-| `ct.response.subnetid`       | `string` | None | the subnet ID included in the response.                                                                                                                  |
-| `ct.response.reservationid`  | `string` | None | the reservation ID included in the response.                                                                                                             |
+|             NAME              |   TYPE   | ARG  |                                                                       DESCRIPTION                                                                        |
+|-------------------------------|----------|------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ct.id`                       | `string` | None | the unique ID of the cloudtrail event (eventID in the json).                                                                                             |
+| `ct.error`                    | `string` | None | The error code from the event. Will be "<NA>" (e.g. the NULL/empty/none value) if there was no error.                                                    |
+| `ct.time`                     | `string` | None | the timestamp of the cloudtrail event (eventTime in the json).                                                                                           |
+| `ct.src`                      | `string` | None | the source of the cloudtrail event (eventSource in the json).                                                                                            |
+| `ct.shortsrc`                 | `string` | None | the source of the cloudtrail event (eventSource in the json, without the '.amazonaws.com' trailer).                                                      |
+| `ct.name`                     | `string` | None | the name of the cloudtrail event (eventName in the json).                                                                                                |
+| `ct.user`                     | `string` | None | the user of the cloudtrail event (userIdentity.userName in the json).                                                                                    |
+| `ct.user.accountid`           | `string` | None | the account id of the user of the cloudtrail event.                                                                                                      |
+| `ct.user.identitytype`        | `string` | None | the kind of user identity (e.g. Root, IAMUser,AWSService, etc.)                                                                                          |
+| `ct.user.principalid`         | `string` | None | A unique identifier for the user that made the request.                                                                                                  |
+| `ct.user.arn`                 | `string` | None | the Amazon Resource Name (ARN) of the user that made the request.                                                                                        |
+| `ct.region`                   | `string` | None | the region of the cloudtrail event (awsRegion in the json).                                                                                              |
+| `ct.response.subnetid`        | `string` | None | the subnet ID included in the response.                                                                                                                  |
+| `ct.response.reservationid`   | `string` | None | the reservation ID included in the response.                                                                                                             |
 | `ct.request.availabilityzone` | `string` | None | the availability zone included in the request.                                                                                                           |
-| `ct.request.cluster`         | `string` | None | the cluster included in the request.                                                                                                                     |
-| `ct.request.functionname`    | `string` | None | the function name included in the request.                                                                                                               |
-| `ct.request.groupname`       | `string` | None | the group name included in the request.                                                                                                                  |
-| `ct.request.host`            | `string` | None | the host included in the request                                                                                                                         |
-| `ct.request.name`            | `string` | None | the name of the entity being acted on in the request.                                                                                                    |
-| `ct.request.policy`          | `string` | None | the policy included in the request                                                                                                                       |
-| `ct.request.serialnumber`    | `string` | None | the serial number provided in the request.                                                                                                               |
-| `ct.request.servicename`     | `string` | None | the service name provided in the request.                                                                                                                |
-| `ct.request.subnetid`        | `string` | None | the subnet ID provided in the request.                                                                                                                   |
-| `ct.request.taskdefinition`  | `string` | None | the task definition prrovided in the request.                                                                                                            |
-| `ct.request.username`        | `string` | None | the username provided in the request.                                                                                                                    |
-| `ct.srcip`                   | `string` | None | the IP address generating the event (sourceIPAddress in the json).                                                                                       |
-| `ct.useragent`               | `string` | None | the user agent generating the event (userAgent in the json).                                                                                             |
-| `ct.info`                    | `string` | None | summary information about the event. This varies depending on the event type and, for some events, it contains event-specific details.                   |
-| `ct.managementevent`         | `string` | None | 'true' if the event is a management event (AwsApiCall, AwsConsoleAction, AwsConsoleSignIn, or AwsServiceEvent), 'false' otherwise.                       |
-| `ct.readonly`                | `string` | None | 'true' if the event only reads information (e.g. DescribeInstances), 'false' if the event modifies the state (e.g. RunInstances, CreateLoadBalancer...). |
-| `s3.uri`                     | `string` | None | the s3 URI (s3://<bucket>/<key>).                                                                                                                        |
-| `s3.bucket`                  | `string` | None | the bucket name for s3 events.                                                                                                                           |
-| `s3.key`                     | `string` | None | the S3 key name.                                                                                                                                         |
-| `s3.bytes`                   | `uint64` | None | the size of an s3 download or upload, in bytes.                                                                                                          |
-| `s3.bytes.in`                | `uint64` | None | the size of an s3 upload, in bytes.                                                                                                                      |
-| `s3.bytes.out`               | `uint64` | None | the size of an s3 download, in bytes.                                                                                                                    |
-| `s3.cnt.get`                 | `uint64` | None | the number of get operations. This field is 1 for GetObject events, 0 otherwise.                                                                         |
-| `s3.cnt.put`                 | `uint64` | None | the number of put operations. This field is 1 for PutObject events, 0 otherwise.                                                                         |
-| `s3.cnt.other`               | `uint64` | None | the number of non I/O operations. This field is 0 for GetObject and PutObject events, 1 for all the other events.                                        |
-| `ec2.name`                   | `string` | None | the name of the ec2 instances, typically stored in the instance tags.                                                                                    |
-| `ec2.imageid`                | `string` | None | the ID for the image used to run the ec2 instance in the response.                                                                                       |
-| `ecr.repository`             | `string` | None | the name of the ecr Repository specified in the request.                                                                                                 |
-| `ecr.imagetag`               | `string` | None | the tag of the image specified in the request.                                                                                                           |
+| `ct.request.cluster`          | `string` | None | the cluster included in the request.                                                                                                                     |
+| `ct.request.functionname`     | `string` | None | the function name included in the request.                                                                                                               |
+| `ct.request.groupname`        | `string` | None | the group name included in the request.                                                                                                                  |
+| `ct.request.host`             | `string` | None | the host included in the request                                                                                                                         |
+| `ct.request.name`             | `string` | None | the name of the entity being acted on in the request.                                                                                                    |
+| `ct.request.policy`           | `string` | None | the policy included in the request                                                                                                                       |
+| `ct.request.serialnumber`     | `string` | None | the serial number provided in the request.                                                                                                               |
+| `ct.request.servicename`      | `string` | None | the service name provided in the request.                                                                                                                |
+| `ct.request.subnetid`         | `string` | None | the subnet ID provided in the request.                                                                                                                   |
+| `ct.request.taskdefinition`   | `string` | None | the task definition prrovided in the request.                                                                                                            |
+| `ct.request.username`         | `string` | None | the username provided in the request.                                                                                                                    |
+| `ct.srcip`                    | `string` | None | the IP address generating the event (sourceIPAddress in the json).                                                                                       |
+| `ct.useragent`                | `string` | None | the user agent generating the event (userAgent in the json).                                                                                             |
+| `ct.info`                     | `string` | None | summary information about the event. This varies depending on the event type and, for some events, it contains event-specific details.                   |
+| `ct.managementevent`          | `string` | None | 'true' if the event is a management event (AwsApiCall, AwsConsoleAction, AwsConsoleSignIn, or AwsServiceEvent), 'false' otherwise.                       |
+| `ct.readonly`                 | `string` | None | 'true' if the event only reads information (e.g. DescribeInstances), 'false' if the event modifies the state (e.g. RunInstances, CreateLoadBalancer...). |
+| `s3.uri`                      | `string` | None | the s3 URI (s3://<bucket>/<key>).                                                                                                                        |
+| `s3.bucket`                   | `string` | None | the bucket name for s3 events.                                                                                                                           |
+| `s3.key`                      | `string` | None | the S3 key name.                                                                                                                                         |
+| `s3.bytes`                    | `uint64` | None | the size of an s3 download or upload, in bytes.                                                                                                          |
+| `s3.bytes.in`                 | `uint64` | None | the size of an s3 upload, in bytes.                                                                                                                      |
+| `s3.bytes.out`                | `uint64` | None | the size of an s3 download, in bytes.                                                                                                                    |
+| `s3.cnt.get`                  | `uint64` | None | the number of get operations. This field is 1 for GetObject events, 0 otherwise.                                                                         |
+| `s3.cnt.put`                  | `uint64` | None | the number of put operations. This field is 1 for PutObject events, 0 otherwise.                                                                         |
+| `s3.cnt.other`                | `uint64` | None | the number of non I/O operations. This field is 0 for GetObject and PutObject events, 1 for all the other events.                                        |
+| `ec2.name`                    | `string` | None | the name of the ec2 instances, typically stored in the instance tags.                                                                                    |
+| `ec2.imageid`                 | `string` | None | the ID for the image used to run the ec2 instance in the response.                                                                                       |
+| `ecr.repository`              | `string` | None | the name of the ecr Repository specified in the request.                                                                                                 |
+| `ecr.imagetag`                | `string` | None | the tag of the image specified in the request.                                                                                                           |
 <!-- /README-PLUGIN-FIELDS -->
 
 ## Handling AWS Authentication

--- a/plugins/dummy/Makefile
+++ b/plugins/dummy/Makefile
@@ -18,7 +18,7 @@ NAME := dummy
 OUTPUT := lib$(NAME).so
 
 ifeq ($(DEBUG), 1)
-    GODEBUGFLAGS= GODEBUG=cgocheck=2
+    GODEBUGFLAGS= GODEBUG=cgocheck=1
 else
     GODEBUGFLAGS= GODEBUG=cgocheck=0
 endif

--- a/plugins/dummy_c/README.md
+++ b/plugins/dummy_c/README.md
@@ -15,11 +15,11 @@ The event source for dummy events is `dummy`.
 Here is the current set of supported fields:
 
 <!-- README-PLUGIN-FIELDS -->
-|       NAME        |   TYPE   | ARG  |                               DESCRIPTION                               |
-|-------------------|----------|------|-------------------------------------------------------------------------|
-| `dummy.divisible` | `uint64` | None | Return 1 if the value is divisible by the provided divisor, 0 otherwise |
-| `dummy.value`     | `uint64` | None | The sample value in the event                                           |
-| `dummy.strvalue`  | `string` | None | The sample value in the event, as a string                              |
+|       NAME        |   TYPE   |  ARG  |                               DESCRIPTION                               |
+|-------------------|----------|-------|-------------------------------------------------------------------------|
+| `dummy.divisible` | `uint64` | Index | Return 1 if the value is divisible by the provided divisor, 0 otherwise |
+| `dummy.value`     | `uint64` | Index | The sample value in the event                                           |
+| `dummy.strvalue`  | `string` | Index | The sample value in the event, as a string                              |
 <!-- /README-PLUGIN-FIELDS -->
 
 ## Configuration

--- a/plugins/gcpaudit/Makefile
+++ b/plugins/gcpaudit/Makefile
@@ -18,7 +18,7 @@ NAME := gcpaudit
 OUTPUT := lib$(NAME).so
 
 ifeq ($(DEBUG), 1)
-    GODEBUGFLAGS= GODEBUG=cgocheck=2
+    GODEBUGFLAGS= GODEBUG=cgocheck=1
 else
     GODEBUGFLAGS= GODEBUG=cgocheck=0
 endif

--- a/plugins/github/Makefile
+++ b/plugins/github/Makefile
@@ -18,7 +18,7 @@ NAME := github
 OUTPUT := lib$(NAME).so
 
 ifeq ($(DEBUG), 1)
-    GODEBUGFLAGS= GODEBUG=cgocheck=2
+    GODEBUGFLAGS= GODEBUG=cgocheck=1
 else
     GODEBUGFLAGS= GODEBUG=cgocheck=0
 endif

--- a/plugins/json/Makefile
+++ b/plugins/json/Makefile
@@ -18,7 +18,7 @@ NAME := json
 OUTPUT := lib$(NAME).so
 
 ifeq ($(DEBUG), 1)
-    GODEBUGFLAGS= GODEBUG=cgocheck=2
+    GODEBUGFLAGS= GODEBUG=cgocheck=1
 else
     GODEBUGFLAGS= GODEBUG=cgocheck=0
 endif

--- a/plugins/k8saudit-eks/Makefile
+++ b/plugins/k8saudit-eks/Makefile
@@ -18,7 +18,7 @@ NAME := k8saudit-eks
 OUTPUT := lib$(NAME).so
 
 ifeq ($(DEBUG), 1)
-    GODEBUGFLAGS= GODEBUG=cgocheck=2
+    GODEBUGFLAGS= GODEBUG=cgocheck=1
 else
     GODEBUGFLAGS= GODEBUG=cgocheck=0
 endif

--- a/plugins/k8saudit/Makefile
+++ b/plugins/k8saudit/Makefile
@@ -23,7 +23,7 @@ NAME := k8saudit
 OUTPUT := lib$(NAME).so
 
 ifeq ($(DEBUG), 1)
-    GODEBUGFLAGS= GODEBUG=cgocheck=2
+    GODEBUGFLAGS= GODEBUG=cgocheck=1
 else
     GODEBUGFLAGS= GODEBUG=cgocheck=0
 endif

--- a/plugins/okta/Makefile
+++ b/plugins/okta/Makefile
@@ -18,7 +18,7 @@ NAME := okta
 OUTPUT := lib$(NAME).so
 
 ifeq ($(DEBUG), 1)
-    GODEBUGFLAGS= GODEBUG=cgocheck=2
+    GODEBUGFLAGS= GODEBUG=cgocheck=1
 else
     GODEBUGFLAGS= GODEBUG=cgocheck=0
 endif

--- a/plugins/okta/README.md
+++ b/plugins/okta/README.md
@@ -23,7 +23,7 @@ The event source for `okta` events is `okta`.
 # Supported Fields
 
 <!-- README-PLUGIN-FIELDS -->
-| NAME                            |   TYPE   |       ARG       | DESCRIPTION                           |
+|              NAME               |   TYPE   |       ARG       |              DESCRIPTION              |
 |---------------------------------|----------|-----------------|---------------------------------------|
 | `okta.app`                      | `string` | None            | Application                           |
 | `okta.org`                      | `string` | None            | Organization                          |


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

Supposedly fixes the following error from CodeQL C++:

```
fatal error: cgocheck > 1 mode is no longer supported at runtime. Use GOEXPERIMENT=cgocheck2 at build time instead.
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
