### PR TITLE
fix(plugins/cloudtrail): Generate the correct interval values

### DIFF
--- a/plugins/cloudtrail/pkg/cloudtrail/interval.go
+++ b/plugins/cloudtrail/pkg/cloudtrail/interval.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-var RFC3339Simple = "2006-01-02T03:04:05Z"
+var RFC3339Simple = "2006-01-02T15:04:05Z"
 
 func parseEndpoint(endpoint string) (time.Time, error) {
 	utc := time.Now().UTC()

--- a/plugins/cloudtrail/pkg/cloudtrail/source.go
+++ b/plugins/cloudtrail/pkg/cloudtrail/source.go
@@ -182,7 +182,6 @@ func (oCtx *PluginInstance) openS3(input string) error {
 	var inputParams []listOrigin
 	ctx := context.Background()
 
-	// XXX Make empty mean no startTime.
 	startTime, endTime, err := ParseInterval(oCtx.config.S3Interval)
 	if err != nil {
 		return fmt.Errorf(PluginName + " invalid interval: \"%s\": %s", oCtx.config.S3Interval, err.Error())
@@ -234,9 +233,10 @@ func (oCtx *PluginInstance) openS3(input string) error {
 
 	if len(inputParams) > 0 {
 		if !startTime.IsZero() {
-			startTS = startTime.Format("20060102T0304")
+			startAfterFormat := "20060102T1504"
+			startTS = startTime.Format(startAfterFormat)
 			if !endTime.IsZero() {
-				endTS = endTime.Format("20060102T0304")
+				endTS = endTime.Format(startAfterFormat)
 				if endTS < startTS {
 					return fmt.Errorf(PluginName + " start time %s must be less than end time %s", startTime.Format(RFC3339Simple), endTime.Format(RFC3339Simple))
 				}


### PR DESCRIPTION
Use the correct format for generating start and stop times.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fixes a time formatting bug in the CloudTrail plugin.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
