### PR TITLE
new(plugins/container): allow to specify which hook to be attached between {"create", "start"}

### DIFF
--- a/plugins/container/Makefile
+++ b/plugins/container/Makefile
@@ -13,6 +13,8 @@
 #
 
 NAME := container
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+PROJECT_ROOT_DIR = $(shell git rev-parse --show-toplevel)
 
 ifeq ($(OS),Windows_NT)
     detected_OS := Windows
@@ -30,8 +32,6 @@ else
     OUTPUT := lib$(NAME).so
     OUTPUT_FILE := build/$(OUTPUT)
 endif
-
-PROJECT_ROOT_DIR = $(shell git rev-parse --show-toplevel)
 
 all: $(OUTPUT)
 
@@ -54,4 +54,4 @@ readme:
 
 # Requires clang-format-18
 fmt:
-	git ls-files --directory ${PROJECT_ROOT_DIR} | grep -E '\.(cpp|h|c)$$' | xargs clang-format-18 -Werror --style=file:${PROJECT_ROOT_DIR}/.clang-format -i --verbose
+	git ls-files --directory $(ROOT_DIR) | grep -E '\.(cpp|h|c)$$' | xargs clang-format-18 -Werror --style=file:${PROJECT_ROOT_DIR}/.clang-format -i --verbose

--- a/plugins/container/README.md
+++ b/plugins/container/README.md
@@ -134,6 +134,7 @@ plugins:
     init_config:
       label_max_len: 100 # (optional, default: 100; container labels larger than this won't be reported)
       with_size: false # (optional, default: false; whether to enable container size inspection, which is inherently slow)
+      hooks: ['create', 'start'] # (optional, default: 'create'. Some fields might not be available in create hook, but we are guaranteed that it gets triggered before first process gets started)
       engines:
         docker:
           enabled: true

--- a/plugins/container/go-worker/pkg/config/config.go
+++ b/plugins/container/go-worker/pkg/config/config.go
@@ -4,7 +4,11 @@ import (
 	"encoding/json"
 )
 
-const defaultLabelMaxLen = 100
+const (
+	defaultLabelMaxLen = 100
+	HookCreate         = 1
+	HookStart          = 2
+)
 
 type SocketsEngine struct {
 	Enabled bool     `json:"enabled"`
@@ -16,6 +20,7 @@ type EngineCfg struct {
 	LabelMaxLen    int                      `json:"label_max_len"`
 	WithSize       bool                     `json:"with_size"`
 	HostRoot       string                   `json:"host_root"`
+	Hooks          byte                     `json:"hooks"`
 }
 
 var c EngineCfg
@@ -24,6 +29,7 @@ var c EngineCfg
 func init() {
 	c.LabelMaxLen = defaultLabelMaxLen
 	c.WithSize = false
+	c.Hooks = HookCreate
 }
 
 func Load(initCfg string) error {
@@ -48,4 +54,8 @@ func GetWithSize() bool {
 
 func GetHostRoot() string {
 	return c.HostRoot
+}
+
+func IsHookEnabled(hook byte) bool {
+	return c.Hooks&hook != 0
 }

--- a/plugins/container/src/macros.h
+++ b/plugins/container/src/macros.h
@@ -17,8 +17,6 @@ limitations under the License.
 
 #pragma once
 
-// This consts file is shared between the plugin and tests
-
 /////////////////////////
 // Async capability
 /////////////////////////

--- a/plugins/container/src/plugin_config.cpp
+++ b/plugins/container/src/plugin_config.cpp
@@ -40,6 +40,9 @@ void from_json(const nlohmann::json& j, PluginConfig& cfg)
 
     std::vector<std::string> hooks =
             j.value("hooks", std::vector<std::string>{"create"});
+    // Reset: by default, it is HOOK_CREATE,
+    // but we are now setting it from json.
+    cfg.hooks = 0;
     for(const auto& hook : hooks)
     {
         if(hook == "create")

--- a/plugins/container/src/plugin_config.cpp
+++ b/plugins/container/src/plugin_config.cpp
@@ -37,6 +37,21 @@ void from_json(const nlohmann::json& j, PluginConfig& cfg)
 {
     cfg.label_max_len = j.value("label_max_len", DEFAULT_LABEL_MAX_LEN);
     cfg.with_size = j.value("with_size", false);
+
+    std::vector<std::string> hooks =
+            j.value("hooks", std::vector<std::string>{"create"});
+    for(const auto& hook : hooks)
+    {
+        if(hook == "create")
+        {
+            cfg.hooks |= HOOK_CREATE;
+        }
+        else if(hook == "start")
+        {
+            cfg.hooks |= HOOK_START;
+        }
+    }
+
     cfg.engines = j.value("engines", Engines{});
 
     // Set default sockets if emtpy
@@ -110,5 +125,6 @@ void to_json(nlohmann::json& j, const PluginConfig& cfg)
     j["label_max_len"] = cfg.label_max_len;
     j["with_size"] = cfg.with_size;
     j["host_root"] = cfg.host_root;
+    j["hooks"] = cfg.hooks;
     j["engines"] = cfg.engines;
 }

--- a/plugins/container/src/plugin_config.h
+++ b/plugins/container/src/plugin_config.h
@@ -6,6 +6,9 @@
 
 #define DEFAULT_LABEL_MAX_LEN 100
 
+#define HOOK_CREATE 1
+#define HOOK_START 2
+
 struct SimpleEngine
 {
     bool enabled;
@@ -57,6 +60,7 @@ struct PluginConfig
 {
     int label_max_len;
     bool with_size;
+    uint8_t hooks;
     std::string host_root;
     Engines engines;
 
@@ -64,6 +68,7 @@ struct PluginConfig
     {
         label_max_len = DEFAULT_LABEL_MAX_LEN;
         with_size = false;
+        hooks = HOOK_CREATE;
         if(const char* hroot = std::getenv("HOST_ROOT"))
         {
             host_root = hroot;

--- a/plugins/container/src/plugin_config_schema.h
+++ b/plugins/container/src/plugin_config_schema.h
@@ -27,7 +27,7 @@ const char plugin_schema_string[] = LONG_STRING_CONST(
         ]
       },
       "title": "Hooks to be attached.",
-      "description": "Hooks to be attached from the engines SDKs."
+      "description": "Hooks to be attached from the engines SDKs. Some fields are not available in 'create' hook. By default, we only attach 'create' that is guaranteed to be notified before first process starts."
     },
     "engines": {
       "$ref": "#/definitions/Engines",

--- a/plugins/container/src/plugin_config_schema.h
+++ b/plugins/container/src/plugin_config_schema.h
@@ -5,131 +5,142 @@
 const char plugin_schema_string[] = LONG_STRING_CONST(
 
 {
-   "$schema":"http://json-schema.org/draft-04/schema#",
-   "required":[],
-   "properties":{
-      "label_max_len":{
-         "type":"integer",
-         "title":"Max label length",
-         "description":"Labels exceeding this limit won't be reported."
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "required": [],
+  "properties": {
+    "label_max_len": {
+      "type": "integer",
+      "title": "Max label length",
+      "description": "Labels exceeding this limit won't be reported."
+    },
+    "with_size": {
+      "type": "boolean",
+      "title": "Inspect containers with size",
+      "description": "Inspect containers size where supported."
+    },
+    "hooks": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "create",
+          "start"
+        ]
       },
-      "with_size":{
-         "type":"boolean",
-         "title":"Inspect containers with size",
-         "description":"Inspect containers size where supported."
+      "title": "Hooks to be attached.",
+      "description": "Hooks to be attached from the engines SDKs."
+    },
+    "engines": {
+      "$ref": "#/definitions/Engines",
+      "title": "The plugin per-engine configuration",
+      "description": "Allows to disable/enable each engine and customize sockets where available."
+    }
+  },
+  "definitions": {
+    "Engines": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "docker": {
+          "$ref": "#/definitions/SocketsContainer"
+        },
+        "podman": {
+          "$ref": "#/definitions/SocketsContainer"
+        },
+        "containerd": {
+          "$ref": "#/definitions/SocketsContainer"
+        },
+        "cri": {
+          "$ref": "#/definitions/SocketsContainer"
+        },
+        "lxc": {
+          "$ref": "#/definitions/SimpleContainer"
+        },
+        "libvirt_lxc": {
+          "$ref": "#/definitions/SimpleContainer"
+        },
+        "bpm": {
+          "$ref": "#/definitions/SimpleContainer"
+        },
+        "static": {
+          "$ref": "#/definitions/StaticContainer"
+        }
       },
-      "engines":{
-         "$ref":"#/definitions/Engines",
-         "title":"The plugin per-engine configuration",
-         "description":"Allows to disable/enable each engine and customize sockets where available."
-      }
-   },
-   "definitions":{
-      "Engines":{
-         "type":"object",
-         "additionalProperties":false,
-         "properties":{
-            "docker":{
-               "$ref":"#/definitions/SocketsContainer"
-            },
-            "podman":{
-               "$ref":"#/definitions/SocketsContainer"
-            },
-            "containerd":{
-               "$ref":"#/definitions/SocketsContainer"
-            },
-            "cri":{
-               "$ref":"#/definitions/SocketsContainer"
-            },
-            "lxc":{
-               "$ref":"#/definitions/SimpleContainer"
-            },
-            "libvirt_lxc":{
-               "$ref":"#/definitions/SimpleContainer"
-            },
-            "bpm":{
-               "$ref":"#/definitions/SimpleContainer"
-            },
-            "static":{
-               "$ref":"#/definitions/StaticContainer"
-            }
-         },
-         "required":[
-            "bpm",
-            "containerd",
-            "cri",
-            "docker",
-            "libvirt_lxc",
-            "lxc",
-            "podman"
-         ],
-         "title":"Engines"
+      "required": [
+        "bpm",
+        "containerd",
+        "cri",
+        "docker",
+        "libvirt_lxc",
+        "lxc",
+        "podman"
+      ],
+      "title": "Engines"
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "SimpleContainer": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
       },
-      "nonEmptyString":{
-         "type":"string",
-         "minLength":1
+      "required": [
+        "enabled"
+      ],
+      "title": "SimpleContainer"
+    },
+    "SocketsContainer": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "sockets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       },
-      "SimpleContainer":{
-         "type":"object",
-         "additionalProperties":false,
-         "properties":{
-            "enabled":{
-               "type":"boolean"
-            }
-         },
-         "required":[
-            "enabled"
-         ],
-         "title":"SimpleContainer"
+      "required": [
+        "enabled",
+        "sockets"
+      ],
+      "title": "SocketsContainer"
+    },
+    "StaticContainer": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "container_id": {
+          "$ref": "#/definitions/nonEmptyString"
+        },
+        "container_name": {
+          "$ref": "#/definitions/nonEmptyString"
+        },
+        "container_image": {
+          "$ref": "#/definitions/nonEmptyString"
+        }
       },
-      "SocketsContainer":{
-         "type":"object",
-         "additionalProperties":false,
-         "properties":{
-            "enabled":{
-               "type":"boolean"
-            },
-            "sockets":{
-               "type":"array",
-               "items":{
-                  "type":"string"
-               }
-            }
-         },
-         "required":[
-            "enabled",
-            "sockets"
-         ],
-         "title":"SocketsContainer"
-      },
-      "StaticContainer":{
-         "type":"object",
-         "additionalProperties":false,
-         "properties":{
-            "enabled":{
-               "type":"boolean"
-            },
-            "container_id":{
-               "$ref":"#/definitions/nonEmptyString"
-            },
-            "container_name":{
-               "$ref":"#/definitions/nonEmptyString"
-            },
-            "container_image":{
-               "$ref":"#/definitions/nonEmptyString"
-            }
-         },
-         "required":[
-            "enabled",
-            "container_id",
-            "container_name",
-            "container_image"
-         ],
-         "title":"StaticContainer"
-      }
-   },
-   "additionalProperties":false,
-   "type":"object"
+      "required": [
+        "enabled",
+        "container_id",
+        "container_name",
+        "container_image"
+      ],
+      "title": "StaticContainer"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
 }
 
 ); // LONG_STRING_CONST macro

--- a/plugins/container/test/config.cpp
+++ b/plugins/container/test/config.cpp
@@ -38,7 +38,8 @@ TEST(plugin_config, from_json)
     }
   },
   "label_max_len": 120,
-  "with_size": true
+  "with_size": true,
+  "hooks": ["start"]
 })";
     auto config_json = nlohmann::json::parse(config);
 
@@ -54,6 +55,7 @@ TEST(plugin_config, from_json)
 
     EXPECT_TRUE(cfg.with_size);
     EXPECT_EQ(cfg.label_max_len, 120);
+    EXPECT_EQ(cfg.hooks, HOOK_START);
 }
 
 TEST(plugin_config, from_json_missing_engines)
@@ -77,6 +79,7 @@ TEST(plugin_config, from_json_missing_engines)
 
     EXPECT_TRUE(cfg.with_size);
     EXPECT_EQ(cfg.label_max_len, 120);
+    EXPECT_EQ(cfg.hooks, HOOK_CREATE);
 }
 
 TEST(plugin_config, from_json_empty_json)
@@ -97,6 +100,7 @@ TEST(plugin_config, from_json_empty_json)
 
     EXPECT_FALSE(cfg.with_size);
     EXPECT_EQ(cfg.label_max_len, DEFAULT_LABEL_MAX_LEN);
+    EXPECT_EQ(cfg.hooks, HOOK_CREATE);
 }
 
 TEST(plugin_config, to_json)
@@ -129,6 +133,7 @@ TEST(plugin_config, to_json)
       ]
     }
   },
+  "hooks": 3,
   "host_root": "",
   "label_max_len": 120,
   "with_size": true
@@ -151,6 +156,7 @@ TEST(plugin_config, to_json)
 
     cfg.label_max_len = 120;
     cfg.with_size = true;
+    cfg.hooks = HOOK_CREATE | HOOK_START;
 
     nlohmann::json j(cfg);
     EXPECT_EQ(j.dump(2).c_str(), expected_config);


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

Some fields (namely IP address for docker engine) are not available at `Create` hook. Allow user to specify which hooks to attach.
By default, we only attach `Create` hook since we can be sure that it is called way before the container gets started, thus it gives us time to retrieve metadata before the first process starts.
If both hooks are attached, you'll get doubled "container" events, and a single "container_removed" event.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
