### PR TITLE
fix(plugins/container): prevent CRI engine goroutine deadlock during shutdown

### DIFF
--- a/plugins/container/go-worker/pkg/container/cri.go
+++ b/plugins/container/go-worker/pkg/container/cri.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/config"
 	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 	remote "k8s.io/cri-client/pkg"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
 )
 
 const maxCNILen = 4096
@@ -449,7 +450,7 @@ func (c *criEngine) List(ctx context.Context) ([]event.Event, error) {
 // an error will be captured and passed to the caller.
 func (c *criEngine) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan event.Event, error) {
 	containerEventsCh := make(chan *v1.ContainerEventResponse)
-	containerEventsErrorCh := make(chan error)
+	containerEventsErrorCh := make(chan error, 1) // Buffered to prevent blocking
 	wg.Add(1)
 	go func() {
 		defer close(containerEventsCh)


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

https://github.com/falcosecurity/plugins/commit/59ae99b4a9f5d92b792744fcec9e466cd199d8f5 introduced an issue that made the container plugin hang during Falco shutdown (SIGINT) due to a race condition in the CRI engine where two goroutines compete (the  [`GetContainerEvents()` producer](https://github.com/falcosecurity/plugins/blob/ba34d95961637080d623bf633d95226c3c63f0b7/plugins/container/go-worker/pkg/container/cri.go#L458) and [the main event loop consumer](https://github.com/falcosecurity/plugins/blob/ba34d95961637080d623bf633d95226c3c63f0b7/plugins/container/go-worker/pkg/container/cri.go#L484)) for the same `containerEventsErrorCh` channel.

The problem has been present since v0.3.4.

Assuming the `containerEventsErrorCh` is meant to carry exactly one result (the return value from `GetContainerEvents()`), this PR makes `containerEventsErrorCh` buffered (size 1) to prevent the first goroutine from blocking when sending results, eliminating the deadlock during shutdown.



**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #934

**Special notes for your reviewer**:
