### PR TITLE
Bump go version in registry actions to 1.24

### DIFF
--- a/.github/workflows/registry.yaml
+++ b/.github/workflows/registry.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.24"
           check-latest: true
 
       - name: Build registry artifact tool


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**Any specific area of the project related to this PR?**

/area registry
/area build

**What this PR does / why we need it**:
Fix `registry` go version CI failures like this: https://github.com/falcosecurity/plugins/actions/runs/19436871153/job/55614360685?pr=1070