### PR TITLE
fix(build/registry): switch to RootDigest

### DIFF
--- a/build/registry/pkg/oci/oci.go
+++ b/build/registry/pkg/oci/oci.go
@@ -284,7 +284,7 @@ func handlePlugin(ctx context.Context, cfg *config, plugin *registry.Plugin, oci
 				Ref: ref,
 			},
 			registry.ArtifactMetadata{
-				Digest: res.Digest,
+				Digest: res.RootDigest,
 				Tags:   tags,
 			},
 		})
@@ -352,7 +352,7 @@ func handleRule(ctx context.Context, cfg *config, plugin *registry.Plugin,
 				Ref: ref,
 			},
 			registry.ArtifactMetadata{
-				Digest: res.Digest,
+				Digest: res.RootDigest,
 				Tags:   tags,
 			},
 		})


### PR DESCRIPTION
This is required as a consequence of the falcoctl v0.11 upgrade.

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
