### PR TITLE
Register Edera zone plugin

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -677,3 +677,25 @@ plugins:
         source: awselb
       extraction:
         supported: true
+  - name: edera
+    description: A Falco plugin for forwarding libscap events out of Edera zones.
+    authors: Edera
+    contact: contact@edera.dev
+    maintainers:
+      - name: Edera
+        email: contact@edera.dev
+    keywords:
+      - edera
+      - containers
+      - audit-events
+      - kubernetes
+    url: https://github.com/edera-dev/falco_plugin/
+    rules_url: https://docs.edera.dev/guides/observability/falco-integration/
+    license: Apache-2.0
+    capabilities:
+      sourcing:
+        supported: true
+        id: 26
+        source: edera_zone
+      extraction:
+        supported: true


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation


**Any specific area of the project related to this PR?**
/area plugins
/area registry
/area documentation

**What this PR does / why we need it**:

Adds the [Edera Falco plugin](https://github.com/edera-dev/falco_plugin) to the Falco plugin registry.

[Docs](https://docs.edera.dev/guides/observability/falco-integration/)

**Special notes for your reviewer**:

I've proactively assigned `26` as the plugin ID as it's the next in the list, let me know if it should change.
