### PR TITLE
fix(gha): catch registry update errors during OCI updates

### DIFF
--- a/.github/workflows/upload-oci-artifacts.yaml
+++ b/.github/workflows/upload-oci-artifacts.yaml
@@ -33,9 +33,8 @@ jobs:
           REPO_GITHUB: https://github.com/${{ github.repository_owner }}/plugins.git
         working-directory: build/registry
         run: >-
-          echo "REGISTRY_UPDATE_STATUS=$(
-            ./bin/registry update-oci-registry ../../registry.yaml
-          )" >> $GITHUB_OUTPUT
+          REGISTRY_UPDATE_STATUS=$(./bin/registry update-oci-registry ../../registry.yaml)
+          echo "REGISTRY_UPDATE_STATUS=${REGISTRY_UPDATE_STATUS}" >> $GITHUB_OUTPUT
 
   # Create signatures of the plugin artifacts as OCI artifacts
   sign-oci-artifacts:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

**What this PR does / why we need it**:

In Bash, `echo "something=$(failing_command)"` does not fail. Meaning, if there is an error the job would attempt to continue and mysteriously fail later on. This fixes it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
