### PR TITLE
fix(plugins/container): avoid possible nil ptr dereference in cri and containerd engines

### DIFF
--- a/plugins/container/go-worker/pkg/container/containerd.go
+++ b/plugins/container/go-worker/pkg/container/containerd.go
@@ -301,6 +301,10 @@ func (c *containerdEngine) Listen(ctx context.Context, wg *sync.WaitGroup) (<-ch
 			case <-ctx.Done():
 				return
 			case ev := <-eventsCh:
+				if ev == nil {
+					// Nothing to do for null event
+					break
+				}
 				var (
 					id       string
 					isCreate bool

--- a/plugins/container/go-worker/pkg/container/cri.go
+++ b/plugins/container/go-worker/pkg/container/cri.go
@@ -462,6 +462,10 @@ func (c *criEngine) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan even
 			case <-ctx.Done():
 				return
 			case evt := <-containerEventsCh:
+				if evt == nil {
+					// Nothing to do for nil event
+					break
+				}
 				switch evt.ContainerEventType {
 				case v1.ContainerEventType_CONTAINER_CREATED_EVENT:
 					if !config.IsHookEnabled(config.HookCreate) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

CRI and Containerd listeners actually push pointers to events; we need to check for `evt != nil` before dereferencing it.

**Which issue(s) this PR fixes**:

See https://github.com/falcosecurity/falco/issues/3601

Fixes #

**Special notes for your reviewer**:
