### PR TITLE
vote: docs(plugins/container): add OWNERS file

### DIFF
--- a/plugins/container/OWNERS
+++ b/plugins/container/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - deepskyblue86


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**Any specific area of the project related to this PR?**
/area plugins
/area documentation

**What this PR does / why we need it**:
Have an OWNERS file for the container plugin. I'm proposing this list from
```
❯ git log --pretty=%aN . | sort | uniq -c | sort -nr
     53 Federico Di Pierro
     14 Leonardo Grasso
     14 Angelo Puglisi
     11 Iacopo Rozzo
      9 dependabot[bot]
      6 Klaus Wagner
      5 Leonardo Di Giovanna
      1 Roberto Scolaro
      1 Luca Guerra
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
