### PR TITLE
fix(k8smeta): introduce /proc scan to recover the pod uid of threads already spawned

### DIFF
--- a/plugins/k8smeta/README.md
+++ b/plugins/k8smeta/README.md
@@ -77,7 +77,7 @@ plugins:
       # name of the node on which the Falco instance is running. (required)
       nodeName: kind-control-plane
       # verbosity level for the plugin logger (optional)
-      verbosity: warn # (default: info)
+      verbosity: warning # (default: info)
       # path to the PEM encoding of the server root certificates. (optional)
       # Used to open an authanticated GRPC channel with the collector.
       # If empty the connection will be insecure.

--- a/plugins/k8smeta/README.md
+++ b/plugins/k8smeta/README.md
@@ -70,18 +70,23 @@ plugins:
     # path to the plugin .so file
     library_path: libk8smeta.so
     init_config:
-      # port exposed by the k8s-metacollector (required)
-      collectorPort: 45000
-      # hostname exposed by the k8s-metacollector (required)
-      collectorHostname: localhost
-      # name of the node on which the Falco instance is running. (required)
-      nodeName: kind-control-plane
-      # verbosity level for the plugin logger (optional)
-      verbosity: warning # (default: info)
-      # path to the PEM encoding of the server root certificates. (optional)
+      # port exposed by the k8s-metacollector
+      collectorPort: 45000 # (required)
+      # hostname exposed by the k8s-metacollector
+      collectorHostname: localhost # (required)
+      # name of the node on which the Falco instance is running.
+      nodeName: kind-control-plane # (required)
+      # verbosity level for the plugin logger
+      verbosity: warning # (optional, default: info)
+      # path to the PEM encoding of the server root certificates.
       # Used to open an authanticated GRPC channel with the collector.
       # If empty the connection will be insecure.
-      caPEMBundle: /etc/ssl/certs/ca-certificates.crt 
+      caPEMBundle: /etc/ssl/certs/ca-certificates.crt # (optional)
+      # The plugin needs to scan the '/proc' of the host on which is running.
+      # In Falco usually we put the host '/proc' folder under '/host/proc' so
+      # the the default for this config is '/host'.
+      # The path used here must not have a final '/'.
+      hostProc: /host  # (optional, default: /host)
 
 load_plugins: [k8smeta]
 ```

--- a/plugins/k8smeta/falco.yaml
+++ b/plugins/k8smeta/falco.yaml
@@ -11,6 +11,7 @@ plugins:
       collectorHostname: localhost
       nodeName: kind-control-plane
       verbosity: critical
+      hostProc: /host
 
 stdout_output:
   enabled: true

--- a/plugins/k8smeta/src/grpc_client.cpp
+++ b/plugins/k8smeta/src/grpc_client.cpp
@@ -45,7 +45,7 @@ K8sMetaClient::K8sMetaClient(const std::string& node_name,
     sel.set_nodename(node_name);
     sel.clear_resourcekinds();
 
-    /// todo! one day we could expose them to the user.
+    /// todo!: one day we could expose them to the user.
     (*sel.mutable_resourcekinds())["Pod"] = "true";
     (*sel.mutable_resourcekinds())["Namespace"] = "true";
     (*sel.mutable_resourcekinds())["Deployment"] = "true";

--- a/plugins/k8smeta/src/plugin.h
+++ b/plugins/k8smeta/src/plugin.h
@@ -126,6 +126,8 @@ class my_plugin
 
     bool init(falcosecurity::init_input& in);
 
+    void do_initial_proc_scan();
+
     //////////////////////////
     // Async capability
     //////////////////////////
@@ -235,7 +237,8 @@ class my_plugin
 
     bool inline parse_async_event(const falcosecurity::parse_event_input& in);
 
-    bool inline extract_pod_uid(const falcosecurity::parse_event_input& in);
+    bool inline parse_process_events(
+            const falcosecurity::parse_event_input& in);
 
     bool parse_event(const falcosecurity::parse_event_input& in);
 
@@ -251,6 +254,8 @@ class my_plugin
     std::string m_collector_port;
     std::string m_node_name;
     std::string m_ca_PEM_encoding;
+    // todo!: populate it when parsing the config.
+    std::string m_host_proc;
 
     // State tables
     std::unordered_map<std::string, resource_layout> m_pod_table;
@@ -261,6 +266,7 @@ class my_plugin
     std::unordered_map<std::string, resource_layout>
             m_replication_controller_table;
     std::unordered_map<std::string, resource_layout> m_deamonset_table;
+    std::unordered_map<int64_t, std::string> m_thread_id_pod_uid_map;
 
     // Last error of the plugin
     std::string m_lasterr;

--- a/plugins/k8smeta/src/plugin.h
+++ b/plugins/k8smeta/src/plugin.h
@@ -254,7 +254,6 @@ class my_plugin
     std::string m_collector_port;
     std::string m_node_name;
     std::string m_ca_PEM_encoding;
-    // todo!: populate it when parsing the config.
     std::string m_host_proc;
 
     // State tables
@@ -268,6 +267,9 @@ class my_plugin
     std::unordered_map<std::string, resource_layout> m_deamonset_table;
     std::unordered_map<int64_t, std::string> m_thread_id_pod_uid_map;
 
+    // The first time we parse an event we populate the sinsp thread table and
+    // we set it to true
+    bool m_sinsp_proc_populated = false;
     // Last error of the plugin
     std::string m_lasterr;
     // Accessor to the thread table

--- a/plugins/k8smeta/src/shared_with_tests_consts.h
+++ b/plugins/k8smeta/src/shared_with_tests_consts.h
@@ -77,7 +77,7 @@ limitations under the License.
 // Generic plugin consts
 /////////////////////////
 #define PLUGIN_NAME "k8smeta"
-#define PLUGIN_VERSION "0.1.0"
+#define PLUGIN_VERSION "0.1.1"
 #define PLUGIN_DESCRIPTION                                                     \
     "Enrich syscall events with information about the pod that throws them"
 #define PLUGIN_CONTACT "github.com/falcosecurity/plugins"
@@ -99,3 +99,4 @@ limitations under the License.
 #define PORT_PATH "/collectorPort"
 #define NODENAME_PATH "/nodeName"
 #define CA_CERT_PATH "/caPEMBundle"
+#define HOST_PROC_PATH "/hostProc"

--- a/plugins/k8smeta/test/README.md
+++ b/plugins/k8smeta/test/README.md
@@ -20,5 +20,5 @@ To run only some tests you need to use the test binary directly
 
 ```bash
 # from the `build` directory
-sudo ./libs_tests/libsinsp/test/unit-test-libsinsp --gtest_filter='*plugin_k8s_PPME_SYSCALL_CLONE3_X_parse'
+./libs_tests/libsinsp/test/unit-test-libsinsp --gtest_filter='*plugin_k8s_PPME_SYSCALL_CLONE3_X_parse'
 ```

--- a/plugins/k8smeta/test/README.md
+++ b/plugins/k8smeta/test/README.md
@@ -15,3 +15,10 @@ make build-tests
 # run tests against the test server
 make run-tests
 ```
+
+To run only some tests you need to use the test binary directly
+
+```bash
+# from the `build` directory
+sudo ./libs_tests/libsinsp/test/unit-test-libsinsp --gtest_filter='*plugin_k8s_PPME_SYSCALL_CLONE3_X_parse'
+```

--- a/plugins/k8smeta/test/include/k8smeta_tests/helpers.h
+++ b/plugins/k8smeta/test/include/k8smeta_tests/helpers.h
@@ -21,7 +21,7 @@ limitations under the License.
 #define INIT_CONFIG                                                            \
     "{\"collectorHostname\":\"localhost\",\"collectorPort\": "                 \
     "45000,\"nodeName\":\"control-plane\",\"verbosity\":"                      \
-    "\"info\"}"
+    "\"info\", \"hostProc\":\"\"}"
 
 #define ASSERT_STRING_SETS(a, b)                                               \
     {                                                                          \

--- a/plugins/k8smeta/test/src/check_events.cpp
+++ b/plugins/k8smeta/test/src/check_events.cpp
@@ -674,15 +674,3 @@ TEST_F(sinsp_with_test_input, plugin_k8s_update_a_pod)
               "10.16.1.20");
     m_inspector.close();
 }
-
-////////////////////////////////////
-// Missing tests
-//////////////////////////////////
-
-/// todo! Add some tests
-
-// add a test on a resource without the `/labels` key.
-
-// Check on a scap file
-
-// Read a scap-file/huge json file and evaluate perf

--- a/plugins/k8smeta/test/src/init_config.cpp
+++ b/plugins/k8smeta/test/src/init_config.cpp
@@ -92,3 +92,15 @@ TEST_F(sinsp_with_test_input, plugin_k8s_env_variable)
                                        err));
     ASSERT_EQ(err, "");
 }
+
+TEST_F(sinsp_with_test_input, plugin_k8s_with_host_proc)
+{
+    auto plugin_owner = m_inspector.register_plugin(PLUGIN_PATH);
+    ASSERT_TRUE(plugin_owner.get());
+    std::string err;
+
+    ASSERT_NO_THROW(plugin_owner->init(R"(
+{"collectorHostname":"localhost","collectorPort":45000,"nodeName":"kind-control-plane", "hostProc": "/host"})",
+                                       err));
+    ASSERT_EQ(err, "");
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind feature


**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

This PR introduces a proc-scan feature in the k8smeta plugin init phase. We need this to collect the pod uid of threads already running when Falco and the k8smeta plugin are started. 

**Which issue(s) this PR fixes**:

Fixes #https://github.com/falcosecurity/plugins/issues/514

**Special notes for your reviewer**:
