### PR TITLE
fix(plugins/container): avoid crash when healthcheck probe args is null

### DIFF
--- a/plugins/container/CMakeLists.txt
+++ b/plugins/container/CMakeLists.txt
@@ -9,7 +9,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 # project metadata
 project(
         container
-        VERSION 0.3.0
+        VERSION 0.3.1
         DESCRIPTION "Falco container metadata enrichment Plugin"
         LANGUAGES CXX)
 

--- a/plugins/container/src/container_info_json.cpp
+++ b/plugins/container/src/container_info_json.cpp
@@ -45,28 +45,6 @@ false, "host_network": false, "host_pid": false, "id": "32a1026ccb88", "image":
 }
 */
 
-void from_json(const nlohmann::json& j, container_health_probe& probe)
-{
-    probe.m_args = j.value("args", std::vector<std::string>{});
-    probe.m_exe = j.value("exe", "");
-}
-
-void from_json(const nlohmann::json& j, container_mount_info& mount)
-{
-    mount.m_source = j.value("Source", "");
-    mount.m_dest = j.value("Destination", "");
-    mount.m_mode = j.value("Mode", "");
-    mount.m_rdwr = j.value("RW", false);
-    mount.m_propagation = j.value("Propagation", "");
-}
-
-void from_json(const nlohmann::json& j, container_port_mapping& port)
-{
-    port.m_host_ip = j.value("HostIp", 0);
-    port.m_host_port = j.value("HostPort", 0);
-    port.m_container_port = j.value("ContainerPort", 0);
-}
-
 /*
  * Since some old json pushed json entries like:
  * "pod_sandbox_labels": null
@@ -85,6 +63,28 @@ static inline void object_from_json(const nlohmann::json& j, const char* key,
     {
         obj = T();
     }
+}
+
+void from_json(const nlohmann::json& j, container_health_probe& probe)
+{
+    object_from_json(j, "args", probe.m_args);
+    probe.m_exe = j.value("exe", "");
+}
+
+void from_json(const nlohmann::json& j, container_mount_info& mount)
+{
+    mount.m_source = j.value("Source", "");
+    mount.m_dest = j.value("Destination", "");
+    mount.m_mode = j.value("Mode", "");
+    mount.m_rdwr = j.value("RW", false);
+    mount.m_propagation = j.value("Propagation", "");
+}
+
+void from_json(const nlohmann::json& j, container_port_mapping& port)
+{
+    port.m_host_ip = j.value("HostIp", 0);
+    port.m_host_port = j.value("HostPort", 0);
+    port.m_container_port = j.value("ContainerPort", 0);
 }
 
 void from_json(const nlohmann::json& j, std::shared_ptr<container_info>& cinfo)

--- a/plugins/container/test/container_info_json.cpp
+++ b/plugins/container/test/container_info_json.cpp
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+#include <container_info.h>
+
+TEST(container_info_json, null_healthcheck)
+{
+    std::string json = R"({
+    "container": {
+        "type": 0,
+        "id": "fee3a77211e1",
+        "User": "root",
+        "cni_json": "",
+        "cpu_period": 100000,
+        "cpu_quota": 100000,
+        "cpu_shares": 1024,
+        "cpuset_cpu_count": 0,
+        "created_time": 1749101763,
+        "env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "TZ=Asia/Shanghai"
+        ],
+        "full_id": "*",
+        "host_ipc": false,
+        "host_network": true,
+        "host_pid": true,
+        "ip": "",
+        "size": -1,
+        "is_pod_sandbox": false,
+        "labels": {
+
+        },
+        "memory_limit": 2147483648,
+        "swap_limit": 4294967296,
+        "pod_sandbox_id": "",
+        "privileged": true,
+        "pod_sandbox_labels": null,
+        "port_mappings": [
+
+        ],
+        "Mounts": [
+
+        ],
+        "Healthcheck": {
+            "exe": "/usr/bin/healthcheck",
+            "args": null
+        }
+    }
+})";
+    auto json_event = nlohmann::json::parse(json);
+    ASSERT_NO_THROW(json_event.get<std::shared_ptr<container_info>>());
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

When healthcheck `args` key exists but is `null` the container plugin raises an exception.
While at it, i also added a test case for this.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
