### PR TITLE
refactor(plugins/krsi): remove `auxbuf` unsafe code using `zerocopy`

### DIFF
--- a/plugins/krsi/Cargo.lock
+++ b/plugins/krsi/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -664,6 +664,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.12",
  "tokio",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -672,7 +673,8 @@ version = "0.1.0"
 dependencies = [
  "aya",
  "bitflags",
- "cfg-if",
+ "zerocopy 0.8.25",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -686,6 +688,7 @@ dependencies = [
  "krsi-ebpf-core",
  "paste",
  "which",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -1454,7 +1457,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -1462,6 +1474,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/plugins/krsi/Cargo.toml
+++ b/plugins/krsi/Cargo.toml
@@ -25,8 +25,9 @@ aya-ebpf = { version = "0.1.1", default-features = false }
 aya-log = { version = "0.2.1", default-features = false }
 aya-log-ebpf = { version = "0.1.1", default-features = false }
 paste = { version = "1.0.15", default-features = false }
-
 anyhow = { version = "1", default-features = false }
+zerocopy = { version = "0.8.25", default-features = false }
+zerocopy-derive = { version = "0.8.25", default-features = false }
 # `std` feature is currently required to build `clap`.
 #
 # See https://github.com/clap-rs/clap/blob/61f5ee5/clap_builder/src/lib.rs#L15.

--- a/plugins/krsi/krsi-common/Cargo.toml
+++ b/plugins/krsi/krsi-common/Cargo.toml
@@ -24,8 +24,9 @@ user = ["aya"]
 
 [dependencies]
 aya = { workspace = true, optional = true }
-cfg-if = "1.0.0"
 bitflags = "2.9.0"
+zerocopy = { workspace = true }
+zerocopy-derive = { workspace = true }
 
 [lib]
 path = "src/lib.rs"

--- a/plugins/krsi/krsi-common/src/lib.rs
+++ b/plugins/krsi/krsi-common/src/lib.rs
@@ -17,6 +17,9 @@ limitations under the License.
 
 #![no_std]
 
+use zerocopy::native_endian::{U16, U32, U64};
+use zerocopy_derive::*;
+
 pub mod flags;
 pub mod scap;
 
@@ -60,12 +63,12 @@ impl TryFrom<u16> for EventType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, KnownLayout, Immutable, Unaligned, FromBytes, IntoBytes)]
 #[repr(C, packed)]
 pub struct EventHeader {
-    pub ts: u64,
-    pub tgid_pid: u64,
-    pub len: u32,
-    pub evt_type: EventType,
-    pub nparams: u32,
+    pub ts: U64,
+    pub tgid_pid: U64,
+    pub len: U32,
+    pub evt_type: U16,
+    pub nparams: U32,
 }

--- a/plugins/krsi/krsi-ebpf/Cargo.toml
+++ b/plugins/krsi/krsi-ebpf/Cargo.toml
@@ -27,6 +27,7 @@ cfg-if = "1.0.0"
 aya-ebpf = { workspace = true }
 aya-log-ebpf = { workspace = true }
 paste = { workspace = true }
+zerocopy = { workspace = true }
 
 [build-dependencies]
 which = { workspace = true }

--- a/plugins/krsi/krsi/Cargo.toml
+++ b/plugins/krsi/krsi/Cargo.toml
@@ -36,6 +36,7 @@ num_cpus = "1.13.0"
 byteorder = "1.5.0"
 thiserror = "2.0.12"
 paste = {workspace = true}
+zerocopy = { workspace = true }
 
 [build-dependencies]
 # TODO(https://github.com/rust-lang/cargo/issues/12375): this should be an artifact dependency, but


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR removes unsafe code from `auxbuf` by using `zerocopy` crate to perform conversions between bytes and structs as well as unaligned read and write operations.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
