### PR TITLE
fix the rule to detect the exec in EKS

### DIFF
--- a/plugins/k8saudit/rules/k8s_audit_rules.yaml
+++ b/plugins/k8saudit/rules/k8s_audit_rules.yaml
@@ -335,7 +335,7 @@
 - rule: Attach/Exec Pod
   desc: >
     Detect any attempt to attach/exec to a pod
-  condition: kevt_started and pod_subresource and kcreate and ka.target.subresource in (exec,attach) and not user_known_exec_pod_activities
+  condition: kevt_started and pod_subresource and (kcreate or kget) and ka.target.subresource in (exec,attach) and not user_known_exec_pod_activities
   output: Attach/Exec to pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace action=%ka.target.subresource command=%ka.uri.param[command])
   priority: NOTICE
   source: k8s_audit


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

I discovered the `exec` in pod in EKS are not firing alert with the current rules for `k8s_audit` sources.

It comes from the `verb` which is not correct in the current rule. The condition expects `ka.verb = create` but for EKS it's `get`. The issue might be there for other managed cluster.

Here's an example of audit log from EKS for example:

```json
{
    "kind": "Event",
    "apiVersion": "audit.k8s.io/v1",
    "level": "Request",
    "auditID": "00c8decc-b988-4086-908b-fe8ec37b9380",
    "stage": "ResponseStarted",
    "requestURI": "/api/v1/namespaces/default/pods/cncf-76b565c64f-wpq4z/exec?command=sh&command=-c&command=command+-v+bash+%3E%2Fdev%2Fnull+%26%26+exec+bash+%7C%7C+exec+sh&container=cncf&stdin=true&stdout=true&tty=true",
    "verb": "get",
    "user": {
        "username": "kubernetes-admin",
        "uid": "aws-iam-authenticator:XXXXXX",
        "groups": [
            "system:masters",
            "system:authenticated"
        ],
        "extra": {}
    },
    "sourceIPs": [
        "X.X.X.X"
    ],
    "userAgent": "kubectl1.30.3/v1.30.3 (linux/amd64) kubernetes/6fc0a69",
    "objectRef": {
        "resource": "pods",
        "namespace": "default",
        "name": "cncf-76b565c64f-wpq4z",
        "apiVersion": "v1",
        "subresource": "exec"
    },
    "responseStatus": {
        "metadata": {},
        "code": 101
    },
    "requestReceivedTimestamp": "2025-01-17T17:13:06.287434Z",
    "stageTimestamp": "2025-01-17T17:13:06.296372Z",
    "annotations": {
        "authorization.k8s.io/decision": "allow",
        "authorization.k8s.io/reason": ""
    }
}
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
