### PR TITLE
refactor(plugins/krsi/krsi-ebpf): remove auxbuf dep on ringbuf

### DIFF
--- a/plugins/krsi/krsi-ebpf/src/operations/bind.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/bind.rs
@@ -54,7 +54,7 @@ use krsi_ebpf_core::{wrap_arg, IoAsyncMsghdr, IoKiocb, Sockaddr};
 use crate::{
     iouring, shared_state,
     shared_state::op_info::{BindData, OpInfo},
-    FileDescriptor,
+    submit_event, FileDescriptor,
 };
 
 #[fentry]
@@ -110,7 +110,7 @@ fn try_io_bind_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_file_descriptor_param(*file_descriptor);
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }
 
@@ -143,6 +143,6 @@ fn try___sys_bind_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_file_descriptor_param(file_descriptor);
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }

--- a/plugins/krsi/krsi-ebpf/src/operations/connect.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/connect.rs
@@ -50,7 +50,7 @@ use krsi_ebpf_core::{wrap_arg, File, IoKiocb, Sockaddr, Socket, Wrap};
 use crate::{
     defs, iouring, shared_state,
     shared_state::op_info::{ConnectData, OpInfo},
-    FileDescriptor,
+    submit_event, FileDescriptor,
 };
 
 #[fentry]
@@ -133,7 +133,7 @@ fn try___sys_connect_file_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_file_descriptor_param(op_data.file_descriptor);
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }
 
@@ -172,7 +172,7 @@ fn try_io_connect_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_file_descriptor_param(op_data.file_descriptor);
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }
 

--- a/plugins/krsi/krsi-ebpf/src/operations/linkat.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/linkat.rs
@@ -55,6 +55,7 @@ use krsi_ebpf_core::{wrap_arg, Filename};
 use crate::{
     defs, scap, shared_state,
     shared_state::op_info::{LinkatData, OpInfo},
+    submit_event,
 };
 
 #[fentry]
@@ -116,7 +117,7 @@ fn try_do_linkat_x(ctx: FExitContext) -> Result<u32, i64> {
         // Parameter 7: iou_ret.
         auxbuf.store_empty_param();
         auxbuf.finalize_event_header();
-        auxbuf.submit_event();
+        submit_event(auxbuf.as_bytes()?);
     }
 
     Ok(0)
@@ -140,6 +141,6 @@ fn try_io_linkat_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_param(iou_ret);
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }

--- a/plugins/krsi/krsi-ebpf/src/operations/mkdirat.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/mkdirat.rs
@@ -54,6 +54,7 @@ use krsi_ebpf_core::{wrap_arg, Filename};
 use crate::{
     defs, scap, shared_state,
     shared_state::op_info::{MkdiratData, OpInfo},
+    submit_event,
 };
 
 #[fentry]
@@ -107,7 +108,7 @@ fn try_do_mkdirat_x(ctx: FExitContext) -> Result<u32, i64> {
         // Parameter 5: iou_ret.
         auxbuf.store_empty_param();
         auxbuf.finalize_event_header();
-        auxbuf.submit_event();
+        submit_event(auxbuf.as_bytes()?);
     }
 
     Ok(0)
@@ -131,6 +132,6 @@ fn try_io_mkdirat_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_param(iou_ret);
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }

--- a/plugins/krsi/krsi-ebpf/src/operations/open.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/open.rs
@@ -75,7 +75,7 @@ use krsi_ebpf_core::{wrap_arg, File};
 use crate::{
     defs, files, scap, shared_state,
     shared_state::op_info::{OpInfo, OpenData},
-    FileDescriptor,
+    submit_event, FileDescriptor,
 };
 
 #[fentry]
@@ -201,7 +201,7 @@ fn try_openat2_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_param(iou_ret);
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }
 
@@ -231,6 +231,6 @@ fn try_do_sys_openat2_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_empty_param();
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }

--- a/plugins/krsi/krsi-ebpf/src/operations/renameat.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/renameat.rs
@@ -66,6 +66,7 @@ use krsi_ebpf_core::{wrap_arg, Filename};
 use crate::{
     defs, scap, shared_state,
     shared_state::op_info::{OpInfo, RenameatData},
+    submit_event,
 };
 
 #[fentry]
@@ -128,7 +129,7 @@ fn try_do_renameat2_x(ctx: FExitContext) -> Result<u32, i64> {
         // Parameter 7: iou_ret.
         auxbuf.store_empty_param();
         auxbuf.finalize_event_header();
-        auxbuf.submit_event();
+        submit_event(auxbuf.as_bytes()?);
     }
 
     Ok(0)
@@ -152,6 +153,6 @@ fn try_io_renameat_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_param(iou_ret);
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }

--- a/plugins/krsi/krsi-ebpf/src/operations/socket.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/socket.rs
@@ -43,7 +43,7 @@ use aya_ebpf::{cty::c_int, macros::fexit, programs::FExitContext};
 use krsi_common::EventType;
 use krsi_ebpf_core::{wrap_arg, IoKiocb, IoSocket};
 
-use crate::{defs, shared_state, FileDescriptor};
+use crate::{defs, shared_state, submit_event, FileDescriptor};
 
 #[fexit]
 fn io_socket_x(ctx: FExitContext) -> u32 {
@@ -91,7 +91,7 @@ fn try_io_socket_x(ctx: FExitContext) -> Result<u32, i64> {
     };
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }
 
@@ -149,6 +149,6 @@ fn try___sys_socket_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_param(sock_proto as u32);
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }

--- a/plugins/krsi/krsi-ebpf/src/operations/symlinkat.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/symlinkat.rs
@@ -55,6 +55,7 @@ use krsi_ebpf_core::{wrap_arg, Filename};
 use crate::{
     defs, scap, shared_state,
     shared_state::op_info::{OpInfo, SymlinkatData},
+    submit_event,
 };
 
 #[fentry]
@@ -108,7 +109,7 @@ fn try_do_symlinkat_x(ctx: FExitContext) -> Result<u32, i64> {
         // Parameter 5: iou_ret.
         auxbuf.store_empty_param();
         auxbuf.finalize_event_header();
-        auxbuf.submit_event();
+        submit_event(auxbuf.as_bytes()?);
     }
 
     Ok(0)
@@ -132,6 +133,6 @@ fn try_io_symlinkat_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_param(iou_ret);
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }

--- a/plugins/krsi/krsi-ebpf/src/operations/unlinkat.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/unlinkat.rs
@@ -54,6 +54,7 @@ use krsi_ebpf_core::{wrap_arg, Filename, IoKiocb, IoUnlink};
 use crate::{
     defs, scap, shared_state,
     shared_state::op_info::{OpInfo, UnlinkatData},
+    submit_event,
 };
 
 #[fentry]
@@ -141,7 +142,7 @@ fn try_do_unlinkat_x(ctx: FExitContext) -> Result<u32, i64> {
         // Parameter 5: iou_ret.
         auxbuf.store_empty_param();
         auxbuf.finalize_event_header();
-        auxbuf.submit_event();
+        submit_event(auxbuf.as_bytes()?);
     }
 
     Ok(0)
@@ -190,6 +191,6 @@ fn try_io_unlinkat_x(ctx: FExitContext) -> Result<u32, i64> {
     auxbuf.store_param(iou_ret);
 
     auxbuf.finalize_event_header();
-    auxbuf.submit_event();
+    submit_event(auxbuf.as_bytes()?);
     Ok(0)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR removes the dependency of auxbuf on the ring buffer.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
