### PR TITLE
update(plugins/cloudtrail): support pre-ControlTower organization trails

### DIFF
--- a/plugins/cloudtrail/pkg/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/pkg/cloudtrail/cloudtrail.go
@@ -48,7 +48,7 @@ const (
 	PluginName               = "cloudtrail"
 	PluginDescription        = "reads cloudtrail JSON data saved to file in the directory specified in the settings"
 	PluginContact            = "github.com/falcosecurity/plugins/"
-	PluginVersion            = "0.12.4"
+	PluginVersion            = "0.12.5"
 	PluginEventSource        = "aws_cloudtrail"
 )
 

--- a/plugins/cloudtrail/pkg/cloudtrail/source.go
+++ b/plugins/cloudtrail/pkg/cloudtrail/source.go
@@ -271,6 +271,8 @@ func (oCtx *PluginInstance) openS3(input string) error {
 	// bucket_name/prefix_name/AWSLogs/Account ID/CloudTrail/region/YYYY/MM/DD/AccountID_CloudTrail_RegionName_YYYYMMDDTHHmmZ_UniqueString.json.gz
 	// for organization trails the format is
 	// bucket_name/prefix_name/AWSLogs/O-ID/Account ID/CloudTrail/Region/YYYY/MM/DD/AccountID_CloudTrail_RegionName_YYYYMMDDTHHmmZ_UniqueString.json.gz
+	// for ControlTower releases before landing zones version 3.0 the organization trails format is
+	// bucket_name/prefix_name/AWSLogs/Account ID/CloudTrail/Region/YYYY/MM/DD/AccountID_CloudTrail_RegionName_YYYYMMDDTHHmmZ_UniqueString.json.gz
 	// Reduce the number of pages we have to process using "StartAfter" parameters
 	// here, then trim individual filepaths below.
 
@@ -278,8 +280,8 @@ func (oCtx *PluginInstance) openS3(input string) error {
 
 	// For durations, carve out a special case for "Copy S3 URI" in the AWS console, which gives you
 	// bucket_name/prefix_name/AWSLogs/<Account ID>/ or bucket_name/prefix_name/AWSLogs/<Org-ID>/<Account ID>/
-	awsLogsRE := regexp.MustCompile(`AWSLogs/(?:o-[a-z0-9]{10,32}/)?\d{12}/?$`)
-	awsLogsOrgRE := regexp.MustCompile(`AWSLogs/o-[a-z0-9]{10,32}/?$`)
+	awsLogsRE := regexp.MustCompile(`/AWSLogs/(?:o-[a-z0-9]{10,32}/)?\d{12}/?$`)
+	awsLogsOrgRE := regexp.MustCompile(`/AWSLogs(?:/o-[a-z0-9]{10,32})?/?$`)
 	if awsLogsRE.MatchString(prefix) {
 		if (! strings.HasSuffix(intervalPrefix, "/")) {
 			intervalPrefix += "/"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind feature

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

Some pre-ControlTower organization Cloutrail trails are missing the OrgId in the AWSLogs S3 path. Making the OrgId optional gives them the option to use S3AccountList.