### PR TITLE
fix(container): don't allocate reflex matcher at every resolve

### DIFF
--- a/plugins/container/src/matchers/containerd.cpp
+++ b/plugins/container/src/matchers/containerd.cpp
@@ -6,6 +6,8 @@ using namespace libsinsp::runc;
 
 static reflex::Pattern pattern("/([A-Za-z0-9]+(?:[._-](?:[A-Za-z0-9]+))*)/");
 
+containerd::containerd(): m_matcher(pattern) {}
+
 bool containerd::resolve(const std::string& cgroup, std::string& container_id)
 {
     // Containers created via ctr
@@ -13,11 +15,11 @@ bool containerd::resolve(const std::string& cgroup, std::string& container_id)
     // Since we cannot know the namespace in advance, we try to
     // extract it from the cgroup path by following provided regex,
     // and use that to eventually extract the container id.
-    reflex::Matcher matcher(pattern, cgroup);
-    if(matcher.find())
+    m_matcher.input(cgroup);
+    if(m_matcher.find())
     {
         const auto containerd_namespace =
-                std::string(matcher[0].first, matcher[0].second);
+                std::string(m_matcher[0].first, m_matcher[0].second);
         const cgroup_layout CONTAINERD_CGROUP_LAYOUT[] = {
                 {containerd_namespace.c_str(), ""}, {nullptr, nullptr}};
         return matches_runc_cgroup(cgroup, CONTAINERD_CGROUP_LAYOUT,

--- a/plugins/container/src/matchers/containerd.h
+++ b/plugins/container/src/matchers/containerd.h
@@ -1,8 +1,14 @@
 #pragma once
 
 #include "matcher.h"
+#include <reflex/matcher.h>
 
 class containerd : public cgroup_matcher
 {
+    public:
+    containerd();
     bool resolve(const std::string& cgroup, std::string& container_id) override;
+
+    private:
+    reflex::Matcher m_matcher;
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

A new reflex matcher was created at each resolve. This creates a common one that is reused.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
