### PR TITLE
cleanup(plugins/container): drop static vars

### DIFF
--- a/plugins/container/CMakeLists.txt
+++ b/plugins/container/CMakeLists.txt
@@ -9,7 +9,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 # project metadata
 project(
         container
-        VERSION 0.2.0
+        VERSION 0.2.1
         DESCRIPTION "Falco container metadata enrichment Plugin"
         LANGUAGES CXX)
 

--- a/plugins/container/src/caps/async/async.cpp
+++ b/plugins/container/src/caps/async/async.cpp
@@ -7,7 +7,6 @@
 
 std::unique_ptr<falcosecurity::async_event_handler>
         s_async_handler[ASYNC_HANDLER_MAX];
-static void *s_async_ctx;
 
 std::vector<std::string> my_plugin::get_async_events()
 {
@@ -34,7 +33,7 @@ bool my_plugin::start_async_events(
                  falcosecurity::_internal::SS_PLUGIN_LOG_SEV_DEBUG);
     nlohmann::json j(m_cfg);
     const char *enabled_engines = nullptr;
-    s_async_ctx = StartWorker(generate_async_event<ASYNC_HANDLER_GO_WORKER>,
+    m_async_ctx = StartWorker(generate_async_event<ASYNC_HANDLER_GO_WORKER>,
                               j.dump().c_str(), &enabled_engines);
     m_logger.log(fmt::format("attached engine sockets: {}", enabled_engines),
                  falcosecurity::_internal::SS_PLUGIN_LOG_SEV_DEBUG);
@@ -48,7 +47,7 @@ bool my_plugin::start_async_events(
                      falcosecurity::_internal::SS_PLUGIN_LOG_SEV_TRACE);
     }
 
-    return s_async_ctx != nullptr;
+    return m_async_ctx != nullptr;
 }
 
 // We need this API to stop the async thread when the
@@ -57,11 +56,11 @@ bool my_plugin::stop_async_events() noexcept
 {
     m_logger.log("stopping async go-worker",
                  falcosecurity::_internal::SS_PLUGIN_LOG_SEV_DEBUG);
-    if(s_async_ctx != nullptr)
+    if(m_async_ctx != nullptr)
     {
         // Implemented by GO worker.go
-        StopWorker(s_async_ctx);
-        s_async_ctx = nullptr;
+        StopWorker(m_async_ctx);
+        m_async_ctx = nullptr;
 
         for(int i = 0; i < ASYNC_HANDLER_MAX; i++)
         {

--- a/plugins/container/src/caps/async/async.cpp
+++ b/plugins/container/src/caps/async/async.cpp
@@ -23,6 +23,17 @@ std::vector<std::string> my_plugin::get_async_event_sources()
 bool my_plugin::start_async_events(
         std::shared_ptr<falcosecurity::async_event_handler_factory> f)
 {
+    // We are already started. This can happen:
+    // * if `start_async_events` is called multiple times
+    // * during Falco hot reload dry-run checks; in that scenario,
+    //   the same library object gets opened once again, thus a new `my_plugin`
+    //   instance is created,
+    //   and all static variables are shared. Just return true and do nothing.
+    if(s_async_handler[ASYNC_HANDLER_DEFAULT] != nullptr)
+    {
+        return true;
+    }
+
     for(int i = 0; i < ASYNC_HANDLER_MAX; i++)
     {
         s_async_handler[i] = std::move(f->new_handler());

--- a/plugins/container/src/plugin.h
+++ b/plugins/container/src/plugin.h
@@ -136,6 +136,8 @@ class my_plugin
 
     falcosecurity::logger m_logger;
 
+    void* m_async_ctx = nullptr;
+
     // Last error of the plugin
     std::string m_lasterr;
     // Accessor to the thread table


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

The PR drops a useless static var in container plugin ASYNC capability. 
Also, it properly checks for the only remaining static variable before using it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
