### PR TITLE
fix typo from #899

### DIFF
--- a/shared/go/aws/cloudwatchlogs/cloudwatch.go
+++ b/shared/go/aws/cloudwatchlogs/cloudwatch.go
@@ -134,7 +134,7 @@ func (client *Client) Open(context context.Context, filter *Filter, options *Opt
 						}
 						if lastEventTime <= *i.Timestamp {
 							if lastEventTime < *i.Timestamp {
-								lastIngestionTime = *i.IngestionTime
+								lastEventTime = *i.Timestamp
 							}
 							lastIngestionTime = *i.IngestionTime
 						}


### PR DESCRIPTION
There is a typo and `lastEventTime` is not updated at all. The line `lastIngestionTime = *i.IngestionTime` is duplicated. Sorry.

https://github.com/falcosecurity/plugins/pull/899
