### PR TITLE
fix(ci): solve VCS stamping issues in validation workflow

### DIFF
--- a/.github/workflows/reusable_validate_plugins.yaml
+++ b/.github/workflows/reusable_validate_plugins.yaml
@@ -33,6 +33,8 @@ jobs:
     if: inputs.arch == 'x86_64'
     runs-on: ubuntu-latest
     container: golang:1.18
+    env:
+      GOFLAGS: '-buildvcs=false'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -67,6 +69,9 @@ jobs:
 
           mkdir -p /etc/falco/falco
           mkdir -p /usr/share/falco/plugins
+          
+          # avoids git exit status 128: detected dubious ownership in repository
+          git config --global --add safe.directory $(pwd)
 
           for plugin_name in $loaded_plugins; do
               echo Installing locally-built plugin "$plugin_name"...


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

In the validation workflow, if/when building plugins on the fly, we currently hit an error like:
```
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
