### PR TITLE
docs(k8smeta): clarify dynamic nodeName usage

### DIFF
--- a/plugins/k8smeta/README.md
+++ b/plugins/k8smeta/README.md
@@ -59,7 +59,14 @@ The `k8smeta` plugin implements 4 capabilities:
 
 Here's an example of configuration of `falco.yaml`:
 
-> NOTE: Please note that you can provide values to the config as environment variables. So, for example, you can take advantage of the Kubernetes downward API to provide the node name as an env variable `nodename: ${MY_NODE}`.
+> NOTE:
+> The `nodeName` field is required by the plugin and must match the name of the
+> Kubernetes node on which the Falco instance is running.
+>
+> When running Falco as a DaemonSet, this value **must be set dynamically**
+> using the Kubernetes Downward API.
+> Hard-coding the node name will cause metadata enrichment to work only for a
+> single node.
 
 ```yaml
 plugins:
@@ -72,7 +79,20 @@ plugins:
       # hostname exposed by the k8s-metacollector
       collectorHostname: localhost # (required)
       # name of the node on which the Falco instance is running.
-      nodeName: kind-control-plane # (required)
+      nodeName: "${FALCO_K8S_NODE_NAME}" # (required)
+      # name of the node on which the Falco instance is running.
+      # In Kubernetes DaemonSets, you should use an environment variable
+      # that is populated via Downward API so that each Falco pod gets
+      # its own node name dynamically:
+      #
+      #   extra:
+      #     # -- Extra environment variables that will be pass onto Falco containers.
+      #     env:
+      #       - name: FALCO_K8S_NODE_NAME
+      #         valueFrom:
+      #           fieldRef:
+      #             fieldPath: spec.nodeName
+      #
       # verbosity level for the plugin logger
       verbosity: warning # (optional, default: info)
       # path to the PEM encoding of the server root certificates.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind documentation

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR clarifies how the required `nodeName` field should be configured when
running Falco as a Kubernetes DaemonSet.

The previous example showed a hard-coded node name, which works for single-node
clusters but causes metadata enrichment issues in multi-node environments.
The updated documentation explains how to correctly set `nodeName` dynamically
using the Kubernetes Downward API, while still documenting the single-node case.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
