### PR TITLE
Registering Box plugin in registry.yaml

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -353,6 +353,26 @@ plugins:
         source: salesforce
       extraction:
         supported: true
+  - name: box
+    description: Falco plugin providing basic runtime threat detection and auditing logging for Box 
+    authors: Andy
+    contact: https://github.com/an1245/falco-plugin-box/issues
+    maintainers:
+      - name: Andy
+    keywords:
+      - audit
+      - log-events
+      - box
+    url: https://github.com/an1245/falco-plugin-box/
+    rules_url: https://github.com/an1245/falco-plugin-box/tree/main/rules
+    license: Apache-2.0
+    capabilities:
+      sourcing:
+        supported: true
+        id: 15
+        source: box
+      extraction:
+        supported: true
   - name: test
     description: This ID is reserved for source plugin development. Any plugin author can use this ID, but authors can expect events from other developers with this ID. After development is complete, the author should request an actual ID
     reserved: true


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

**What this PR does / why we need it**:
Falco plugin providing basic runtime threat detection and auditing logging for Box.  Because Falco can perform threat detection across a number of cloud platforms in parallel, it allows you to correlate security events across multiple sources in real-time, to detect active lateral movement as it is occurring.