### PR TITLE
Expose gcp.resourceLabels field in the gcp plugin

### DIFF
--- a/plugins/gcpaudit/README.md
+++ b/plugins/gcpaudit/README.md
@@ -111,6 +111,7 @@ For more details about what Cloud logging log queries, see the [GCP official doc
 | `gcp.projectId`               | `string` | None | GCP project ID                                  |
 | `gcp.resourceName`            | `string` | None | GCP resource name                               |
 | `gcp.resourceType`            | `string` | None | GCP resource type                               |
+| `gcp.resourceLabels`          | `string` | None | GCP resource labels                             |
 | `gcp.storage.bucket`          | `string` | None | GCP bucket name                                 |
 <!-- /README-PLUGIN-FIELDS -->
 

--- a/plugins/gcpaudit/pkg/gcpaudit/extract.go
+++ b/plugins/gcpaudit/pkg/gcpaudit/extract.go
@@ -48,6 +48,7 @@ func (p *Plugin) Fields() []sdk.FieldEntry {
 		{Type: "string", Name: "gcp.projectId", Display: "Project ID", Desc: "GCP project ID"},
 		{Type: "string", Name: "gcp.resourceName", Display: "Resource Name", Desc: "GCP resource name"},
 		{Type: "string", Name: "gcp.resourceType", Display: "Resource Type", Desc: "GCP resource type"},
+		{Type: "string", Name: "gcp.resourceLabels", Display: "Resource Labels", Desc: "GCP resource labels"},
 		{Type: "string", Name: "gcp.storage.bucket", Display: "Bucket Name", Desc: "GCP bucket name"},
 	}
 }
@@ -223,6 +224,12 @@ func (p *Plugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
 		resourceType := p.jdata.Get("resource").GetStringBytes("type")
 		if resourceType != nil {
 			req.SetValue(string(resourceType))
+		}
+
+	case "gcp.resourceLabels":
+		resourceLabels := p.jdata.Get("resource").Get("labels").MarshalTo(nil)
+		if resourceLabels != nil && len(resourceLabels) > 0 {
+			req.SetValue(string(resourceLabels))
 		}
 
 	case "gcp.storage.bucket":

--- a/plugins/gcpaudit/pkg/gcpaudit/gcpaudit.go
+++ b/plugins/gcpaudit/pkg/gcpaudit/gcpaudit.go
@@ -30,7 +30,7 @@ const (
 	PluginName               = "gcpaudit"
 	PluginDescription        = "Read GCP Audit Logs"
 	PluginContact            = "github.com/falcosecurity/plugins"
-	PluginVersion            = "0.4.0"
+	PluginVersion            = "0.5.0"
 	PluginEventSource        = "gcp_auditlog"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**
/area plugins

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
On the GCP Plugin we already expose the resource type via the `gcp.resourceType` field. Given that the log-entry also supports a `labels` field which can contains useful information for correctly identifying a resource on GCP, we want to expose that using a new `gcp.resourceLabels` field.
This field will contain the JSON representation of the labels attached on the [cloud log entry.](https://cloud.google.com/logging/docs/reference/v2/rest/v2/MonitoredResource)


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
