### PR TITLE
chore(container/make): add CMAKE_EXPORT_COMPILE_COMMANDS

### DIFF
--- a/plugins/container/Makefile
+++ b/plugins/container/Makefile
@@ -43,7 +43,7 @@ clean:
 # This Makefile requires CMake installed on the system
 .PHONY: $(OUTPUT)
 $(OUTPUT):
-	cmake -B build -S . && cmake --build build --target $(NAME) --parallel 6 --config Release && cp $(OUTPUT_FILE) $(OUTPUT)
+	cmake -B build -S . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && cmake --build build --target $(NAME) --parallel 6 --config Release && cp $(OUTPUT_FILE) $(OUTPUT)
 
 .PHONY: test
 test: $(OUTPUT)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:
-> container plugin <-
Generate the compile commands by default, to improve the development experience (e.g. with clangd)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
