### PR TITLE
fix(plugins/container): properly cleanup stale container cache entries for exiting containers

### DIFF
--- a/plugins/container/CMakeLists.txt
+++ b/plugins/container/CMakeLists.txt
@@ -9,7 +9,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 # project metadata
 project(
         container
-        VERSION 0.3.1
+        VERSION 0.3.2
         DESCRIPTION "Falco container metadata enrichment Plugin"
         LANGUAGES CXX)
 

--- a/plugins/container/src/caps/parse/parse.cpp
+++ b/plugins/container/src/caps/parse/parse.cpp
@@ -177,7 +177,9 @@ bool my_plugin::parse_exit_process_event(
     std::string container_id;
 
     // retrieve the thread entry associated with this thread id,
-    // then, fetch the container_id and remove it from the container cache.
+    // check if vpid is 1, so if this is an init process,
+    // then, fetch the container_id and if not empty,
+    // remove its associated entry from the container cache.
     try
     {
         auto thread_entry = m_threads_table.get_entry(tr, thread_id);
@@ -187,6 +189,9 @@ bool my_plugin::parse_exit_process_event(
             m_container_id_field.read_value(tr, thread_entry, container_id);
             if(!container_id.empty())
             {
+                m_logger.log(fmt::format("Removing container from procexit: {}",
+                                         container_id),
+                             falcosecurity::_internal::SS_PLUGIN_LOG_SEV_TRACE);
                 m_containers.erase(container_id);
             }
         }

--- a/plugins/container/src/consts.h
+++ b/plugins/container/src/consts.h
@@ -35,5 +35,6 @@ constexpr auto PPME_SYSCALL_EXECVE_18_X = (_et)289;
 constexpr auto PPME_SYSCALL_EXECVE_19_X = (_et)293;
 constexpr auto PPME_SYSCALL_EXECVEAT_X = (_et)331;
 constexpr auto PPME_SYSCALL_CHROOT_X = (_et)267;
+constexpr auto PPME_PROCEXIT_1_E = (_et)186;
 
 #define SHORT_ID_LEN 12

--- a/plugins/container/src/macros.h.in
+++ b/plugins/container/src/macros.h.in
@@ -60,7 +60,7 @@ limitations under the License.
                 PPME_SYSCALL_CLONE3_X, PPME_SYSCALL_EXECVE_16_X,               \
                 PPME_SYSCALL_EXECVE_17_X, PPME_SYSCALL_EXECVE_18_X,            \
                 PPME_SYSCALL_EXECVE_19_X, PPME_SYSCALL_EXECVEAT_X,             \
-                PPME_SYSCALL_CHROOT_X                                          \
+                PPME_SYSCALL_CHROOT_X, PPME_PROCEXIT_1_E                                          \
     }
 
 #define PARSE_EVENT_SOURCES                                                    \

--- a/plugins/container/src/plugin.h
+++ b/plugins/container/src/plugin.h
@@ -87,6 +87,7 @@ class my_plugin
     bool parse_container_json_event(const falcosecurity::parse_event_input& in);
     bool
     parse_container_json_2_event(const falcosecurity::parse_event_input& in);
+    bool parse_exit_process_event(const falcosecurity::parse_event_input& in);
     bool parse_new_process_event(const falcosecurity::parse_event_input& in);
     bool parse_event(const falcosecurity::parse_event_input& in);
 #endif


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

Normally, we receive "removed" events from the container runtime; but that's not the case for libvirt-lxc, lxc and bpm.
In these cases, properly cleanup container cache upon init_container process exiting.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
