### PR TITLE
fix(plugins/k8saudit/rules): split rbac rules by individual rbac object

### DIFF
--- a/plugins/k8saudit/CHANGELOG.md
+++ b/plugins/k8saudit/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.9.0
+
+* [`029593e`](https://github.com/falcosecurity/plugins/commit/029593e) fix(plugins/k8saudit/rules): split rbac rules by individual rbac object
+
+
+## v0.8.0
+
+* [`24e9f22`](https://github.com/falcosecurity/plugins/commit/24e9f22) update(plugins/k8s_audit): rename more falco_ lists
+
+* [`0879a81`](https://github.com/falcosecurity/plugins/commit/0879a81) update(plugins/k8s_audit): k8s_* -> k8s_audit_*
+
+* [`2c4a275`](https://github.com/falcosecurity/plugins/commit/2c4a275) cleanup(plugins/k8s_audit): make the rulesefile self-referenced
+
+* [`ef07168`](https://github.com/falcosecurity/plugins/commit/ef07168) chore(k8saudit): add k8saudit-gke as plugin alternative
+
+* [`0c21c8a`](https://github.com/falcosecurity/plugins/commit/0c21c8a) update(k8saudit/docs): add k8s configuration files
+
+
+## v0.7.0
+
+* [`028fa19`](https://github.com/falcosecurity/plugins/commit/028fa19) feat(plugins/k8saudit/rules) add detection for portforwarding
+
+
 ## v0.6.1
 
 

--- a/plugins/k8saudit/pkg/k8saudit/k8saudit.go
+++ b/plugins/k8saudit/pkg/k8saudit/k8saudit.go
@@ -54,7 +54,7 @@ func (k *Plugin) Info() *plugins.Info {
 		Name:        pluginName,
 		Description: "Read Kubernetes Audit Events and monitor Kubernetes Clusters",
 		Contact:     "github.com/falcosecurity/plugins",
-		Version:     "0.8.0",
+		Version:     "0.9.0",
 		EventSource: "k8s_audit",
 	}
 }

--- a/plugins/k8saudit/rules/k8s_audit_rules.yaml
+++ b/plugins/k8saudit/rules/k8s_audit_rules.yaml
@@ -182,6 +182,9 @@
 - macro: role
   condition: ka.target.resource=roles
 
+- macro: rolebinding
+  condition: ka.target.resource=rolebindings
+
 - macro: secret
   condition: ka.target.resource=secrets
 
@@ -603,34 +606,66 @@
   source: k8s_audit
   tags: [k8s]
 
-- rule: K8s Role/Clusterrole Created
-  desc: Detect any attempt to create a cluster role/role
-  condition: (kactivity and kcreate and (clusterrole or role) and response_successful)
-  output: K8s Cluster Role Created (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource rules=%ka.req.role.rules resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
+- rule: K8s Role Created
+  desc: Detect any attempt to create a role
+  condition: (kactivity and kcreate and role and response_successful)
+  output: K8s Role Created (user=%ka.user.name role=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource rules=%ka.req.role.rules resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
   tags: [k8s]
 
-- rule: K8s Role/Clusterrole Deleted
-  desc: Detect any attempt to delete a cluster role/role
-  condition: (kactivity and kdelete and (clusterrole or role) and response_successful)
-  output: K8s Cluster Role Deleted (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
+- rule: K8s Role Deleted
+  desc: Detect any attempt to delete a role
+  condition: (kactivity and kdelete and role and response_successful)
+  output: K8s Role Deleted (user=%ka.user.name role=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
   tags: [k8s]
 
-- rule: K8s Role/Clusterrolebinding Created
+- rule: K8s ClusterRole Created
+  desc: Detect any attempt to create a cluster role
+  condition: (kactivity and kcreate and clusterrole and response_successful)
+  output: K8s ClusterRole Created (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource rules=%ka.req.role.rules resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
+  priority: INFO
+  source: k8s_audit
+  tags: [k8s]
+
+- rule: K8s ClusterRole Deleted
+  desc: Detect any attempt to delete a cluster role
+  condition: (kactivity and kdelete and clusterrole and response_successful)
+  output: K8s ClusterRole Deleted (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
+  priority: INFO
+  source: k8s_audit
+  tags: [k8s]
+
+- rule: K8s RoleBinding Created
+  desc: Detect any attempt to create a rolebinding
+  condition: (kactivity and kcreate and rolebinding and response_successful)
+  output: K8s RoleBinding Created (user=%ka.user.name binding=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource subjects=%ka.req.binding.subjects role=%ka.req.binding.role resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
+  priority: INFO
+  source: k8s_audit
+  tags: [k8s]
+
+- rule: K8s RoleBinding Deleted
+  desc: Detect any attempt to delete a rolebinding
+  condition: (kactivity and kdelete and rolebinding and response_successful)
+  output: K8s RoleBinding Deleted (user=%ka.user.name binding=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
+  priority: INFO
+  source: k8s_audit
+  tags: [k8s]
+
+- rule: K8s ClusterRoleBinding Created
   desc: Detect any attempt to create a clusterrolebinding
   condition: (kactivity and kcreate and clusterrolebinding and response_successful)
-  output: K8s Cluster Role Binding Created (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource subjects=%ka.req.binding.subjects role=%ka.req.binding.role resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
+  output: K8s ClusterRoleBinding Created (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource subjects=%ka.req.binding.subjects role=%ka.req.binding.role resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
   tags: [k8s]
 
-- rule: K8s Role/Clusterrolebinding Deleted
+- rule: K8s ClusterRoleBinding Deleted
   desc: Detect any attempt to delete a clusterrolebinding
   condition: (kactivity and kdelete and clusterrolebinding and response_successful)
-  output: K8s Cluster Role Binding Deleted (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
+  output: K8s ClusterRoleBinding Deleted (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
   priority: INFO
   source: k8s_audit
   tags: [k8s]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
k8saudit ruleset is only detecting create/delete events for `ClusterRoleBinding` objects. As the rules do detect the create/delete events for `Role` objects, it makes sense to detect create/delete events for `RoleBinding` objects as well.

As `Role` and `RoleBinding` are namespace scoped objects, I did split the rules out for each individual rbac object to include the namespace field into the output. As well as to make it easier to see the difference between cluster wide and namespace scoped objects by rule name, instead of having to parse out the 'resources' field.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #319 

**Special notes for your reviewer**:
