### PR TITLE
fix(container): correct image parsing with registry port

### DIFF
--- a/plugins/container/go-worker/pkg/container/containerd.go
+++ b/plugins/container/go-worker/pkg/container/containerd.go
@@ -147,11 +147,7 @@ func (c *containerdEngine) ctrToInfo(namespacedContext context.Context, containe
 			imageSize = image.Target().Size
 		}
 	}
-	imageRepoTag := strings.Split(info.Image, ":")
-	if len(imageRepoTag) == 2 {
-		imageRepo = imageRepoTag[0]
-		imageTag = imageRepoTag[1]
-	}
+	imageRepo, imageTag = parseImageRepoTag(info.Image)
 
 	// Network related - TODO
 

--- a/plugins/container/go-worker/pkg/container/cri.go
+++ b/plugins/container/go-worker/pkg/container/cri.go
@@ -322,27 +322,18 @@ func (c *criEngine) ctrToInfo(ctx context.Context, ctr *v1.ContainerStatus, podS
 		}
 	}
 
-	imageRepoTag := strings.Split(imageName, ":")
-	imageRepo = imageRepoTag[0]
-	if len(imageRepoTag) == 2 {
-		imageTag = imageRepoTag[1]
-	}
+	imageRepo, imageTag = parseImageRepoTag(imageName)
 
 	if getTagFromImage {
-		imageRepoTag = strings.Split(ctr.GetImage().GetImage(), ":")
-		if len(imageRepoTag) == 2 {
-			imageTag = imageRepoTag[1]
+		_, tag := parseImageRepoTag(ctr.GetImage().GetImage())
+		if tag != "" {
+			imageTag = tag
 			imageName += ":" + imageTag
 		}
 	}
 
 	imageStr := ctrInfo.getImage()
-	imageStrs := strings.Split(imageStr, ":")
-	if len(imageStrs) == 2 {
-		imageID = imageStrs[1]
-	} else {
-		imageID = imageStr
-	}
+	_, imageID = parseImageRepoTag(imageStr)
 	if imageID == "" {
 		imageID = ctr.GetImageId()
 	}

--- a/plugins/container/go-worker/pkg/container/docker.go
+++ b/plugins/container/go-worker/pkg/container/docker.go
@@ -200,23 +200,23 @@ func (dc *dockerEngine) ctrToInfo(ctx context.Context, ctr container.InspectResp
 	}
 
 	for _, repoTag := range img.RepoTags {
-		repoTagsParts := strings.Split(repoTag, ":")
-		if len(repoTagsParts) != 2 {
+		repo, tag := parseImageRepoTag(repoTag)
+		if repo == "" || tag == "" {
 			// malformed
 			continue
 		}
 		if imageRepo == "" {
-			imageRepo = repoTagsParts[0]
+			imageRepo = repo
 		}
 		if strings.Contains(repoTag, imageRepo) {
-			imageTag = repoTagsParts[1]
+			imageTag = tag
 			break
 		}
 	}
 
 	imgName := ctr.Image
-	if !strings.Contains(imgName, "/") && strings.Contains(imgName, ":") {
-		imageID = strings.Split(imgName, ":")[1]
+	if !strings.Contains(imgName, "/") {
+		_, imageID = parseImageRepoTag(imgName)
 	}
 
 	labels := make(map[string]string)

--- a/plugins/container/go-worker/pkg/container/engine_test.go
+++ b/plugins/container/go-worker/pkg/container/engine_test.go
@@ -140,3 +140,70 @@ func TestParsePortBindingHostPort(t *testing.T) {
 		})
 	}
 }
+
+func TestParseImageRepoTag(t *testing.T) {
+	tCases := map[string]struct {
+		image        string
+		expectedRepo string
+		expectedTag  string
+	}{
+		"Registry with port and tag": {
+			image:        "registry.example.com:5000/foo/bar:latest",
+			expectedRepo: "registry.example.com:5000/foo/bar",
+			expectedTag:  "latest",
+		},
+		"Registry with port without tag": {
+			image:        "registry.example.com:5000/foo/bar",
+			expectedRepo: "registry.example.com:5000/foo/bar",
+			expectedTag:  "",
+		},
+		"Simple image with tag": {
+			image:        "foo/bar:latest",
+			expectedRepo: "foo/bar",
+			expectedTag:  "latest",
+		},
+		"Simple image without path with tag": {
+			image:        "foo:latest",
+			expectedRepo: "foo",
+			expectedTag:  "latest",
+		},
+		"Simple image without tag": {
+			image:        "foo/bar",
+			expectedRepo: "foo/bar",
+			expectedTag:  "",
+		},
+		"Empty string": {
+			image:        "",
+			expectedRepo: "",
+			expectedTag:  "",
+		},
+		"Digest based image": {
+			image:        "registry.example.com:5000/foo/bar@sha256:abc123",
+			expectedRepo: "registry.example.com:5000/foo/bar",
+			expectedTag:  "",
+		},
+		"Both tag and digest": {
+			image:        "registry.example.com:5000/foo/bar:latest@sha256:abc123",
+			expectedRepo: "registry.example.com:5000/foo/bar",
+			expectedTag:  "latest",
+		},
+		"Multi-level path with registry port and tag": {
+			image:        "registry.example.com:5000/org/project/image:v1.2.3",
+			expectedRepo: "registry.example.com:5000/org/project/image",
+			expectedTag:  "v1.2.3",
+		},
+		"Localhost with port and tag": {
+			image:        "localhost:5000/myimage:latest",
+			expectedRepo: "localhost:5000/myimage",
+			expectedTag:  "latest",
+		},
+	}
+
+	for name, tc := range tCases {
+		t.Run(name, func(t *testing.T) {
+			repo, tag := parseImageRepoTag(tc.image)
+			assert.Equal(t, tc.expectedRepo, repo)
+			assert.Equal(t, tc.expectedTag, tag)
+		})
+	}
+}

--- a/plugins/container/go-worker/pkg/container/podman.go
+++ b/plugins/container/go-worker/pkg/container/podman.go
@@ -106,11 +106,7 @@ func (pc *podmanEngine) ctrToInfo(ctr *define.InspectContainerData) event.Info {
 		imageRepo string
 		imageTag  string
 	)
-	imageRepoTag := strings.Split(ctr.ImageName, ":")
-	if len(imageRepoTag) == 2 {
-		imageRepo = imageRepoTag[0]
-		imageTag = imageRepoTag[1]
-	}
+	imageRepo, imageTag = parseImageRepoTag(ctr.ImageName)
 
 	labels := make(map[string]string)
 	var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fixes container image parsing when the registry URL contains a port number.

Previously, the code used `strings.Split(image, ":")` which incorrectly split on ALL colons, making it unable to distinguish between registry ports and image tags. For example:
- `registry.example.com:5000/foo/bar:latest` would fail parsing (3 parts, fails len==2 check)
- `registry.example.com:5000/foo/bar` would incorrectly parse `registry.example.com` as repo and `5000/foo/bar` as tag

This PR introduces a new `parseImageRepoTag` function that correctly parses image references by:
- Only splitting on the last colon that appears after the last slash
- Properly handling registry URLs with ports
- Maintaining backward compatibility with simple image references

The fix has been applied to all container runtime engines: Docker, Podman, containerd, and CRI.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1139

**Special notes for your reviewer**:

- This is the same bug as #825, which was auto-closed by the stale bot without being fixed
- Added comprehensive unit tests covering various image reference formats including:
  - Registry with port and tag
  - Registry with port without tag
  - Multi-level paths with registry ports
  - Digest-based images
- The parsing logic now correctly handles all edge cases mentioned in the issue
