### PR TITLE
registry: add nginx access log monitoring plugin

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -707,3 +707,30 @@ plugins:
         source: edera_zone
       extraction:
         supported: true
+  - name: nginx
+    description: |
+      Real-time nginx access log monitoring for security threats.
+      Detects SQL injection, XSS, path traversal, command injection,
+      brute force attacks, and OWASP Top 10 vulnerabilities.
+    authors: takaosgb3
+    contact: https://github.com/takaosgb3/falco-plugin-nginx/issues
+    maintainers:
+      - name: takaosgb3
+    keywords:
+      - nginx
+      - web-security
+      - waf
+      - sqli
+      - xss
+      - owasp
+      - access-log
+    url: https://github.com/takaosgb3/falco-plugin-nginx
+    rules_url: https://github.com/takaosgb3/falco-plugin-nginx/tree/main/rules
+    license: Apache-2.0
+    capabilities:
+      sourcing:
+        supported: true
+        id: 27
+        source: nginx
+      extraction:
+        supported: true


### PR DESCRIPTION
Add nginx plugin for real-time security threat detection from nginx access logs. Supports detection of SQL injection, XSS, path traversal, command injection, and OWASP Top 10 vulnerabilities.

Plugin features:
  - 300+ detection patterns across 12 attack categories
  - Real-time log monitoring with fsnotify
  - 17 extractable fields for flexible rule creation
  - Comprehensive E2E test coverage

Repository: https://github.com/takaosgb3/falco-plugin-nginx
Documentation: https://github.com/takaosgb3/falco-plugin-nginx#readme

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area registry

**What this PR does / why we need it**:

This PR adds the **nginx** plugin to the Falco plugin registry.

The nginx plugin provides:
  - Real-time nginx access log monitoring for security threat detection
  - Detection of SQL injection, XSS, path traversal, command injection
  - OWASP Top 10 vulnerability detection
  - 300+ attack patterns across 12 categories
  - 17 extractable fields for flexible Falco rule creation

### Plugin Details

| Field | Value |
|-------|-------|
| Name | nginx |
| Plugin ID | 27 |
| Source | nginx |
| Type | Source + Extractor |
| License | Apache-2.0 |
| Repository | https://github.com/takaosgb3/falco-plugin-nginx |

**Which issue(s) this PR fixes**:

N/A - New plugin registration

**Special notes for your reviewer**:

  - This is an external plugin registration (source code remains in the external repository)
  - Plugin has been tested with Falco 0.36.0+
  - Comprehensive E2E test coverage with 300 attack patterns
  - Apache 2.0 licensed