### PR TITLE
fix(build): do not halt the build on missing rules repository

### DIFF
--- a/build/registry/pkg/oci/oci.go
+++ b/build/registry/pkg/oci/oci.go
@@ -137,8 +137,8 @@ func latestVersionArtifact(ctx context.Context, ref string, ociClient remote.Cli
 	remoteTags, err := repo.Tags(ctx)
 	// Only way to know if the repo does not exist is to check the content of the error.
 	if err != nil && !strings.Contains(err.Error(), "unexpected status code 404") {
-		klog.Errorf("unable to get latest version from remote repository for %q: %v", ref, err)
-		return "", err
+		klog.Warningf("unable to get latest version from remote repository for %q: %v", ref, err)
+		return "", nil
 	}
 
 	// If no tags found it means that the artifact does not exist in the OCI registry or


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:


/area build


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Not all rulesfile that have a `rules_url` have an OCI repository for rules that is called `<plugin_name>-rules`. In that case, do not halt the build process but proceed and emit a warning instead.

I believe the proper fix for this would be to remove this job entirely and integrate it with release but we have more cleanups to do before we can do that. In the meantime, this should unblock the current release.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
