### PR TITLE
fix(plugins/k8saudit-eks): Improve handling of events with the same timestamp

### DIFF
--- a/shared/go/aws/cloudwatchlogs/cloudwatch.go
+++ b/shared/go/aws/cloudwatchlogs/cloudwatch.go
@@ -120,11 +120,11 @@ func (client *Client) Open(context context.Context, filter *Filter, options *Opt
 	go func() {
 		defer close(eventC)
 		defer close(errC)
+		var (
+			lastEventTime     int64
+			lastIngestionTime int64
+		)
 		for {
-			var (
-				lastEventTime     int64
-				lastIngestionTime int64
-			)
 			err := client.CloudWatchLogs.FilterLogEventsPagesWithContext(aws.Context(context), filters,
 				func(page *cloudwatchlogs.FilterLogEventsOutput, lastPage bool) bool {
 					for _, i := range page.Events {

--- a/shared/go/aws/cloudwatchlogs/cloudwatch.go
+++ b/shared/go/aws/cloudwatchlogs/cloudwatch.go
@@ -129,7 +129,7 @@ func (client *Client) Open(context context.Context, filter *Filter, options *Opt
 				func(page *cloudwatchlogs.FilterLogEventsOutput, lastPage bool) bool {
 					for _, i := range page.Events {
 						eventC <- i
-						if *filters.StartTime == *i.Timestamp && lastIngestionTime > *i.IngestionTime {
+						if *filters.StartTime == *i.Timestamp && lastIngestionTime >= *i.IngestionTime {
 							continue
 						}
 						if lastEventTime <= *i.Timestamp {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

Cloudwatch events can have the same timestamp but different IngestionTime, making the logic of polling with `filters.SetStartTime(lastEventTime + 1)` flawed against these late events.

The idea here is to query again the events from the `lastEventTime` and filter out any duplicates. This shouldn't have a relevant performance penalty since the number of events with the same timestamp is very small compared to the number of events fetched when the polling interval is in the order of seconds.

[According to the AWS docs for `FilterLogEvents`](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html):

> The returned log events are sorted by event timestamp, the timestamp when the event was ingested by CloudWatch Logs, and the ID of the PutLogEvents request.

Also:

> Partially full or empty pages don't necessarily mean that pagination is finished. If the results include a nextToken, there might be more log events available. You can return these additional log events by providing the nextToken in a subsequent FilterLogEvents operation. If the results don't include a nextToken, then pagination is finished. 

So I removed the page length check. `FilterLogEventsPagesWithContext` should also call the function with `lastPage` set to true, so doesn't make sense to have a separate check. 

```
- if len(page.Events) == 0 {
-     return false
- }
```

**Which issue(s) this PR fixes**:

Partially fixes https://github.com/falcosecurity/plugins/issues/893

**Special notes for your reviewer**:

In my tests I found that events with the same timestamp, can have up to 15s of difference in the `IngestionTime`. The number is probably larger since I only checked logs for a few hours.

This doesn't solve the issue completely because it depends on how large the polling interval is set. If the polling interval is 5 seconds and an event of the same timestamp takes 10s to be ingested by AWS, it will be missed anyways.