### PR TITLE
fix(container): Propagate engine initialization errors to the caller

### DIFF
--- a/plugins/container/go-worker/main_exe.go
+++ b/plugins/container/go-worker/main_exe.go
@@ -70,9 +70,10 @@ func main() {
 	fmt.Println("Starting worker")
 	cstr := C.CString(initCfg)
 	enabledSocks := C.CString("")
-	ptr := StartWorker((*[0]byte)(C.echo_cb), cstr, &enabledSocks)
+	errmsg := C.CString("")
+	ptr := StartWorker((*[0]byte)(C.echo_cb), cstr, &enabledSocks, &errmsg)
 	if ptr == nil {
-		fmt.Println("Failed to start worker; nothing configured?")
+		fmt.Println(fmt.Sprintf("Failed to start worker; nothing configured? %s", C.GoString(errmsg)))
 		os.Exit(1)
 	}
 	socks := C.GoString(enabledSocks)

--- a/plugins/container/src/caps/async/async.cpp
+++ b/plugins/container/src/caps/async/async.cpp
@@ -43,11 +43,22 @@ bool my_plugin::start_async_events(
     m_logger.log("starting async go-worker",
                  falcosecurity::_internal::SS_PLUGIN_LOG_SEV_DEBUG);
     nlohmann::json j(m_cfg);
+
     const char *enabled_engines = nullptr;
+    const char *err = nullptr;
+
     m_async_ctx = StartWorker(generate_async_event<ASYNC_HANDLER_GO_WORKER>,
-                              j.dump().c_str(), &enabled_engines);
+                              j.dump().c_str(), &enabled_engines, &err);
     m_logger.log(fmt::format("attached engine sockets: {}", enabled_engines),
                  falcosecurity::_internal::SS_PLUGIN_LOG_SEV_DEBUG);
+
+    if(err)
+    {
+        m_logger.log(fmt::format("failed to start async go-worker: {}", err),
+                     falcosecurity::_internal::SS_PLUGIN_LOG_SEV_ERROR);
+        free((void *)err);
+    }
+
     free((void *)enabled_engines);
 
     // Merge back pre-existing containers to our cache


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:
 
/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

If the specific container engine worker fails during initialization, the error is silently skipped, making it hard to troubleshoot the real problem. Instead, accumulate and bubble up all the errors to the async handler.

**Special notes for your reviewer**:
