### PR TITLE
chore: bump Go version to 1.25 in CI/CD workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
-        go-version: 1.21
+        go-version-file: build/registry/go.mod
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/k8smeta-ci.yaml
+++ b/.github/workflows/k8smeta-ci.yaml
@@ -28,7 +28,7 @@ jobs:
         - name: Setup Go
           uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
           with:
-            go-version: '1.21'
+            go-version: '1.25'
             check-latest: true
 
         - name: Install deps ⛓️

--- a/.github/workflows/registry.yaml
+++ b/.github/workflows/registry.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: "1.24"
+          go-version-file: build/registry/go.mod
           check-latest: true
 
       - name: Build registry artifact tool

--- a/.github/workflows/reusable-publish-oci-artifacts.yaml
+++ b/.github/workflows/reusable-publish-oci-artifacts.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: "^1.21"
+          go-version-file: build/registry/go.mod
 
       - name: Build registry artifact tool
         working-directory: build/registry

--- a/.github/workflows/reusable_build_rules_tool.yaml
+++ b/.github/workflows/reusable_build_rules_tool.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: "1.19.0"
+          go-version: '1.25'
 
       - name: Checkout rules
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

> /area registry

/area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Update all GitHub Actions workflows to use Go 1.25:
- k8smeta-ci.yaml: 1.21 -> 1.25
- reusable_build_rules_tool.yaml: 1.19.0 -> 1.25
- reusable-publish-oci-artifacts.yaml: ^1.21 -> ^1.25
- registry.yaml: 1.24 -> 1.25
- codeql-analysis.yml: 1.21 -> 1.25

This addresses part of issue #1184. The reusable_build_packages.yaml and container-ci.yaml workflows are already correctly configured.

Refs: https://github.com/falcosecurity/plugins/issues/1184

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
