### PR TITLE
refactor(plugins/krsi/krsi-ebpf): use slices in auxbuf code

### DIFF
--- a/plugins/krsi/krsi-ebpf/src/main.rs
+++ b/plugins/krsi/krsi-ebpf/src/main.rs
@@ -19,6 +19,7 @@ limitations under the License.
 #![no_main]
 
 use aya_ebpf::{macros::fexit, programs::FExitContext};
+use krsi_common::EventHeader;
 use krsi_ebpf_core::{wrap_arg, File};
 use operations::*;
 
@@ -80,5 +81,10 @@ fn io_fixed_fd_install_x(ctx: FExitContext) -> u32 {
     res
 }
 
-/// Event maximum length. This must be a power of 2.
+/// Event maximum length.
+///
+/// Its lengths must be at least equal to the event header length.
 pub const MAX_EVENT_LEN: usize = 8 * 1024;
+
+// Enforce `MAX_EVENT_LEN` constraints.
+const _: () = assert!(MAX_EVENT_LEN >= size_of::<EventHeader>());

--- a/plugins/krsi/krsi-ebpf/src/operations/bind.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/bind.rs
@@ -88,8 +88,7 @@ fn try_io_bind_x(ctx: FExitContext) -> Result<u32, i64> {
     let _ = shared_state::op_info::remove(pid);
 
     let auxbuf = shared_state::auxiliary_buffer().ok_or(1)?;
-    let mut writer = auxbuf.writer();
-    writer_helpers::preload_event_header(&mut writer, EventType::Bind);
+    let mut writer = writer_helpers::writer(auxbuf, EventType::Bind)?;
 
     // Parameter 1: iou_ret.
     let iou_ret: i64 = unsafe { ctx.arg(2) };
@@ -126,8 +125,7 @@ fn __sys_bind_x(ctx: FExitContext) -> u32 {
 #[allow(non_snake_case)]
 fn try___sys_bind_x(ctx: FExitContext) -> Result<u32, i64> {
     let auxbuf = shared_state::auxiliary_buffer().ok_or(1)?;
-    let mut writer = auxbuf.writer();
-    writer_helpers::preload_event_header(&mut writer, EventType::Bind);
+    let mut writer = writer_helpers::writer(auxbuf, EventType::Bind)?;
 
     // Parameter 1: iou_ret.
     writer.store_empty_param()?;

--- a/plugins/krsi/krsi-ebpf/src/operations/linkat.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/linkat.rs
@@ -87,8 +87,7 @@ fn try_do_linkat_x(ctx: FExitContext) -> Result<u32, i64> {
     }
 
     let auxbuf = shared_state::auxiliary_buffer().ok_or(1)?;
-    let mut writer = auxbuf.writer();
-    writer_helpers::preload_event_header(&mut writer, EventType::Linkat);
+    let mut writer = writer_helpers::writer(auxbuf, EventType::Linkat)?;
 
     // Parameter 1: olddirfd.
     let olddirfd: i32 = unsafe { ctx.arg(0) };
@@ -119,6 +118,9 @@ fn try_do_linkat_x(ctx: FExitContext) -> Result<u32, i64> {
         writer.store_empty_param()?;
         writer.finalize_event_header();
         helpers::submit_event(auxbuf.as_bytes()?);
+    } else {
+        let writer_state = writer.save();
+        auxbuf.save_writer_state(writer_state);
     }
 
     Ok(0)
@@ -134,9 +136,9 @@ fn try_io_linkat_x(ctx: FExitContext) -> Result<u32, i64> {
     let _ = shared_state::op_info::remove(pid);
 
     let auxbuf = shared_state::auxiliary_buffer().ok_or(1)?;
-    let mut writer = auxbuf.writer();
-    // Don't call writer.preload_event_header, because we want to continue to append to the work
-    // already done on `fexit:do_linkat`.
+    // Don't call auxbuf.writer(), because we want to continue to append to the work already done on
+    // `fexit:do_linkat`.
+    let mut writer = auxbuf.resume_writer()?;
 
     // Parameter 7: iou_ret.
     let iou_ret: i64 = unsafe { ctx.arg(2) };

--- a/plugins/krsi/krsi-ebpf/src/operations/mkdirat.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/mkdirat.rs
@@ -86,8 +86,7 @@ fn try_do_mkdirat_x(ctx: FExitContext) -> Result<u32, i64> {
     }
 
     let auxbuf = shared_state::auxiliary_buffer().ok_or(1)?;
-    let mut writer = auxbuf.writer();
-    writer_helpers::preload_event_header(&mut writer, EventType::Mkdirat);
+    let mut writer = writer_helpers::writer(auxbuf, EventType::Mkdirat)?;
 
     // Parameter 1: dirfd.
     let dirfd: i32 = unsafe { ctx.arg(0) };
@@ -110,6 +109,9 @@ fn try_do_mkdirat_x(ctx: FExitContext) -> Result<u32, i64> {
         writer.store_empty_param()?;
         writer.finalize_event_header();
         helpers::submit_event(auxbuf.as_bytes()?);
+    } else {
+        let writer_state = writer.save();
+        auxbuf.save_writer_state(writer_state);
     }
 
     Ok(0)
@@ -125,9 +127,9 @@ fn try_io_mkdirat_x(ctx: FExitContext) -> Result<u32, i64> {
     let _ = shared_state::op_info::remove(pid);
 
     let auxbuf = shared_state::auxiliary_buffer().ok_or(1)?;
-    let mut writer = auxbuf.writer();
-    // Don't call writer.preload_event_header, because we want to continue to append to the work
-    // already done on `fexit:do_mkdirat`.
+    // Don't call auxbuf.writer(), because we want to continue to append to the work already done on
+    // `fexit:do_mkdirat`.
+    let mut writer = auxbuf.resume_writer()?;
 
     // Parameter 5: iou_ret.
     let iou_ret: i64 = unsafe { ctx.arg(2) };

--- a/plugins/krsi/krsi-ebpf/src/operations/socket.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/socket.rs
@@ -56,8 +56,7 @@ fn io_socket_x(ctx: FExitContext) -> u32 {
 
 fn try_io_socket_x(ctx: FExitContext) -> Result<u32, i64> {
     let auxbuf = shared_state::auxiliary_buffer().ok_or(1)?;
-    let mut writer = auxbuf.writer();
-    writer_helpers::preload_event_header(&mut writer, EventType::Socket);
+    let mut writer = writer_helpers::writer(auxbuf, EventType::Socket)?;
 
     let req: IoKiocb = wrap_arg(unsafe { ctx.arg(0) });
     let sock = req.cmd_as::<IoSocket>();
@@ -131,8 +130,7 @@ fn __sys_socket_x(ctx: FExitContext) -> u32 {
 #[allow(non_snake_case)]
 fn try___sys_socket_x(ctx: FExitContext) -> Result<u32, i64> {
     let auxbuf = shared_state::auxiliary_buffer().ok_or(1)?;
-    let mut writer = auxbuf.writer();
-    writer_helpers::preload_event_header(&mut writer, EventType::Socket);
+    let mut writer = writer_helpers::writer(auxbuf, EventType::Socket)?;
 
     // Parameter 1: iou_ret.
     writer.store_empty_param()?;

--- a/plugins/krsi/krsi-ebpf/src/operations/unlinkat.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/unlinkat.rs
@@ -118,8 +118,7 @@ fn try_do_unlinkat_x(ctx: FExitContext) -> Result<u32, i64> {
     };
 
     let auxbuf = shared_state::auxiliary_buffer().ok_or(1)?;
-    let mut writer = auxbuf.writer();
-    writer_helpers::preload_event_header(&mut writer, EventType::Unlinkat);
+    let mut writer = writer_helpers::writer(auxbuf, EventType::Unlinkat)?;
 
     // Parameter 1: dirfd.
     let dirfd: i32 = unsafe { ctx.arg(0) };
@@ -144,6 +143,9 @@ fn try_do_unlinkat_x(ctx: FExitContext) -> Result<u32, i64> {
         writer.store_empty_param()?;
         writer.finalize_event_header();
         helpers::submit_event(auxbuf.as_bytes()?);
+    } else {
+        let writer_state = writer.save();
+        auxbuf.save_writer_state(writer_state);
     }
 
     Ok(0)
@@ -184,9 +186,9 @@ fn try_io_unlinkat_x(ctx: FExitContext) -> Result<u32, i64> {
     let _ = shared_state::op_info::remove(pid);
 
     let auxbuf = shared_state::auxiliary_buffer().ok_or(1)?;
-    let mut writer = auxbuf.writer();
-    // Don't call writer.preload_event_header, because we want to continue to append to the work
-    // already done on `fexit:do_unlinkat` or `fexit:do_rmdir`.
+    // Don't call auxbuf.writer(), because we want to continue to append to the work already done on
+    // `fexit:do_unlinkat` or `fexit:do_rmdir`.
+    let mut writer = auxbuf.resume_writer()?;
 
     // Parameter 5: iou_ret.
     let iou_ret: i64 = unsafe { ctx.arg(2) };

--- a/plugins/krsi/krsi-ebpf/src/operations/writer_helpers.rs
+++ b/plugins/krsi/krsi-ebpf/src/operations/writer_helpers.rs
@@ -13,17 +13,17 @@ use krsi_ebpf_core::{
 };
 
 use crate::{
-    auxbuf::{ParamWriter, Writer},
+    auxbuf::{AuxiliaryBuffer, ParamWriter, Writer},
     defs, scap, shared_state, sockets, FileDescriptor,
 };
 
-/// Wrapper around [Writer::preload_event_header] just collecting some additional
-/// information before calling it.
-pub fn preload_event_header(writer: &mut Writer, event_type: EventType) {
+/// Wrapper around [AuxiliaryBuffer::writer] just collecting some additional information before
+/// calling it.
+pub fn writer(auxbuf: &mut AuxiliaryBuffer, event_type: EventType) -> Result<Writer, i64> {
     let ts = shared_state::boot_time() + unsafe { bpf_ktime_get_boot_ns() };
     let tgid_pid = bpf_get_current_pid_tgid();
     let nparams = get_event_num_params(event_type) as u32;
-    writer.preload_event_header(ts, tgid_pid, event_type, nparams);
+    auxbuf.writer(ts, tgid_pid, event_type, nparams)
 }
 
 fn get_event_num_params(event_type: EventType) -> u8 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

/kind design

/kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR replaces the usage of offsets with slices in `auxbuf`. This enables better compile-time checks thanks to the language native support for slice types.
In order to restore a previous auxbuf writer state, the user must now first cache its state using the `Writer::save()` and `AuxiliaryBuffer::save_writer_state()` APIs; then it can restore it using the `AuxiliaryBuffer::resume_writer()` API.

Moreover, it makes constants governing the auxbuf limits more precise, and adds documentation related to some auxbuf APIs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
