### PR TITLE
Added config max_event_size to allow larger eks audit logs

### DIFF
--- a/plugins/k8saudit-eks/README.md
+++ b/plugins/k8saudit-eks/README.md
@@ -129,6 +129,8 @@ load_plugins: [k8saudit-eks, json]
  * `polling_interval`: Polling Interval in seconds (default: 5s)
  * `shift`: Time shift in past in seconds (default: 1s)
  * `buffer_size`: Buffer Size (default: 200)
+ * `max_event_size`: Maximum size of single audit event (default: 262144)
+
 
 **Open Parameters**
 A string which contains the name of your EKS Cluster (required).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Addresses plugin crash due too large eks audit logs, adding the config parameter max_event_size like in k8saudit-gke  

**Which issue(s) this PR fixes**:

Fixes #1098

**Special notes for your reviewer**:
