### PR TITLE
fix(build): prevent race condition when dlopening a Go runtime embedd…

### DIFF
--- a/build/utils/version.go
+++ b/build/utils/version.go
@@ -43,7 +43,7 @@ import (
 #include <stdio.h>
 
 static uintptr_t pluginOpen(const char* path, char** err) {
-	void* h = dlopen(path, RTLD_NOW|RTLD_GLOBAL);
+	void* h = dlopen(path, RTLD_NOW|RTLD_GLOBAL|RTLD_DEEPBIND);
 	if (h == NULL) {
 		*err = (char*)dlerror();
 	}


### PR DESCRIPTION

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

> /area registry

/area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When building a shared library (.so) that contains CGO, it embeds its own instance of the Go runtime. When later the we dlopen that library from a Go program (which already has its own Go runtime) both copies of the runtime are loaded into the same process. Go’s runtime is designed to be a singleton, and having two instances leads to conflicts during the execution of the library’s global init functions, ultimately causing a segfault.
This error was noticed for the first time with the `container` plugin, which makes use of the Podman package, which in turn makes massive use of Go `init()` functions.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
