### PR TITLE
chore(plugins/container): bump go-worker go version to `1.25.5`

### DIFF
--- a/.github/workflows/container-ci.yaml
+++ b/.github/workflows/container-ci.yaml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [ amd64, arm64 ]
-    container: golang:1.24-bullseye
+    container: golang:1.25-bullseye
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -20,7 +20,7 @@ jobs:
         arch: [x86_64, aarch64]
     # Upgrading to a newer debian version would make the build process generate
     # binaries that require newer GLIBC version so we need to be based on bullseye for now
-    container: golang:1.24-bullseye
+    container: golang:1.25-bullseye
     steps:
       - name: Checkout Plugins ⤵️
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/plugins/container/go-worker/go.mod
+++ b/plugins/container/go-worker/go.mod
@@ -1,6 +1,6 @@
 module github.com/falcosecurity/plugins/plugins/container/go-worker
 
-go 1.24.2
+go 1.25.5
 
 require (
 	github.com/containerd/containerd/api v1.9.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

/area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR bumps the go-worker go version to `1.25.5` in container plugin.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
