### PR TITLE
chore(plugins/container): avoid building unneeded RE-flex targets

### DIFF
--- a/plugins/container/CMakeLists.txt
+++ b/plugins/container/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "release")

--- a/plugins/container/cmake/modules/reflex.cmake
+++ b/plugins/container/cmake/modules/reflex.cmake
@@ -3,5 +3,7 @@ FetchContent_Declare(
         reflex
         GIT_REPOSITORY https://github.com/Genivia/RE-flex.git
         GIT_TAG v5.3.0
+        UPDATE_DISCONNECTED TRUE
+        EXCLUDE_FROM_ALL TRUE
 )
 FetchContent_MakeAvailable(reflex)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**

/area plugins
/area build

**What this PR does / why we need it**:
Building the container plugin without specifying the `container` target makes it build `reflex` too, which is not needed, and fails too:
```
❯ cmake -B build -S .
...
❯ cmake --build build --parallel
...
[ 98%] Linking CXX executable reflex
/usr/bin/ld: libreflex_static_lib.a(unicode.cpp.o): in function `reflex::Unicode::toupper(int)':
unicode.cpp:(.text+0x6d5): undefined reference to `reflex::Unicode::Tables::toupper(int)'
/usr/bin/ld: libreflex_static_lib.a(unicode.cpp.o): in function `reflex::Unicode::tolower(int)':
unicode.cpp:(.text+0x6e5): undefined reference to `reflex::Unicode::Tables::tolower(int)'
collect2: error: ld returned 1 exit status
gmake[2]: *** [_deps/reflex-build/CMakeFiles/Reflex.dir/build.make:98: _deps/reflex-build/reflex] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:271: _deps/reflex-build/CMakeFiles/Reflex.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
[100%] Linking CXX shared library libreflex_shared_lib.so
[100%] Built target ReflexLib
gmake: *** [Makefile:136: all] Error 2
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
