### PR TITLE
fix(container): prevent int64 overflow in JSON deserialization

### DIFF
--- a/plugins/container/src/container_info_json.cpp
+++ b/plugins/container/src/container_info_json.cpp
@@ -101,12 +101,12 @@ void from_json(const nlohmann::json& j, container_info::ptr_t& cinfo)
     info->m_imagetag = container.value("imagetag", "");
     info->m_container_user = container.value("User", "");
     info->m_pod_sandbox_cniresult = container.value("cni_json", "");
-    info->m_cpu_period = container.value("cpu_period", 0);
-    info->m_cpu_quota = container.value("cpu_quota", 0);
-    info->m_cpu_shares = container.value("cpu_shares", 0);
-    info->m_cpuset_cpu_count = container.value("cpuset_cpu_count", 0);
-    info->m_created_time = container.value("created_time", 0);
-    info->m_size_rw_bytes = container.value("size", -1);
+    info->m_cpu_period = container.value("cpu_period", int64_t{0});
+    info->m_cpu_quota = container.value("cpu_quota", int64_t{0});
+    info->m_cpu_shares = container.value("cpu_shares", int64_t{0});
+    info->m_cpuset_cpu_count = container.value("cpuset_cpu_count", int64_t{0});
+    info->m_created_time = container.value("created_time", int64_t{0});
+    info->m_size_rw_bytes = container.value("size", int64_t{-1});
     object_from_json(container, "env", info->m_env);
     info->m_full_id = container.value("full_id", "");
     info->m_host_ipc = container.value("host_ipc", false);
@@ -115,8 +115,8 @@ void from_json(const nlohmann::json& j, container_info::ptr_t& cinfo)
     info->m_container_ip = container.value("ip", "");
     info->m_is_pod_sandbox = container.value("is_pod_sandbox", false);
     object_from_json(container, "labels", info->m_labels);
-    info->m_memory_limit = container.value("memory_limit", 0);
-    info->m_swap_limit = container.value("swap_limit", 0);
+    info->m_memory_limit = container.value("memory_limit", int64_t{0});
+    info->m_swap_limit = container.value("swap_limit", int64_t{0});
     info->m_pod_sandbox_id = container.value("pod_sandbox_id", "");
     info->m_privileged = container.value("privileged", false);
     object_from_json(container, "pod_sandbox_labels",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix integer overflow when deserializing container resource limits from JSON.
Using int (32-bit) as default value in nlohmann::json::value() causes
overflow for values > INT_MAX. Memory limit of 5GB (5368709120) was
incorrectly parsed as 1GB (1073741824) due to 32-bit overflow.

Changed all int64_t fields to use int64_t{0} as default value to ensure
proper type inference and prevent overflow.

Affected fields:
- m_memory_limit (main issue)
- m_swap_limit
- m_cpu_period, m_cpu_quota, m_cpu_shares
- m_cpuset_cpu_count, m_created_time, m_size_rw_bytes


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
