### PR TITLE
feat(plugins/container): cache resolution results

### DIFF
--- a/plugins/container/src/matchers/matcher.cpp
+++ b/plugins/container/src/matchers/matcher.cpp
@@ -15,44 +15,44 @@ matcher_manager::matcher_manager(const Engines& cfg)
         // Configured with a static engine; add it and return.
         auto engine = std::make_shared<static_container>(
                 cfg.static_ctr.id, cfg.static_ctr.name, cfg.static_ctr.image);
-        m_matchers.push_back(engine);
+        m_cgroup_matchers.push_back(engine);
         return;
     }
 
     if(cfg.podman.enabled)
     {
         auto podman_engine = std::make_shared<podman>();
-        m_matchers.push_back(podman_engine);
+        m_cgroup_matchers.push_back(podman_engine);
     }
     if(cfg.docker.enabled)
     {
         auto docker_engine = std::make_shared<docker>();
-        m_matchers.push_back(docker_engine);
+        m_cgroup_matchers.push_back(docker_engine);
     }
     if(cfg.cri.enabled)
     {
         auto cri_engine = std::make_shared<cri>();
-        m_matchers.push_back(cri_engine);
+        m_cgroup_matchers.push_back(cri_engine);
     }
     if(cfg.containerd.enabled)
     {
         auto containerd_engine = std::make_shared<containerd>();
-        m_matchers.push_back(containerd_engine);
+        m_cgroup_matchers.push_back(containerd_engine);
     }
     if(cfg.lxc.enabled)
     {
         auto lxc_engine = std::make_shared<lxc>();
-        m_matchers.push_back(lxc_engine);
+        m_cgroup_matchers.push_back(lxc_engine);
     }
     if(cfg.libvirt_lxc.enabled)
     {
         auto libvirt_lxc_engine = std::make_shared<libvirt_lxc>();
-        m_matchers.push_back(libvirt_lxc_engine);
+        m_cgroup_matchers.push_back(libvirt_lxc_engine);
     }
     if(cfg.bpm.enabled)
     {
         auto bpm_engine = std::make_shared<bpm>();
-        m_matchers.push_back(bpm_engine);
+        m_cgroup_matchers.push_back(bpm_engine);
     }
 }
 
@@ -60,13 +60,32 @@ bool matcher_manager::match_cgroup(const std::string& cgroup,
                                    std::string& container_id,
                                    container_info::ptr_t& ctr)
 {
-    for(const auto& matcher : m_matchers)
+    std::pair<std::string, std::shared_ptr<cgroup_matcher>> cid_matcher_p;
+    if(m_cgroup_cinfo_cache.get(cgroup, cid_matcher_p))
+    {
+        container_id = cid_matcher_p.first;
+        if(cid_matcher_p.second != nullptr)
+        {
+            ctr = cid_matcher_p.second->to_container(container_id);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    for(const auto& matcher : m_cgroup_matchers)
     {
         if(matcher->resolve(cgroup, container_id))
         {
             ctr = matcher->to_container(container_id);
+            m_cgroup_cinfo_cache.set(cgroup, {container_id, matcher});
             return true;
         }
     }
+
+    // If a cgroup does not match is host.
+    m_cgroup_cinfo_cache.set(cgroup, {"", nullptr});
     return false;
 }

--- a/plugins/container/src/matchers/matcher.h
+++ b/plugins/container/src/matchers/matcher.h
@@ -2,7 +2,7 @@
 
 #include "../container_info.h"
 #include "../plugin_config.h"
-#include <list>
+#include "../utils.h"
 
 class cgroup_matcher
 {
@@ -29,5 +29,7 @@ class matcher_manager
                       container_info::ptr_t& ctr);
 
     private:
-    std::list<std::shared_ptr<cgroup_matcher>> m_matchers;
+    std::vector<std::shared_ptr<cgroup_matcher>> m_cgroup_matchers;
+    LRU<std::string, std::pair<std::string, std::shared_ptr<cgroup_matcher>>>
+            m_cgroup_cinfo_cache;
 };

--- a/plugins/container/src/utils.h
+++ b/plugins/container/src/utils.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <list>
+#include <unordered_map>
+#include <utility>
+
+template<typename Key, typename Value> class LRU
+{
+    public:
+    LRU(size_t cap = 100): m_cap(cap) {}
+
+    void set(const Key& k, const Value& v)
+    {
+        auto it = m_key_to_value.find(k);
+        if(it == m_key_to_value.end())
+        {
+            // Didn't find the element in the cache:
+            // move the element on top of the list.
+            m_values.emplace_front(k);
+            // If we reached max capacity pop the last element.
+            if(m_values.size() > m_cap)
+            {
+                m_key_to_value.erase(m_values.back());
+                m_values.pop_back();
+            }
+            // Populate the cache.
+            m_key_to_value.insert({k, {v, m_values.begin()}});
+        }
+        else
+        {
+            // Update the element pointers moving it on the front of the list
+            m_values.splice(m_values.begin(), m_values, it->second.second);
+            // The element could be different: update it anyway.
+            it->second.first = v;
+            // Update the iterator accordingly
+            it->second.second = m_values.begin();
+        }
+    }
+
+    bool get(const Key& k, Value& v)
+    {
+        auto it = m_key_to_value.find(k);
+        if(it != m_key_to_value.end())
+        {
+            // We have the value in the cache
+            v = it->second.first;
+            // Update the element pointers moving it on the front of the list
+            m_values.splice(m_values.begin(), m_values, it->second.second);
+            // Update the iterator accordingly
+            it->second.second = m_values.begin();
+            return true;
+        }
+        return false;
+    }
+
+    private:
+    size_t m_cap = 100;
+    std::unordered_map<Key, std::pair<Value, typename std::list<Key>::iterator>>
+            m_key_to_value;
+    std::list<Key> m_values;
+};

--- a/plugins/container/test/CMakeLists.txt
+++ b/plugins/container/test/CMakeLists.txt
@@ -12,6 +12,7 @@ configure_file(
 add_executable(test src/extract.cpp
     config.cpp
     container_info_json.cpp
+    lru.cpp
     matchers.cpp
     mounts.cpp
 )

--- a/plugins/container/test/lru.cpp
+++ b/plugins/container/test/lru.cpp
@@ -1,0 +1,234 @@
+#include <gtest/gtest.h>
+#include <utils.h>
+#include <memory>
+#include <string>
+
+// Test basic set and get operations
+TEST(LRU, BasicSetGet)
+{
+    LRU<int, std::string> cache(3);
+
+    std::string value;
+    EXPECT_FALSE(cache.get(1, value)); // Not in cache yet
+
+    cache.set(1, "one");
+    EXPECT_TRUE(cache.get(1, value));
+    EXPECT_EQ(value, "one");
+
+    cache.set(2, "two");
+    EXPECT_TRUE(cache.get(2, value));
+    EXPECT_EQ(value, "two");
+
+    // First key should still be accessible
+    EXPECT_TRUE(cache.get(1, value));
+    EXPECT_EQ(value, "one");
+}
+
+// Test cache capacity and eviction
+TEST(LRU, CapacityEviction)
+{
+    LRU<int, std::string> cache(2);
+
+    cache.set(1, "one");
+    cache.set(2, "two");
+
+    std::string value;
+    EXPECT_TRUE(cache.get(1, value));
+    EXPECT_TRUE(cache.get(2, value));
+
+    // Adding third element should evict the least recently used (1)
+    cache.set(3, "three");
+
+    EXPECT_FALSE(cache.get(1, value)); // Should be evicted
+    EXPECT_TRUE(cache.get(2, value));  // Should still be present
+    EXPECT_EQ(value, "two");
+    EXPECT_TRUE(cache.get(3, value)); // Should be present
+    EXPECT_EQ(value, "three");
+}
+
+// Test LRU ordering - accessing an element makes it most recently used
+TEST(LRU, LRUOrdering)
+{
+    LRU<int, std::string> cache(2);
+
+    cache.set(1, "one");
+    cache.set(2, "two");
+
+    std::string value;
+    // Access key 1 to make it most recently used
+    EXPECT_TRUE(cache.get(1, value));
+    EXPECT_EQ(value, "one");
+
+    // Add new element - should evict key 2 (least recently used)
+    cache.set(3, "three");
+
+    EXPECT_TRUE(cache.get(1, value)); // Should still be present
+    EXPECT_EQ(value, "one");
+    EXPECT_FALSE(cache.get(2, value)); // Should be evicted
+    EXPECT_TRUE(cache.get(3, value));  // Should be present
+    EXPECT_EQ(value, "three");
+}
+
+// Test updating existing keys
+TEST(LRU, UpdateExisting)
+{
+    LRU<int, std::string> cache(2);
+
+    cache.set(1, "one");
+    cache.set(2, "two");
+
+    // Update key 1
+    cache.set(1, "ONE");
+
+    std::string value;
+    EXPECT_TRUE(cache.get(1, value));
+    EXPECT_EQ(value, "ONE"); // Should have updated value
+
+    // Key 1 should now be most recently used
+    cache.set(3, "three");
+
+    EXPECT_TRUE(cache.get(1, value));  // Should still be present
+    EXPECT_FALSE(cache.get(2, value)); // Should be evicted (was LRU)
+    EXPECT_TRUE(cache.get(3, value));  // Should be present
+}
+
+// Test with complex value types (pair of string and shared_ptr)
+TEST(LRU, ComplexValueType)
+{
+    using ValueType = std::pair<std::string, std::shared_ptr<int>>;
+    LRU<std::string, ValueType> cache(2);
+
+    auto ptr1 = std::make_shared<int>(42);
+    auto ptr2 = std::make_shared<int>(100);
+
+    cache.set("key1", {"container1", ptr1});
+    cache.set("key2", {"container2", ptr2});
+
+    ValueType value;
+    EXPECT_TRUE(cache.get("key1", value));
+    EXPECT_EQ(value.first, "container1");
+    EXPECT_EQ(*value.second, 42);
+    EXPECT_EQ(ptr1.use_count(), 3); // ptr1, cache, and value
+
+    EXPECT_TRUE(cache.get("key2", value));
+    EXPECT_EQ(value.first, "container2");
+    EXPECT_EQ(*value.second, 100);
+}
+
+// Test cache with capacity 1
+TEST(LRU, SingleCapacity)
+{
+    LRU<int, std::string> cache(1);
+
+    cache.set(1, "one");
+
+    std::string value;
+    EXPECT_TRUE(cache.get(1, value));
+    EXPECT_EQ(value, "one");
+
+    // Adding second element should evict the first
+    cache.set(2, "two");
+    EXPECT_FALSE(cache.get(1, value));
+    EXPECT_TRUE(cache.get(2, value));
+    EXPECT_EQ(value, "two");
+}
+
+// Test repeated updates don't break cache
+TEST(LRU, RepeatedUpdates)
+{
+    LRU<int, std::string> cache(2);
+
+    cache.set(1, "one");
+    cache.set(1, "ONE");
+    cache.set(1, "uno");
+
+    std::string value;
+    EXPECT_TRUE(cache.get(1, value));
+    EXPECT_EQ(value, "uno");
+
+    cache.set(2, "two");
+    EXPECT_TRUE(cache.get(1, value));
+    EXPECT_EQ(value, "uno");
+    EXPECT_TRUE(cache.get(2, value));
+    EXPECT_EQ(value, "two");
+
+    cache.set(3, "three");
+
+    value = "";
+    EXPECT_FALSE(cache.get(1, value));
+    EXPECT_EQ(value, "");
+}
+
+// Test with string keys (as used in container matcher)
+TEST(LRU, StringKeys)
+{
+    LRU<std::string, std::string> cache(3);
+
+    cache.set("/kubepods/pod123", "container123");
+    cache.set("/docker/abc456", "containerabc");
+    cache.set("/libpod-def789", "containerdef");
+
+    std::string value;
+    EXPECT_TRUE(cache.get("/kubepods/pod123", value));
+    EXPECT_EQ(value, "container123");
+    EXPECT_TRUE(cache.get("/docker/abc456", value));
+    EXPECT_EQ(value, "containerabc");
+    EXPECT_TRUE(cache.get("/libpod-def789", value));
+    EXPECT_EQ(value, "containerdef");
+
+    // Access middle key
+    EXPECT_TRUE(cache.get("/docker/abc456", value));
+
+    // Add fourth element - should evict first one
+    cache.set("/crio-xyz", "containerxyz");
+
+    EXPECT_FALSE(cache.get("/kubepods/pod123", value)); // Evicted
+    EXPECT_TRUE(cache.get("/docker/abc456", value));    // Still present
+    EXPECT_TRUE(cache.get("/libpod-def789", value));    // Still present
+    EXPECT_TRUE(cache.get("/crio-xyz", value));         // New entry
+}
+
+// Test cache behavior with default capacity
+TEST(LRU, DefaultCapacity)
+{
+    LRU<int, std::string> cache; // Uses default capacity (100)
+
+    // Add many elements
+    for(int i = 0; i < 100; i++)
+    {
+        cache.set(i, "value" + std::to_string(i));
+    }
+
+    std::string value;
+    // All 100 should be present
+    for(int i = 0; i < 100; i++)
+    {
+        EXPECT_TRUE(cache.get(i, value));
+    }
+
+    // Adding 101st element should evict the first one
+    cache.set(100, "value100");
+    EXPECT_FALSE(cache.get(0, value));  // Should be evicted
+    EXPECT_TRUE(cache.get(100, value)); // Should be present
+    EXPECT_TRUE(cache.get(99, value));  // Should still be present
+}
+
+// Test with nullptr values (as used in matcher for host cgroups)
+TEST(LRU, NullptrValues)
+{
+    using ValueType = std::pair<std::string, std::shared_ptr<int>>;
+    LRU<std::string, ValueType> cache(2);
+
+    // Simulate host cgroup (empty string, nullptr)
+    cache.set("/host/cgroup", {"", nullptr});
+    cache.set("/container/cgroup", {"container123", std::make_shared<int>(42)});
+
+    ValueType value;
+    EXPECT_TRUE(cache.get("/host/cgroup", value));
+    EXPECT_EQ(value.first, "");
+    EXPECT_EQ(value.second, nullptr);
+
+    EXPECT_TRUE(cache.get("/container/cgroup", value));
+    EXPECT_EQ(value.first, "container123");
+    EXPECT_NE(value.second, nullptr);
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Adds an LRU cache to the container matcher to cache cgroup-to-container resolution results, reducing repeated lookups and improving performance.

The `match_cgroup` method iterates through all configured container engines (Docker, Podman, CRI, Containerd, etc.) to resolve a `cgroup` path to a container ID. The same cgroup paths can be resolved repeatedly, causing unnecessary work.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1179

**Special notes for your reviewer**:
