### PR TITLE
doc: add support for `krsi` plugin field extraction doc auto-gen

### DIFF
--- a/build/readme/fields.go
+++ b/build/readme/fields.go
@@ -48,6 +48,11 @@ func fieldsRenderArgRow(a *sdk.FieldEntryArg) string {
 	return strings.Join(res, ", ")
 }
 
+// renderNewLines replaces '\n' character with "<br/>" for proper table formatting.
+func renderNewLines(desc string) string {
+    return strings.ReplaceAll(desc, "\n", "<br/>")
+}
+
 func fieldsEditor(p *loader.Plugin, s string) (string, error) {
 	if !p.HasCapExtraction() {
 		return s, nil
@@ -74,7 +79,7 @@ func fieldsEditor(p *loader.Plugin, s string) (string, error) {
 			row = append(row, "`"+f.Type+"`")
 		}
 		row = append(row, fieldsRenderArgRow(&f.Arg))
-		row = append(row, f.Desc)
+		row = append(row, renderNewLines(f.Desc))
 		table.Append(row)
 	}
 	table.Render()

--- a/plugins/krsi/README.md
+++ b/plugins/krsi/README.md
@@ -7,58 +7,36 @@ The main difference between these operations and regular Falco events is that:
 * The arguments are collected directly from the kernel, making data collection more resilient against TOCTOU attacks and other conditions that could prevent Falco from getting accurate data
 * File path and network connection data resolution is performed directly in the kernel to provide more accurate information
 
-It generates the following types of events with parameters:
-* `krsi_open`: open operation, only generated if the operation is successful
-  * `krsi.name` (string) : full path to file
-  * `krsi.fd` (int) : fd number
-  * `krsi.file_index` (int) : file index (if available)
-  * `krsi.flags` (int) : flags (same as a regular file open from the Falco instrumentation)
-  * `krsi.mode` (int) : file mode
-  * `krsi.dev` (int) : device number
-  * `krsi.ino` (int) : inode number
-  * `krsi.iou_ret` (int) : io_uring return value (if available)
-* `krsi_socket`: 
-  * `krsi.fd` (int) : fd number (if available)
-  * `krsi.domain` (int) : socket domain
-  * `krsi.type` (int) : socket type
-  * `krsi.file_index` (int) : file index (if available)
-  * `krsi.iou_ret` (int) : io_uring return value (if available)
-* `krsi_connect`: 
-  * `krsi.fd` (int) : fd number (if available)
-  * `krsi.file_index` (int) : file index number (if available)
-  * `krsi.name` (string) : connection display name (e.g. `127.0.0.1:54321->10.0.0.1:8000`)
-  * `krsi.res` (int) : operation result (if available)
-  * `krsi.iou_ret` (int) : io_uring return value (if available)
-  * `krsi.sip` (IP address): server IP
-  * `krsi.sport` (int): server port
-  * `krsi.cip` (IP address): client IP
-  * `krsi.cport` (int): client port
-* `krsi_symlinkat`: 
-  * `krsi.target` (string) : target file name (oldpath)
-  * `krsi.linkdirfd` (int) : link dirfd
-  * `krsi.linkpath` (string) : link path
-  * `krsi.res` (int) : operation result (if available)
-  * `krsi.iou_ret` (int) : io_uring return value (if available)
-* `krsi_linkat`:
-  * `krsi.olddirfd` (int) : dir fd for the existing file
-  * `krsi.oldpath` (string) : path to the existing file
-  * `krsi.newdirfd` (int) : dir fd for the new link location
-  * `krsi.newpath` (string) : path for the new link location
-  * `krsi.flags` (int) : flags
-  * `krsi.res` (int) : operation result (if available)
-  * `krsi.iou_ret` (int) : io_uring return value (if available)
-* `krsi_unlinkat`:
-  * `krsi.path` (string) : operation path
-  * `krsi.dirfd` (int) : dirfd
-  * `krsi.flags` (int) : flags
-  * `krsi.res` (int) : operation result (if available)
-  * `krsi.iou_ret` (int) : io_uring return value (if available)
-* `krsi_mkdirat`:
-  * `krsi.path` (string) : operation path
-  * `krsi.dirfd` (int) : dirfd
-  * `krsi.mode` (int) : mode
-  * `krsi.res` (int) : operation result (if available)
-  * `krsi.iou_ret` (int) : io_uring return value (if available)
+## Supported fields
+
+<!-- README-PLUGIN-FIELDS -->
+|       NAME        |   TYPE   | ARG  |                                                                                                               DESCRIPTION                                                                                                               |
+|-------------------|----------|------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `krsi.name`       | `string` | None | Availability: `krsi_open`, `krsi_connect`.<br/>Per-event descriptions:<br/>- `krsi_open`: full path to file<br/>- `krsi_connect`: connection display name (e.g. `127.0.0.1:54321->10.0.0.1:8000`)                                       |
+| `krsi.fd`         | `uint64` | None | Availability: `krsi_open`, `krsi_socket`, `krsi_connect`.<br/>Description: fd number (if available)                                                                                                                                     |
+| `krsi.file_index` | `uint64` | None | Availability: `krsi_open`, `krsi_socket`, `krsi_connect`.<br/>Description: file index number (if available)                                                                                                                             |
+| `krsi.flags`      | `uint64` | None | Availability: `krsi_open`, `krsi_linkat`, `krsi_unlinkat`.<br/>Per-event descriptions:<br/>- `krsi_open`: open* flags, equivalent to open* syscall family flags<br/>- `krsi_linkat`: linkat flags<br/>- `krsi_unlinkat`: unlinkat flags |
+| `krsi.mode`       | `uint64` | None | Availability: `krsi_open`, `krsi_mkdirat`.<br/>Per-event descriptions:<br/>- `krsi_open`: open file mode<br/>- `krsi_mkdirat`: mkdirat mode, indicating permission to use                                                               |
+| `krsi.dev`        | `uint64` | None | Availability: `krsi_open`.<br/>Per-event descriptions:<br/>- `krsi_open`: file device number                                                                                                                                            |
+| `krsi.ino`        | `uint64` | None | Availability: `krsi_open`.<br/>Per-event descriptions:<br/>- `krsi_open`: file inode number                                                                                                                                             |
+| `krsi.domain`     | `uint64` | None | Availability: `krsi_socket`.<br/>Per-event descriptions:<br/>- `krsi_socket`: socket domain                                                                                                                                             |
+| `krsi.type`       | `uint64` | None | Availability: `krsi_socket`.<br/>Per-event descriptions:<br/>- `krsi_socket`: socket type                                                                                                                                               |
+| `krsi.iou_ret`    | `uint64` | None | Availability: `krsi_open`, `krsi_socket`, `krsi_connect`, `krsi_symlinkat`, `krsi_linkat`, `krsi_unlinkat`, `krsi_mkdirat`.<br/>Description: io_uring internal return value (if available)                                              |
+| `krsi.res`        | `uint64` | None | Availability: `krsi_connect`, `krsi_symlinkat`, `krsi_linkat`, `krsi_unlinkat`, `krsi_mkdirat`.<br/>Description: `operation return value (if available)                                                                                 |
+| `krsi.target`     | `string` | None | Availability: `krsi_symlinkat`.<br/>Per-event descriptions:<br/>- `krsi_symlinkat`: symbolic link target path                                                                                                                           |
+| `krsi.linkdirfd`  | `uint64` | None | Availability: `krsi_symlinkat`.<br/>Per-event descriptions:<br/>- `krsi_symlinkat`: symbolic link dir fd                                                                                                                                |
+| `krsi.linkpath`   | `string` | None | Availability: `krsi_symlinkat`.<br/>Per-event descriptions:<br/>- `krsi_symlinkat`: symbolic link path                                                                                                                                  |
+| `krsi.olddirfd`   | `uint64` | None | Availability: `krsi_linkat`.<br/>Per-event descriptions:<br/>- `krsi_linkat`: dir fd for the target path                                                                                                                                |
+| `krsi.newdirfd`   | `uint64` | None | Availability: `krsi_linkat`.<br/>Per-event descriptions:<br/>- `krsi_linkat`: dir fd for the link path                                                                                                                                  |
+| `krsi.dirfd`      | `uint64` | None | Availability: `krsi_unlinkat`, `krsi_mkdirat`.<br/>Description: dir fd of the path                                                                                                                                                      |
+| `krsi.path`       | `string` | None | Availability: `krsi_unlinkat`, `krsi_mkdirat`.<br/>Per-event descriptions:<br/>- `krsi_unlinkat`: path to be unlinked<br/>- `krsi_mkdirat`: path to the directory to be created                                                         |
+| `krsi.oldpath`    | `string` | None | Availability: `krsi_linkat`.<br/>Per-event descriptions:<br/>- `krsi_linkat`: target path                                                                                                                                               |
+| `krsi.newpath`    | `string` | None | Availability: `krsi_linkat`.<br/>Per-event descriptions:<br/>- `krsi_linkat`: link path                                                                                                                                                 |
+| `krsi.cip`        | `ipaddr` | None | Availability: `krsi_connect`.<br/>Per-event descriptions:<br/>- `krsi_connect`: client IP address                                                                                                                                       |
+| `krsi.sip`        | `ipaddr` | None | Availability: `krsi_connect`.<br/>Per-event descriptions:<br/>- `krsi_connect`: server IP address                                                                                                                                       |
+| `krsi.cport`      | `uint64` | None | Availability: `krsi_connect`.<br/>Per-event descriptions:<br/>- `krsi_connect`: client port                                                                                                                                             |
+| `krsi.sport`      | `uint64` | None | Availability: `krsi_connect`.<br/>Per-event descriptions:<br/>- `krsi_connect`: server port                                                                                                                                             |
+<!-- /README-PLUGIN-FIELDS -->
 
 ## Running and configuring the plugin
 

--- a/plugins/krsi/krsi/src/lib.rs
+++ b/plugins/krsi/krsi/src/lib.rs
@@ -757,31 +757,105 @@ impl ExtractPlugin for KrsiPlugin {
     const EVENT_TYPES: &'static [EventType] = &[EventType::ASYNCEVENT_E];
     const EVENT_SOURCES: &'static [&'static str] = &["syscall"];
     type ExtractContext = Option<KrsiEvent>;
+    #[rustfmt::skip]
     const EXTRACT_FIELDS: &'static [ExtractFieldInfo<Self>] = &[
-        field("krsi.name", &Self::extract_fd_name),
-        field("krsi.fd", &Self::extract_fd),
-        field("krsi.file_index", &Self::extract_file_index),
-        field("krsi.flags", &Self::extract_flags),
-        field("krsi.mode", &Self::extract_mode),
-        field("krsi.dev", &Self::extract_dev),
-        field("krsi.ino", &Self::extract_ino),
-        field("krsi.domain", &Self::extract_domain),
-        field("krsi.type", &Self::extract_type),
-        field("krsi.iou_ret", &Self::extract_iou_ret),
-        field("krsi.res", &Self::extract_res),
-        field("krsi.target", &Self::extract_target),
-        field("krsi.linkdirfd", &Self::extract_linkdirfd),
-        field("krsi.olddirfd", &Self::extract_olddirfd),
-        field("krsi.newdirfd", &Self::extract_newdirfd),
-        field("krsi.dirfd", &Self::extract_dirfd),
-        field("krsi.linkpath", &Self::extract_linkpath),
-        field("krsi.path", &Self::extract_path),
-        field("krsi.oldpath", &Self::extract_oldpath),
-        field("krsi.newpath", &Self::extract_newpath),
-        field("krsi.cip", &Self::extract_cip),
-        field("krsi.sip", &Self::extract_sip),
-        field("krsi.cport", &Self::extract_cport),
-        field("krsi.sport", &Self::extract_sport),
+        field("krsi.name", &Self::extract_fd_name).with_description(
+"Availability: `krsi_open`, `krsi_connect`.
+Per-event descriptions:
+- `krsi_open`: full path to file
+- `krsi_connect`: connection display name (e.g. `127.0.0.1:54321->10.0.0.1:8000`)"),
+        field("krsi.fd", &Self::extract_fd).with_description(
+"Availability: `krsi_open`, `krsi_socket`, `krsi_connect`.
+Description: fd number (if available)"),
+        field("krsi.file_index", &Self::extract_file_index).with_description(
+"Availability: `krsi_open`, `krsi_socket`, `krsi_connect`.
+Description: file index number (if available)"),
+        field("krsi.flags", &Self::extract_flags).with_description(
+"Availability: `krsi_open`, `krsi_linkat`, `krsi_unlinkat`.
+Per-event descriptions:
+- `krsi_open`: open* flags, equivalent to open* syscall family flags
+- `krsi_linkat`: linkat flags
+- `krsi_unlinkat`: unlinkat flags"),
+        field("krsi.mode", &Self::extract_mode).with_description(
+"Availability: `krsi_open`, `krsi_mkdirat`.
+Per-event descriptions:
+- `krsi_open`: open file mode
+- `krsi_mkdirat`: mkdirat mode, indicating permission to use"),
+        field("krsi.dev", &Self::extract_dev).with_description(
+"Availability: `krsi_open`.
+Per-event descriptions:
+- `krsi_open`: file device number"),
+        field("krsi.ino", &Self::extract_ino).with_description(
+"Availability: `krsi_open`.
+Per-event descriptions:
+- `krsi_open`: file inode number"),
+        field("krsi.domain", &Self::extract_domain).with_description(
+"Availability: `krsi_socket`.
+Per-event descriptions:
+- `krsi_socket`: socket domain"),
+        field("krsi.type", &Self::extract_type).with_description(
+"Availability: `krsi_socket`.
+Per-event descriptions:
+- `krsi_socket`: socket type"),
+        field("krsi.iou_ret", &Self::extract_iou_ret).with_description(
+"Availability: `krsi_open`, `krsi_socket`, `krsi_connect`, `krsi_symlinkat`, `krsi_linkat`, \
+`krsi_unlinkat`, `krsi_mkdirat`.
+Description: io_uring internal return value (if available)"),
+        field("krsi.res", &Self::extract_res).with_description(
+"Availability: `krsi_connect`, `krsi_symlinkat`, `krsi_linkat`, `krsi_unlinkat`, `krsi_mkdirat`.
+Description: `operation return value (if available)"),
+        field("krsi.target", &Self::extract_target).with_description(
+"Availability: `krsi_symlinkat`.
+Per-event descriptions:
+- `krsi_symlinkat`: symbolic link target path"),
+        field("krsi.linkdirfd", &Self::extract_linkdirfd).with_description(
+"Availability: `krsi_symlinkat`.
+Per-event descriptions:
+- `krsi_symlinkat`: symbolic link dir fd"),
+        field("krsi.linkpath", &Self::extract_linkpath).with_description(
+"Availability: `krsi_symlinkat`.
+Per-event descriptions:
+- `krsi_symlinkat`: symbolic link path"),
+        field("krsi.olddirfd", &Self::extract_olddirfd).with_description(
+"Availability: `krsi_linkat`.
+Per-event descriptions:
+- `krsi_linkat`: dir fd for the target path"),
+        field("krsi.newdirfd", &Self::extract_newdirfd).with_description(
+"Availability: `krsi_linkat`.
+Per-event descriptions:
+- `krsi_linkat`: dir fd for the link path"),
+        field("krsi.dirfd", &Self::extract_dirfd).with_description(
+"Availability: `krsi_unlinkat`, `krsi_mkdirat`.
+Description: dir fd of the path"),
+        field("krsi.path", &Self::extract_path).with_description(
+"Availability: `krsi_unlinkat`, `krsi_mkdirat`.
+Per-event descriptions:
+- `krsi_unlinkat`: path to be unlinked
+- `krsi_mkdirat`: path to the directory to be created"),
+        field("krsi.oldpath", &Self::extract_oldpath).with_description(
+"Availability: `krsi_linkat`.
+Per-event descriptions:
+- `krsi_linkat`: target path"),
+        field("krsi.newpath", &Self::extract_newpath).with_description(
+"Availability: `krsi_linkat`.
+Per-event descriptions:
+- `krsi_linkat`: link path"),
+        field("krsi.cip", &Self::extract_cip).with_description(
+"Availability: `krsi_connect`.
+Per-event descriptions:
+- `krsi_connect`: client IP address"),
+        field("krsi.sip", &Self::extract_sip).with_description(
+"Availability: `krsi_connect`.
+Per-event descriptions:
+- `krsi_connect`: server IP address"),
+        field("krsi.cport", &Self::extract_cport).with_description(
+"Availability: `krsi_connect`.
+Per-event descriptions:
+- `krsi_connect`: client port"),
+        field("krsi.sport", &Self::extract_sport).with_description(
+"Availability: `krsi_connect`.
+Per-event descriptions:
+- `krsi_connect`: server port"),
     ];
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

/area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds support for automatic generation of `krsi` plugin's field extraction. Moreover, it adds support for handling multi-line field extraction descriptions.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
