### PR TITLE
chore(plugins): bump versions

### DIFF
--- a/plugins/cloudtrail/pkg/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/pkg/cloudtrail/cloudtrail.go
@@ -48,7 +48,7 @@ const (
 	PluginName               = "cloudtrail"
 	PluginDescription        = "reads cloudtrail JSON data saved to file in the directory specified in the settings"
 	PluginContact            = "github.com/falcosecurity/plugins/"
-	PluginVersion            = "0.12.1"
+	PluginVersion            = "0.12.2"
 	PluginEventSource        = "aws_cloudtrail"
 )
 

--- a/plugins/dummy/pkg/dummy/dummy.go
+++ b/plugins/dummy/pkg/dummy/dummy.go
@@ -37,7 +37,7 @@ const (
 	PluginName               = "dummy"
 	PluginDescription        = "Reference plugin for educational purposes"
 	PluginContact            = "github.com/falcosecurity/plugins"
-	PluginVersion            = "0.11.2"
+	PluginVersion            = "0.11.3"
 	PluginEventSource        = "dummy"
 )
 

--- a/plugins/gcpaudit/pkg/gcpaudit/gcpaudit.go
+++ b/plugins/gcpaudit/pkg/gcpaudit/gcpaudit.go
@@ -30,7 +30,7 @@ const (
 	PluginName               = "gcpaudit"
 	PluginDescription        = "Read GCP Audit Logs"
 	PluginContact            = "github.com/falcosecurity/plugins"
-	PluginVersion            = "0.3.2"
+	PluginVersion            = "0.3.3"
 	PluginEventSource        = "gcp_auditlog"
 )
 

--- a/plugins/github/pkg/github/github.go
+++ b/plugins/github/pkg/github/github.go
@@ -39,7 +39,7 @@ const (
 	PluginName                = "github"
 	PluginDescription         = "Reads github webhook events, by listening on a socket or by reading events from disk"
 	PluginContact             = "github.com/falcosecurity/plugins"
-	PluginVersion             = "0.7.3"
+	PluginVersion             = "0.7.4"
 	PluginEventSource         = "github"
 	ExtractEventSource        = "github"
 )

--- a/plugins/k8saudit/pkg/k8saudit/k8saudit.go
+++ b/plugins/k8saudit/pkg/k8saudit/k8saudit.go
@@ -54,7 +54,7 @@ func (k *Plugin) Info() *plugins.Info {
 		Name:        pluginName,
 		Description: "Read Kubernetes Audit Events and monitor Kubernetes Clusters",
 		Contact:     "github.com/falcosecurity/plugins",
-		Version:     "0.10.0-rc1",
+		Version:     "0.10.0",
 		EventSource: "k8s_audit",
 	}
 }

--- a/plugins/kafka/pkg/kafka/kafka.go
+++ b/plugins/kafka/pkg/kafka/kafka.go
@@ -5,13 +5,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"os"
+	"time"
+
 	"github.com/alecthomas/jsonschema"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins/source"
 	"github.com/segmentio/kafka-go"
-	"os"
-	"time"
 )
 
 const (
@@ -19,7 +20,7 @@ const (
 	PluginName               = "kafka"
 	PluginDescription        = "Read events from Kafka topics into Falco"
 	PluginContact            = "github.com/falcosecurity/plugins"
-	PluginVersion            = "0.1.0"
+	PluginVersion            = "0.1.1"
 	PluginEventSource        = "kafka"
 )
 


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

As per title. Some plugins have recently been released with a GLIBC version too high, leading to issues like

```
can't load plugin dynamic library: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/share/falco/plugins/libk8saudit.so)
```

The CI has been updated to fix it and now a release is required.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
