### PR TITLE
fix(pkg/oci): trim spaces when handling required_engine_version

### DIFF
--- a/build/registry/go.mod
+++ b/build/registry/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.4 // indirect
 	github.com/aws/smithy-go v1.14.2 // indirect
 	github.com/containerd/console v1.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v24.0.5+incompatible // indirect
 	github.com/docker/docker v24.0.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.0 // indirect
@@ -57,6 +58,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc4 // indirect
 	github.com/oras-project/oras-credentials-go v0.3.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pterm/pterm v0.12.67 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
@@ -66,6 +68,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.16.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/build/registry/pkg/oci/requirements.go
+++ b/build/registry/pkg/oci/requirements.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/blang/semver"
@@ -67,15 +68,16 @@ func rulesfileRequirement(filePath string) (*oci.ArtifactRequirement, error) {
 	// In case the requirement was expressed as a numeric value,
 	// we convert it to semver and treat it as minor version.
 	tokens := strings.Split(fileScanner.Text(), ":")
-	reqVer, err := semver.Parse(tokens[1])
+	version := strings.TrimSpace(tokens[1])
+	reqVer, err := semver.Parse(version)
 	if err != nil {
-		reqVer, err = semver.ParseTolerant(tokens[1])
+		minor, err := strconv.ParseUint(version, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("unable to parse requirement %q: expected a numeric value or a valid semver string", tokens[1])
+			return nil, fmt.Errorf("unable to parse requirement %q: expected a numeric value or a valid semver string", version)
 		}
 		reqVer = semver.Version{
 			Major: 0,
-			Minor: reqVer.Major,
+			Minor: minor,
 			Patch: 0,
 		}
 	}

--- a/build/registry/pkg/oci/requirements_test.go
+++ b/build/registry/pkg/oci/requirements_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRulesfileRequirement(t *testing.T) {
+	req, err := rulesfileRequirement("testdata/rules-failed-req.yaml")
+	assert.Error(t, err)
+
+	req, err = rulesfileRequirement("testdata/rules-numeric-req.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "0.15.0", req.Version)
+	assert.Equal(t, "engine_version_semver", req.Name)
+
+	req, err = rulesfileRequirement("testdata/rules-semver-req.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "0.31.0", req.Version)
+	assert.Equal(t, "engine_version_semver", req.Name)
+}

--- a/build/registry/pkg/oci/testdata/rules-failed-req.yaml
+++ b/build/registry/pkg/oci/testdata/rules-failed-req.yaml
@@ -1,0 +1,1 @@
+- required_engine_version: test

--- a/build/registry/pkg/oci/testdata/rules-numeric-req.yaml
+++ b/build/registry/pkg/oci/testdata/rules-numeric-req.yaml
@@ -1,0 +1,1 @@
+- required_engine_version: 15

--- a/build/registry/pkg/oci/testdata/rules-semver-req.yaml
+++ b/build/registry/pkg/oci/testdata/rules-semver-req.yaml
@@ -1,0 +1,1 @@
+- required_engine_version: 0.31.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

> /area registry

/area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Properly trim spaces and parse the required engine version. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
