### PR TITLE
fix(plugin/container): avoid overwriting host container info when loading pre-existing containers

### DIFF
--- a/plugins/container/src/caps/async/async.cpp
+++ b/plugins/container/src/caps/async/async.cpp
@@ -41,9 +41,9 @@ bool my_plugin::start_async_events(
     free((void *)enabled_engines);
 
     // Merge back pre-existing containers to our cache
-    m_containers = s_preexisting_containers;
-    for(const auto &c : m_containers)
+    for(const auto &c : s_preexisting_containers)
     {
+        m_containers.insert(c);
         m_logger.log(fmt::format("Added pre-existing container: {}", c.first),
                      falcosecurity::_internal::SS_PLUGIN_LOG_SEV_TRACE);
     }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

#715  loaded pre-existing containers and then copied them to the containers cache; doing so, it was overriding the `""` (empty) key, that is used for host container info.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
