### PR TITLE
fix(plugins/krsi/krsi-ebpf): send only interesting payload

### DIFF
--- a/plugins/krsi/krsi-ebpf/src/auxmap.rs
+++ b/plugins/krsi/krsi-ebpf/src/auxmap.rs
@@ -461,7 +461,7 @@ impl AuxiliaryMap {
             return;
         }
 
-        let _ =
-            shared_state::events_ringbuf().output(self.data.as_ref(), BPF_RB_FORCE_WAKEUP as u64);
+        let evt = &self.data.as_ref()[..self.payload_pos as usize];
+        let _ = shared_state::events_ringbuf().output(evt, BPF_RB_FORCE_WAKEUP as u64);
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes the eBPF event submission by only sending the interesting payload, instead of sending the entire auxiliary map buffer.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
