### PR TITLE
chore(plugins): bump versions for Falco 0.37.0

### DIFF
--- a/plugins/cloudtrail/pkg/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/pkg/cloudtrail/cloudtrail.go
@@ -48,7 +48,7 @@ const (
 	PluginName               = "cloudtrail"
 	PluginDescription        = "reads cloudtrail JSON data saved to file in the directory specified in the settings"
 	PluginContact            = "github.com/falcosecurity/plugins/"
-	PluginVersion            = "0.9.1"
+	PluginVersion            = "0.10.0"
 	PluginEventSource        = "aws_cloudtrail"
 )
 

--- a/plugins/cloudtrail/rules/aws_cloudtrail_rules.yaml
+++ b/plugins/cloudtrail/rules/aws_cloudtrail_rules.yaml
@@ -21,7 +21,7 @@
 
 - required_plugin_versions:
   - name: cloudtrail
-    version: 0.8.0
+    version: 0.10.0
   - name: json
     version: 0.7.0
 

--- a/plugins/dummy/pkg/dummy/dummy.go
+++ b/plugins/dummy/pkg/dummy/dummy.go
@@ -37,7 +37,7 @@ const (
 	PluginName               = "dummy"
 	PluginDescription        = "Reference plugin for educational purposes"
 	PluginContact            = "github.com/falcosecurity/plugins"
-	PluginVersion            = "0.10.0-rc1"
+	PluginVersion            = "0.10.0"
 	PluginEventSource        = "dummy"
 )
 

--- a/plugins/gcpaudit/pkg/gcpaudit/gcpaudit.go
+++ b/plugins/gcpaudit/pkg/gcpaudit/gcpaudit.go
@@ -30,7 +30,7 @@ const (
 	PluginName               = "gcpaudit"
 	PluginDescription        = "Read GCP Audit Logs"
 	PluginContact            = "github.com/falcosecurity/plugins"
-	PluginVersion            = "0.2.2"
+	PluginVersion            = "0.3.0"
 	PluginEventSource        = "gcp_auditlog"
 )
 

--- a/plugins/gcpaudit/rules/gcp_auditlog_rules.yaml
+++ b/plugins/gcpaudit/rules/gcp_auditlog_rules.yaml
@@ -20,7 +20,7 @@
 
 - required_plugin_versions:
   - name: gcpaudit
-    version: 0.2.0
+    version: 0.3.0
   - name: json
     version: 0.7.0
 

--- a/plugins/github/pkg/github/github.go
+++ b/plugins/github/pkg/github/github.go
@@ -39,7 +39,7 @@ const (
 	PluginName                = "github"
 	PluginDescription         = "Reads github webhook events, by listening on a socket or by reading events from disk"
 	PluginContact             = "github.com/falcosecurity/plugins"
-	PluginVersion             = "0.6.1"
+	PluginVersion             = "0.7.0"
 	PluginEventSource         = "github"
 	ExtractEventSource        = "github"
 )

--- a/plugins/github/rules/github.yaml
+++ b/plugins/github/rules/github.yaml
@@ -20,7 +20,7 @@
 
 - required_plugin_versions:
   - name: github
-    version: 0.6.0
+    version: 0.7.0
 
 - rule: Webhook Connected
   desc: Detect a webhook link

--- a/plugins/k8saudit-eks/pkg/k8sauditeks/k8sauditeks.go
+++ b/plugins/k8saudit-eks/pkg/k8sauditeks/k8sauditeks.go
@@ -63,7 +63,7 @@ func (k *Plugin) Info() *plugins.Info {
 		Name:        pluginName,
 		Description: "Read Kubernetes Audit Events for EKS from Cloudwatch Logs",
 		Contact:     "github.com/falcosecurity/plugins",
-		Version:     "0.3.0",
+		Version:     "0.4.0",
 		EventSource: "k8s_audit",
 	}
 }

--- a/plugins/k8saudit/pkg/k8saudit/k8saudit.go
+++ b/plugins/k8saudit/pkg/k8saudit/k8saudit.go
@@ -54,7 +54,7 @@ func (k *Plugin) Info() *plugins.Info {
 		Name:        pluginName,
 		Description: "Read Kubernetes Audit Events and monitor Kubernetes Clusters",
 		Contact:     "github.com/falcosecurity/plugins",
-		Version:     "0.6.1",
+		Version:     "0.7.0",
 		EventSource: "k8s_audit",
 	}
 }

--- a/plugins/k8saudit/rules/k8s_audit_rules.yaml
+++ b/plugins/k8saudit/rules/k8s_audit_rules.yaml
@@ -20,10 +20,10 @@
 
 - required_plugin_versions:
   - name: k8saudit
-    version: 0.6.0
+    version: 0.7.0
     alternatives:
       - name: k8saudit-eks
-        version: 0.2.0
+        version: 0.4.0
   - name: json
     version: 0.7.0
 

--- a/plugins/okta/rules/okta_rules.yaml
+++ b/plugins/okta/rules/okta_rules.yaml
@@ -20,7 +20,7 @@
 
 - required_plugin_versions:
   - name: okta
-    version: 0.8.0
+    version: 0.10.0
 
 # Example Rule on login in to OKTA. Disabled by default since it might be noisy
 #- rule: User logged in to OKTA


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

After #373 was merged every plugin with rules needs a version bump because OCI rules will not be able to be followed in Falco versions < 0.37.0 (to be released this month). This PR bumps every version. Specifically:
* k8saudit-0.7.0
* cloudtrail-0.10.0
* dummy-0.10.0
* github-0.7.0
* gcpaudit-0.3.0
* k8saudit-eks-0.4.0

This ensures we do not break existing downloads and follows for older Falco versions

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
