### PR TITLE
new(plugins/k8smeta): update k8smeta plugin to require plugin API version 3.9.0.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,8 @@ jobs:
     uses: ./.github/workflows/reusable_validate_plugins.yaml
     with:
       plugin: ${{ matrix.plugin }}
-      falcoctl-version: 0.10.0
-      falco-image: falcosecurity/falco-no-driver:0.38.2
+      falcoctl-version: 0.11.0
+      falco-image: falcosecurity/falco:0.40.0
       plugins-artifact: plugins-x86_64-${{ github.event.number }}.tar.gz
       rules-checker: ./rules-checker
       arch: x86_64
@@ -55,7 +55,7 @@ jobs:
     uses: ./.github/workflows/reusable_suggest_rules_version.yaml
     with:
       plugin: ${{ matrix.plugin }}
-      falco-image: falcosecurity/falco-no-driver:0.38.2
+      falco-image: falcosecurity/falco:0.40.0
       plugins-artifact: plugins-x86_64-${{ github.event.number }}.tar.gz
       rules-checker: ./rules-checker
       arch: x86_64

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,8 +39,8 @@ jobs:
     uses: ./.github/workflows/reusable_validate_plugins.yaml
     with:
       plugin: ${{ matrix.plugin }}
-      falcoctl-version: 0.10.0
-      falco-image: falcosecurity/falco-no-driver:0.38.2
+      falcoctl-version: 0.11.0
+      falco-image: falcosecurity/falco:0.40.0
       plugins-artifact: plugins-x86_64-dev.tar.gz
       rules-checker: ./rules-checker
       arch: x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
     uses: ./.github/workflows/reusable_validate_plugins.yaml
     with:
       plugin: ${{ needs.extract-info.outputs.package }}
-      falcoctl-version: 0.10.0
-      falco-image: falcosecurity/falco-no-driver:0.38.2
+      falcoctl-version: 0.11.0
+      falco-image: falcosecurity/falco:0.40.0
       plugins-artifact: plugins-x86_64-stable.tar.gz
       rules-checker: ./rules-checker
       arch: x86_64

--- a/plugins/k8smeta/README.md
+++ b/plugins/k8smeta/README.md
@@ -14,11 +14,12 @@ The plugin gathers details about Kubernetes resources from a remote collector kn
 
 ## Capabilities
 
-The `k8smeta` plugin implements 3 capabilities:
+The `k8smeta` plugin implements 4 capabilities:
 
 * `extraction`
 * `parsing`
 * `async`
+* `capture listening`
 
 ### Plugin official name
 
@@ -82,7 +83,7 @@ plugins:
       # Used to open an authanticated GRPC channel with the collector.
       # If empty the connection will be insecure.
       caPEMBundle: /etc/ssl/certs/ca-certificates.crt # (optional)
-      # The plugin needs to scan the '/proc' of the host on which is running.
+      # [DEPRECATED] The plugin needs to scan the '/proc' of the host on which is running.
       # In Falco usually we put the host '/proc' folder under '/host/proc' so
       # the the default for this config is '/host'.
       # The path used here must not have a final '/'.
@@ -101,11 +102,16 @@ The plugin doesn't have open params
 
 ### Rules
 
-This plugin doesn't provide any custom rule, you can use the default Falco ruleset and add the necessary `k8smeta` fields. A very simple example rule can be found [here](https://github.com/falcosecurity/plugins/blob/main/plugins/k8smeta/test/rules/example_rule.yaml)
+This plugin doesn't provide any custom rule, you can use the default Falco ruleset and add the necessary `k8smeta` fields. A very simple example rule can be found [here](https://github.com/falcosecurity/plugins/blob/main/plugins/k8smeta/test/rules/example_rule.yaml).  
+
+Note: leveraging latest plugin SDK features, the plugin itself will expose certain fields as suggested output fields:
+* `k8s.pod.name`
+* `k8s.ns.name`
 
 ### Running
 
-This plugin requires Falco with version >= **0.37.0**.
+This plugin requires Falco with version >= **0.40.0**.  
+For older Falco version (>= 0.37.0) please use plugin version 0.2.x.
 Modify the `falco.yaml` with the [configuration above](#configuration) and you are ready to go!
 
 ```shell

--- a/plugins/k8smeta/README.md
+++ b/plugins/k8smeta/README.md
@@ -105,8 +105,8 @@ The plugin doesn't have open params
 This plugin doesn't provide any custom rule, you can use the default Falco ruleset and add the necessary `k8smeta` fields. A very simple example rule can be found [here](https://github.com/falcosecurity/plugins/blob/main/plugins/k8smeta/test/rules/example_rule.yaml).  
 
 Note: leveraging latest plugin SDK features, the plugin itself will expose certain fields as suggested output fields:
-* `k8s.pod.name`
-* `k8s.ns.name`
+* `k8smeta.pod.name`
+* `k8smeta.ns.name`
 
 ### Running
 

--- a/plugins/k8smeta/cmake/modules/libs.cmake
+++ b/plugins/k8smeta/cmake/modules/libs.cmake
@@ -4,7 +4,7 @@ message(STATUS "Fetching libs at 'https://github.com/falcosecurity/libs.git'")
 FetchContent_Declare(
   libs
   GIT_REPOSITORY https://github.com/falcosecurity/libs.git
-  GIT_TAG 0.14.1
+  GIT_TAG 0.20.0
   CONFIGURE_COMMAND "" BUILD_COMMAND "")
 
 FetchContent_Populate(libs)

--- a/plugins/k8smeta/cmake/modules/plugin-sdk-cpp.cmake
+++ b/plugins/k8smeta/cmake/modules/plugin-sdk-cpp.cmake
@@ -6,7 +6,7 @@ message(
 FetchContent_Declare(
   plugin-sdk-cpp
   GIT_REPOSITORY https://github.com/falcosecurity/plugin-sdk-cpp.git
-  GIT_TAG 2097bdb5a5d77f3f38162da1f438382912465340)
+  GIT_TAG 0.2.0)
 
 FetchContent_MakeAvailable(plugin-sdk-cpp)
 set(PLUGIN_SDK_INLCUDE "${plugin-sdk-cpp_SOURCE_DIR}/include")

--- a/plugins/k8smeta/src/plugin.cpp
+++ b/plugins/k8smeta/src/plugin.cpp
@@ -256,6 +256,13 @@ void my_plugin::parse_init_config(nlohmann::json& config_json)
             }
         }
     }
+
+    // TODO: clean this up after deprecation period is over
+    if(config_json.contains(nlohmann::json::json_pointer("/hostProc")))
+    {
+        SPDLOG_WARN("hostProc init config key is deprecated since it is no "
+                    "more in use");
+    }
 }
 
 bool my_plugin::init(falcosecurity::init_input& in)

--- a/plugins/k8smeta/src/plugin.h
+++ b/plugins/k8smeta/src/plugin.h
@@ -276,7 +276,8 @@ class my_plugin
     falcosecurity::table m_thread_table;
     // Accessors to the thread table "cgroups" table
     falcosecurity::table_field m_thread_field_cgroups;
-    // Accessors to the thread table "cgroups" "second" field, ie: the cgroups path
+    // Accessors to the thread table "cgroups" "second" field, ie: the cgroups
+    // path
     falcosecurity::table_field m_cgroups_field_second;
     // Accessors to the fixed fields of the thread table
     falcosecurity::table_field m_pod_uid_field;

--- a/plugins/k8smeta/src/plugin.h
+++ b/plugins/k8smeta/src/plugin.h
@@ -126,7 +126,12 @@ class my_plugin
 
     bool init(falcosecurity::init_input& in);
 
-    void do_initial_proc_scan();
+    //////////////////////////
+    // Listen capability
+    //////////////////////////
+
+    bool capture_open(const falcosecurity::capture_listen_input& in);
+    bool capture_close(const falcosecurity::capture_listen_input& in);
 
     //////////////////////////
     // Async capability
@@ -245,7 +250,7 @@ class my_plugin
     private:
     // Async thread
     std::thread m_async_thread;
-    std::atomic<bool> m_async_thread_quit;
+    std::atomic<bool> m_async_thread_quit = false;
     std::condition_variable m_cv;
     std::mutex m_mu;
 
@@ -254,7 +259,6 @@ class my_plugin
     std::string m_collector_port;
     std::string m_node_name;
     std::string m_ca_PEM_encoding;
-    std::string m_host_proc;
 
     // State tables
     std::unordered_map<std::string, resource_layout> m_pod_table;
@@ -265,15 +269,15 @@ class my_plugin
     std::unordered_map<std::string, resource_layout>
             m_replication_controller_table;
     std::unordered_map<std::string, resource_layout> m_deamonset_table;
-    std::unordered_map<int64_t, std::string> m_thread_id_pod_uid_map;
 
-    // The first time we parse an event we populate the sinsp thread table and
-    // we set it to true
-    bool m_sinsp_proc_populated = false;
     // Last error of the plugin
     std::string m_lasterr;
     // Accessor to the thread table
     falcosecurity::table m_thread_table;
+    // Accessors to the thread table "cgroups" table
+    falcosecurity::table_field m_thread_field_cgroups;
+    // Accessors to the thread table "cgroups" "second" field, ie: the cgroups path
+    falcosecurity::table_field m_cgroups_field_second;
     // Accessors to the fixed fields of the thread table
     falcosecurity::table_field m_pod_uid_field;
 };
@@ -282,3 +286,4 @@ FALCOSECURITY_PLUGIN(my_plugin);
 FALCOSECURITY_PLUGIN_FIELD_EXTRACTION(my_plugin);
 FALCOSECURITY_PLUGIN_ASYNC_EVENTS(my_plugin);
 FALCOSECURITY_PLUGIN_EVENT_PARSING(my_plugin);
+FALCOSECURITY_PLUGIN_CAPTURE_LISTENING(my_plugin);

--- a/plugins/k8smeta/src/shared_with_tests_consts.h
+++ b/plugins/k8smeta/src/shared_with_tests_consts.h
@@ -64,6 +64,7 @@ limitations under the License.
 // Table fields
 /////////////////////////
 #define THREAD_TABLE_NAME "threads"
+#define CGROUPS_TABLE_NAME "cgroups"
 #define POD_UID_FIELD_NAME "pod_uid"
 
 /////////////////////////
@@ -77,11 +78,11 @@ limitations under the License.
 // Generic plugin consts
 /////////////////////////
 #define PLUGIN_NAME "k8smeta"
-#define PLUGIN_VERSION "0.2.1"
+#define PLUGIN_VERSION "0.3.0"
 #define PLUGIN_DESCRIPTION                                                     \
     "Enrich syscall events with information about the pod that throws them"
 #define PLUGIN_CONTACT "github.com/falcosecurity/plugins"
-#define PLUGIN_REQUIRED_API_VERSION "3.1.0"
+#define PLUGIN_REQUIRED_API_VERSION "3.9.0"
 
 #define REASON_PATH "/reason"
 #define KIND_PATH "/kind"
@@ -99,4 +100,3 @@ limitations under the License.
 #define PORT_PATH "/collectorPort"
 #define NODENAME_PATH "/nodeName"
 #define CA_CERT_PATH "/caPEMBundle"
-#define HOST_PROC_PATH "/hostProc"

--- a/plugins/k8smeta/test/src/check_events.cpp
+++ b/plugins/k8smeta/test/src/check_events.cpp
@@ -182,7 +182,8 @@ TEST_F(sinsp_with_test_input, plugin_k8s_basic_API)
     filter_check_list pl_flist;
     ASSERT_PLUGIN_INITIALIZATION(plugin_owner, pl_flist)
 
-    ASSERT_EQ(plugin_owner->caps(), CAP_EXTRACTION | CAP_PARSING | CAP_ASYNC);
+    ASSERT_EQ(plugin_owner->caps(),
+              CAP_EXTRACTION | CAP_PARSING | CAP_ASYNC | CAP_CAPTURE_LISTENING);
     ASSERT_EQ(plugin_owner->name(), PLUGIN_NAME);
     ASSERT_EQ(plugin_owner->description(), PLUGIN_DESCRIPTION);
     ASSERT_EQ(plugin_owner->contact(), PLUGIN_CONTACT);

--- a/plugins/k8smeta/test/src/parsing_pod.cpp
+++ b/plugins/k8smeta/test/src/parsing_pod.cpp
@@ -102,9 +102,10 @@ limitations under the License.
                                                                                \
     auto evt = add_event_advance_ts(                                           \
             increasing_ts(), INIT_TID, event, 27, (int64_t)0, "/bin/test-exe", \
-            empty_bytebuf, INIT_TID, INIT_PID, INIT_PTID, "", not_relevant_64, \
-            not_relevant_64, not_relevant_64, not_relevant_32,                 \
-            not_relevant_32, not_relevant_32, "test-exe",                      \
+            empty_bytebuf, (int64_t)INIT_TID, (int64_t)INIT_PID,               \
+            (int64_t)INIT_PTID, "", not_relevant_64, not_relevant_64,          \
+            not_relevant_64, not_relevant_32, not_relevant_32,                 \
+            not_relevant_32, "test-exe",                                       \
             scap_const_sized_buffer{cgroupsv.data(), cgroupsv.size()},         \
             empty_bytebuf, not_relevant_32, not_relevant_64, not_relevant_32,  \
             (int32_t)PPM_EXE_WRITABLE, not_relevant_64, not_relevant_64,       \
@@ -403,123 +404,5 @@ TEST_F(sinsp_with_test_input, plugin_k8s_parse_parent_clone)
                            PPME_SYSCALL_CLONE_20_X);
     // We have again the pod_uid for the parent thread
     p1_thread_entry->get_dynamic_field(fieldacc, pod_uid);
-    ASSERT_EQ(pod_uid, expected_pod_uid);
-}
-
-TEST_F(sinsp_with_test_input, plugin_k8s_proc_scan_in_the_plugin)
-{
-    std::shared_ptr<sinsp_plugin> plugin_owner;
-    filter_check_list pl_flist;
-    ASSERT_PLUGIN_INITIALIZATION(plugin_owner, pl_flist)
-
-    // We do a real /proc scan in the plugin while in sinsp we don't do that.
-    add_default_init_thread();
-    open_inspector();
-
-    // We create a random clone event to trigger the parsing logic.
-    generate_clone_x_event(0, 2, 2, INIT_TID);
-
-    // The plugin shouldn't crash during the parsing logic of the previous event
-}
-
-#define PLUGIN_PROC_SCAN_UNDER_TMP_PROC                                        \
-    int32_t mock_tid = (1 << 16) - 1;                                          \
-    std::string mock_proc_dir = "/tmp/proc/" + std::to_string(mock_tid) +      \
-                                "/task/" + std::to_string(mock_tid);           \
-    std::string mock_proc_cgroup = mock_proc_dir + "/cgroup";                  \
-    std::string expected_pod_uid = "1d34c7bb-7d94-4f00-bed9-fe4eca61d446";     \
-                                                                               \
-    std::error_code ec;                                                        \
-    std::filesystem::path fullPath = std::filesystem::path(mock_proc_dir);     \
-    if(!std::filesystem::create_directories(fullPath, ec))                     \
-    {                                                                          \
-        FAIL() << "unable to create the mock dir: " << mock_proc_dir           \
-               << ". Error: " << ec.message();                                 \
-    }                                                                          \
-                                                                               \
-    std::ofstream cgroup_file(mock_proc_cgroup);                               \
-    if(!cgroup_file.is_open())                                                 \
-    {                                                                          \
-        FAIL() << "cannot open: " << mock_proc_cgroup                          \
-               << ". Errno: " << strerror(errno);                              \
-    }                                                                          \
-                                                                               \
-    cgroup_file << "0::/kubepods/besteffort/pod" + expected_pod_uid +          \
-                           "/fc16540dcd776bb475437b722c";                      \
-    if(cgroup_file.fail())                                                     \
-    {                                                                          \
-        FAIL() << "cannot write to: " << mock_proc_cgroup                      \
-               << ". Errno: " << strerror(errno);                              \
-    }                                                                          \
-    cgroup_file.close();                                                       \
-                                                                               \
-    std::string plugin_init_config =                                           \
-            "{\"collectorHostname\":\"localhost\",\"collectorPort\": "         \
-            "45000,\"nodeName\":\"control-plane\",\"verbosity\":"              \
-            "\"info\", \"hostProc\":\"/tmp\"}";                                \
-    std::shared_ptr<sinsp_plugin> plugin_owner;                                \
-    filter_check_list pl_flist;                                                \
-    plugin_owner = m_inspector.register_plugin(PLUGIN_PATH);                   \
-    ASSERT_TRUE(plugin_owner.get());                                           \
-    std::string err;                                                           \
-    ASSERT_TRUE(plugin_owner->init(plugin_init_config, err))                   \
-            << "err: " << err;                                                 \
-    pl_flist.add_filter_check(m_inspector.new_generic_filtercheck());          \
-    pl_flist.add_filter_check(sinsp_plugin::new_filtercheck(plugin_owner));    \
-                                                                               \
-    std::filesystem::path mock_proc = std::filesystem::path("/tmp/proc");      \
-    ASSERT_EQ(std::filesystem::remove_all(mock_proc), 5);
-
-TEST_F(sinsp_with_test_input, plugin_k8s_proc_scan_mismatch)
-{
-    PLUGIN_PROC_SCAN_UNDER_TMP_PROC
-
-    // We do a real /proc scan in the plugin while in sinsp we don't do that.
-    // Now the plugin cache has one entry while sinps has no entry. we want to
-    // see how exceptions are handled during the parsing logic.
-    add_default_init_thread();
-    open_inspector();
-
-    // We create a random clone event to trigger the parsing logic.
-    generate_clone_x_event(0, 2, 2, INIT_TID);
-}
-
-TEST_F(sinsp_with_test_input, plugin_k8s_pod_uid_population_from_proc)
-{
-    PLUGIN_PROC_SCAN_UNDER_TMP_PROC
-
-    add_default_init_thread();
-    add_simple_thread(mock_tid, mock_tid, INIT_TID);
-
-    // Open test inspector
-    open_inspector();
-
-    // we add a new thread manually to the thread table and we check its pod_uid
-    auto tinfo = m_inspector.get_thread_ref(mock_tid);
-    ASSERT_TRUE(tinfo);
-    auto &reg = m_inspector.get_table_registry();
-    auto thread_table = reg->get_table<int64_t>(THREAD_TABLE_NAME);
-    auto field =
-            thread_table->dynamic_fields()->fields().find(POD_UID_FIELD_NAME);
-    auto fieldacc = field->second.new_accessor<std::string>();
-
-    std::string pod_uid = "";
-    tinfo->get_dynamic_field(fieldacc, pod_uid);
-    ASSERT_EQ(pod_uid, "");
-
-    // Now we try to generate a random event from this thread
-    // but this is not parsed by the plugin so the pod_uid is not extracted
-    generate_random_event(mock_tid);
-
-    tinfo->get_dynamic_field(fieldacc, pod_uid);
-    ASSERT_EQ(pod_uid, "");
-
-    // Now if we generate an event that is parsed by the plugin
-    // the pod_uid should be extracted
-    generate_execve_enter_and_exit_event(0, mock_tid, mock_tid, mock_tid,
-                                         INIT_TID);
-
-    // The pod_uid is populated thanks to the plugin internal cache
-    tinfo->get_dynamic_field(fieldacc, pod_uid);
     ASSERT_EQ(pod_uid, expected_pod_uid);
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind feature

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

Implemented the "suggested output fields feature", by suggesting `k8smeta.pod.name` and `k8smeta.ns.name` as output fields.

Also, entirely avoid the proc scan, instead relying on the listening CAPability to initially loop over the thread table to attach pod_uid to threads.
Following the above, `hostProc` initConfig key is now deprecated and unused.

Moved the plugin to 0.3.0 too (given the minimum plugin API version changes).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
