### PR TITLE
fix(proc/scan): scan all existing threads

### DIFF
--- a/plugins/k8smeta/src/plugin.cpp
+++ b/plugins/k8smeta/src/plugin.cpp
@@ -302,42 +302,65 @@ void my_plugin::do_initial_proc_scan()
             continue;
         }
 
-        // Example of the path: `/proc/1/cgroup`
-        proc_path = std::string(proc_root)
-                            .append("/")
-                            .append(file_name.c_str())
-                            .append("/cgroup");
+        // Now scan /proc/pid/task for threads
+        std::string task_dir = proc_root + "/" + file_name.c_str() + "/task";
+        std::filesystem::directory_iterator task_iter(task_dir);
 
-        std::ifstream file(proc_path);
-
-        if(file.is_open())
+        for(const auto& task_entry : task_iter)
         {
-            // Read the first line from the file
-            if(std::getline(file, cgroup_line))
+            auto task_file_name = task_entry.path().filename();
+            tid = strtol(task_file_name.c_str(), NULL, 10);
+
+            if(tid == 0 || !task_entry.is_directory())
             {
-                std::string pod_uid =
-                        get_pod_uid_from_cgroup_string(cgroup_line);
-                if(!pod_uid.empty())
-                {
-                    m_thread_id_pod_uid_map[tid] = pod_uid;
-                    SPDLOG_TRACE("Found thread with tid '{}' and pod uid '{}'",
-                                 tid, pod_uid);
-                }
+                SPDLOG_WARN("Found task entry `{}` in process `{}` that is not "
+                            "a number",
+                            task_file_name.c_str(), file_name.c_str());
+                continue; // skip if not a thread id directory
             }
-            else
+            // Example of the path: `/proc/1/task/200/cgroup`
+            proc_path = std::string(proc_root)
+                                .append("/")
+                                .append(file_name.c_str())
+                                .append("/task/")
+                                .append(task_file_name.c_str())
+                                .append("/cgroup");
+
+            std::ifstream file(proc_path);
+
+            if(file.is_open())
             {
-                SPDLOG_WARN("cannot retrieve the cgroup first line for '{}'. "
+                // Read the first line from the file
+                if(std::getline(file, cgroup_line))
+                {
+                    std::string pod_uid =
+                            get_pod_uid_from_cgroup_string(cgroup_line);
+                    if(!pod_uid.empty())
+                    {
+                        m_thread_id_pod_uid_map[tid] = pod_uid;
+                        SPDLOG_TRACE(
+                                "Found thread with tid '{}' and pod uid '{}'",
+                                tid, pod_uid);
+                    }
+                }
+                else
+                {
+                    SPDLOG_WARN(
+                            "Cannot retrieve the cgroup first line for '{}'. "
                             "Error: {}. Skip it",
                             proc_path,
                             file.eof() ? "Empty file" : strerror(errno));
+                }
+                file.close();
             }
-            file.close();
+            else
+            {
+                SPDLOG_WARN("Cannot open '{}'. Error: {}. Skip it.", proc_path,
+                            strerror(errno));
+            }
         }
-        else
-        {
-            SPDLOG_WARN("cannot open '{}'. Error: {}. Skip it.", proc_path,
-                        strerror(errno));
-        }
+        SPDLOG_DEBUG("Thread scan correctly completed for process `{}`",
+                     file_name.c_str());
     }
     SPDLOG_INFO(
             "Process scan correctly completed. Found '{}' threads inside pods.",

--- a/plugins/k8smeta/test/src/parsing_pod.cpp
+++ b/plugins/k8smeta/test/src/parsing_pod.cpp
@@ -424,7 +424,8 @@ TEST_F(sinsp_with_test_input, plugin_k8s_proc_scan_in_the_plugin)
 
 #define PLUGIN_PROC_SCAN_UNDER_TMP_PROC                                        \
     int32_t mock_tid = (1 << 16) - 1;                                          \
-    std::string mock_proc_dir = "/tmp/proc/" + std::to_string(mock_tid);       \
+    std::string mock_proc_dir = "/tmp/proc/" + std::to_string(mock_tid) +      \
+                                "/task/" + std::to_string(mock_tid);           \
     std::string mock_proc_cgroup = mock_proc_dir + "/cgroup";                  \
     std::string expected_pod_uid = "1d34c7bb-7d94-4f00-bed9-fe4eca61d446";     \
                                                                                \
@@ -467,7 +468,7 @@ TEST_F(sinsp_with_test_input, plugin_k8s_proc_scan_in_the_plugin)
     pl_flist.add_filter_check(sinsp_plugin::new_filtercheck(plugin_owner));    \
                                                                                \
     std::filesystem::path mock_proc = std::filesystem::path("/tmp/proc");      \
-    ASSERT_EQ(std::filesystem::remove_all(mock_proc), 3);
+    ASSERT_EQ(std::filesystem::remove_all(mock_proc), 5);
 
 TEST_F(sinsp_with_test_input, plugin_k8s_proc_scan_mismatch)
 {


### PR DESCRIPTION
By scanning only /proc we missed the threads of a given process. It scans all threads under a given process in /proc/pid/task.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

 /area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

By scanning only /proc we missed the threads of a given process.
It scans all threads under a given process in /proc/pid/task.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
