### PR TITLE
feat(cloudtrail): Add ct.response and ct.request field

### DIFF
--- a/plugins/cloudtrail/README.md
+++ b/plugins/cloudtrail/README.md
@@ -36,6 +36,7 @@ Here is the current set of supported fields:
 | `ct.region`                   | `string` | None | the region of the cloudtrail event (awsRegion in the json).                                                                                              |
 | `ct.response.subnetid`        | `string` | None | the subnet ID included in the response.                                                                                                                  |
 | `ct.response.reservationid`   | `string` | None | the reservation ID included in the response.                                                                                                             |
+| `ct.response`                 | `string` | None | All response elements.                                                                                                                                   |
 | `ct.request.availabilityzone` | `string` | None | the availability zone included in the request.                                                                                                           |
 | `ct.request.cluster`          | `string` | None | the cluster included in the request.                                                                                                                     |
 | `ct.request.functionname`     | `string` | None | the function name included in the request.                                                                                                               |
@@ -48,6 +49,7 @@ Here is the current set of supported fields:
 | `ct.request.subnetid`         | `string` | None | the subnet ID provided in the request.                                                                                                                   |
 | `ct.request.taskdefinition`   | `string` | None | the task definition prrovided in the request.                                                                                                            |
 | `ct.request.username`         | `string` | None | the username provided in the request.                                                                                                                    |
+| `ct.request`                  | `string` | None | All request parameters.                                                                                                                                  |
 | `ct.srcip`                    | `string` | None | the IP address generating the event (sourceIPAddress in the json).                                                                                       |
 | `ct.useragent`                | `string` | None | the user agent generating the event (userAgent in the json).                                                                                             |
 | `ct.info`                     | `string` | None | summary information about the event. This varies depending on the event type and, for some events, it contains event-specific details.                   |

--- a/plugins/cloudtrail/pkg/cloudtrail/extract.go
+++ b/plugins/cloudtrail/pkg/cloudtrail/extract.go
@@ -46,6 +46,7 @@ var supportedFields = []sdk.FieldEntry{
 	{Type: "string", Name: "ct.region", Display: "Region", Desc: "the region of the cloudtrail event (awsRegion in the json)."},
 	{Type: "string", Name: "ct.response.subnetid", Display: "Response Subnet ID", Desc: "the subnet ID included in the response."},
 	{Type: "string", Name: "ct.response.reservationid", Display: "Response Reservation ID", Desc: "the reservation ID included in the response."},
+	{Type: "string", Name: "ct.response", Display: "Response Elements", Desc: "All response elements."},
 	{Type: "string", Name: "ct.request.availabilityzone", Display: "Request Availability Zone", Desc: "the availability zone included in the request."},
 	{Type: "string", Name: "ct.request.cluster", Display: "Request Cluster", Desc: "the cluster included in the request."},
 	{Type: "string", Name: "ct.request.functionname", Display: "Request Function Name", Desc: "the function name included in the request."},
@@ -58,6 +59,7 @@ var supportedFields = []sdk.FieldEntry{
 	{Type: "string", Name: "ct.request.subnetid", Display: "Request Subnet ID", Desc: "the subnet ID provided in the request."},
 	{Type: "string", Name: "ct.request.taskdefinition", Display: "Request Task Definition", Desc: "the task definition prrovided in the request."},
 	{Type: "string", Name: "ct.request.username", Display: "Request User Name", Desc: "the username provided in the request."},
+	{Type: "string", Name: "ct.request", Display: "Request Parameters", Desc: "All request parameters."},
 	{Type: "string", Name: "ct.srcip", Display: "Source IP", Desc: "the IP address generating the event (sourceIPAddress in the json).", Properties: []string{"conversation"}},
 	{Type: "string", Name: "ct.useragent", Display: "User Agent", Desc: "the user agent generating the event (userAgent in the json)."},
 	{Type: "string", Name: "ct.info", Display: "Info", Desc: "summary information about the event. This varies depending on the event type and, for some events, it contains event-specific details.", Properties: []string{"info"}},
@@ -347,6 +349,13 @@ func getfieldStr(jdata *fastjson.Value, field string) (bool, string) {
 		} else {
 			res = string(val)
 		}
+	case "ct.response":
+		val := jdata.Get("responseElements")
+		if val == nil {
+			return false, ""
+		} else {
+			res = string(val.MarshalTo(nil))
+		}
 	case "ct.request.availabilityzone":
 		val := jdata.GetStringBytes("requestParameters", "availabilityZone")
 		if val == nil {
@@ -430,6 +439,13 @@ func getfieldStr(jdata *fastjson.Value, field string) (bool, string) {
 			return false, ""
 		} else {
 			res = string(val)
+		}
+	case "ct.request":
+		val := jdata.Get("requestParameters")
+		if val == nil {
+			return false, ""
+		} else {
+			res = string(val.MarshalTo(nil))
 		}
 	case "ct.srcip":
 		val := jdata.GetStringBytes("sourceIPAddress")


### PR DESCRIPTION
Adding CloudTrail fields `requestParameters` as `ct.request` and `responseElements` as `ct.response`.

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

There are too many parameters/elements in `requestParameters`/`responseElements` for all the different API calls to have a dedicated field for every one. Nevertheless, I want to be able to filter or search for the content of these fields in Logray.

This commit provides the entire content of the two fields.

Maybe we can have a 'Custom CloudTrail requestParameters fields' option in Logray (like we have it for 'Custom HTTP Header Fields') in the future. But this needs to be discussed in a separate issue in the Wireshark project.