### PR TITLE
fix(container): add back support for Falco libs 0.21

### DIFF
--- a/plugins/container/src/caps/extract/extract.cpp
+++ b/plugins/container/src/caps/extract/extract.cpp
@@ -558,9 +558,10 @@ bool my_plugin::extract(const falcosecurity::extract_fields_input &in)
                 std::strcmp(ad.get_name(), ASYNC_EVENT_NAME_REMOVED) == 0;
     }
 
-    bool is_container_event{evt_type == PPME_CONTAINER_JSON_2_E ||
-                            is_container_async_event_create ||
-                            is_container_async_event_remove};
+    bool is_container_event{
+            evt_type == PPME_CONTAINER_E || evt_type == PPME_CONTAINER_JSON_E ||
+            evt_type == PPME_CONTAINER_JSON_2_E ||
+            is_container_async_event_create || is_container_async_event_remove};
     // As mentioned above, m_last_container might be null or relative to another
     // event. Check the timestamp.
     if(is_container_event && m_last_container.first == evt_reader.get_num())

--- a/plugins/container/src/consts.h
+++ b/plugins/container/src/consts.h
@@ -22,11 +22,16 @@ limitations under the License.
 // Sinsp events used in the plugin
 using _et = falcosecurity::event_type;
 constexpr auto PPME_ASYNCEVENT_E = (_et)402;
+constexpr auto PPME_CONTAINER_E = (_et)228;
+constexpr auto PPME_CONTAINER_JSON_E = (_et)272;
 constexpr auto PPME_CONTAINER_JSON_2_E = (_et)324;
 constexpr auto PPME_SYSCALL_CLONE_20_X = (_et)223;
 constexpr auto PPME_SYSCALL_CLONE3_X = (_et)335;
 constexpr auto PPME_SYSCALL_FORK_20_X = (_et)225;
 constexpr auto PPME_SYSCALL_VFORK_20_X = (_et)227;
+constexpr auto PPME_SYSCALL_EXECVE_16_X = (_et)231;
+constexpr auto PPME_SYSCALL_EXECVE_17_X = (_et)283;
+constexpr auto PPME_SYSCALL_EXECVE_18_X = (_et)289;
 constexpr auto PPME_SYSCALL_EXECVE_19_X = (_et)293;
 constexpr auto PPME_SYSCALL_EXECVEAT_X = (_et)331;
 constexpr auto PPME_SYSCALL_CHROOT_X = (_et)267;

--- a/plugins/container/src/macros.h.in
+++ b/plugins/container/src/macros.h.in
@@ -21,7 +21,7 @@ limitations under the License.
 // Async capability
 /////////////////////////
 // This is the same name as the pre-existing container event
-// (PPME_CONTAINER_JSON_2_E) to avoid touching the rules (eg:
+// (PPME_CONTAINER_JSON_E) to avoid touching the rules (eg:
 // https://github.com/falcosecurity/rules/blob/d8415c1bc13e6607b477360afda3dae66d2abd16/rules/falco-incubating_rules.yaml#L300)
 #define ASYNC_EVENT_NAME_ADDED "container"
 #define ASYNC_EVENT_NAME_REMOVED                                               \
@@ -54,11 +54,14 @@ limitations under the License.
 /////////////////////////
 #define PARSE_EVENT_CODES                                                      \
     {                                                                          \
-            PPME_ASYNCEVENT_E,        PPME_CONTAINER_JSON_2_E,                 \
-            PPME_SYSCALL_CLONE_20_X,  PPME_SYSCALL_FORK_20_X,                  \
-            PPME_SYSCALL_VFORK_20_X,  PPME_SYSCALL_CLONE3_X,                   \
-            PPME_SYSCALL_EXECVE_19_X, PPME_SYSCALL_EXECVEAT_X,                 \
-            PPME_SYSCALL_CHROOT_X,    PPME_PROCEXIT_1_E}
+        PPME_ASYNCEVENT_E, PPME_CONTAINER_E, PPME_CONTAINER_JSON_E,            \
+                PPME_CONTAINER_JSON_2_E, PPME_SYSCALL_CLONE_20_X,              \
+                PPME_SYSCALL_FORK_20_X, PPME_SYSCALL_VFORK_20_X,               \
+                PPME_SYSCALL_CLONE3_X, PPME_SYSCALL_EXECVE_16_X,               \
+                PPME_SYSCALL_EXECVE_17_X, PPME_SYSCALL_EXECVE_18_X,            \
+                PPME_SYSCALL_EXECVE_19_X, PPME_SYSCALL_EXECVEAT_X,             \
+                PPME_SYSCALL_CHROOT_X, PPME_PROCEXIT_1_E                                          \
+    }
 
 #define PARSE_EVENT_SOURCES                                                    \
     {                                                                          \
@@ -91,5 +94,5 @@ limitations under the License.
 #define PLUGIN_VERSION "@CMAKE_PROJECT_VERSION@"
 #define PLUGIN_DESCRIPTION "@CMAKE_PROJECT_DESCRIPTION@"
 #define PLUGIN_CONTACT "github.com/falcosecurity/plugins"
-#define PLUGIN_REQUIRED_API_VERSION "3.12.0"
+#define PLUGIN_REQUIRED_API_VERSION "3.10.0"
 #define PLUGIN_REQUIRED_EVENT_SCHEMA_VERSION "4.0.0"

--- a/plugins/container/src/plugin.h
+++ b/plugins/container/src/plugin.h
@@ -44,8 +44,8 @@ class my_plugin
     std::string get_description();
     std::string get_contact();
     std::string get_required_api_version();
-    std::string get_required_event_schema_version();
     std::string get_last_error();
+    std::string get_required_event_schema_version();
     void destroy();
     falcosecurity::init_schema get_init_schema();
     void parse_init_config(nlohmann::json& config_json);
@@ -84,6 +84,8 @@ class my_plugin
     std::vector<std::string> get_parse_event_sources();
     std::vector<falcosecurity::event_type> get_parse_event_types();
     bool parse_async_event(const falcosecurity::parse_event_input& in);
+    bool parse_container_event(const falcosecurity::parse_event_input& in);
+    bool parse_container_json_event(const falcosecurity::parse_event_input& in);
     bool
     parse_container_json_2_event(const falcosecurity::parse_event_input& in);
     bool parse_exit_process_event(const falcosecurity::parse_event_input& in);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Partial revert of commit f1e38d4b4720fc71efeb070e307023d0cc074037 to be able to support Falco libs 0.21

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
Keeping `PLUGIN_REQUIRED_EVENT_SCHEMA_VERSION=4.0.0` is a bit misleading, because the plugin still supports event schema version `3.x.x` used by libs `0.21` and `0.20`, but it's required because version `3.0.0` is assumed otherwise by libs >= `0.22`. The tricks is that those libs version do not enforce the check yet.
The utility of keeping it is that it protects from using the plugins after an event schema version bump to `5.x.x`.