### PR TITLE
fix(k8smeta): wait for the client to be done before destroying

### DIFF
--- a/plugins/k8smeta/src/plugin.cpp
+++ b/plugins/k8smeta/src/plugin.cpp
@@ -373,7 +373,7 @@ bool my_plugin::stop_async_events() noexcept
     {
         std::unique_lock<std::mutex> l(m_mu);
         m_async_thread_quit = true;
-        m_cv.notify_one();
+        m_cv.notify_all();
         // Release the lock
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix race condition on the K8sMetaClient, resulting in callbacks to be invoked after the client has been destroyed.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

I introduced a new flag `m_done`, because we need to wait for the `OnDone` callback to be completed, and `m_status_code` gets changed both on `OnDone` and `OnReadDone`.
