### PR TITLE
chore(ci): update Go version to 1.25 in reusable_validate_plugins workflow

### DIFF
--- a/.github/workflows/reusable_validate_plugins.yaml
+++ b/.github/workflows/reusable_validate_plugins.yaml
@@ -32,7 +32,7 @@ jobs:
   validate-local:
     if: inputs.arch == 'x86_64'
     runs-on: ubuntu-latest
-    container: golang:1.18
+    container: golang:1.25
     env:
       GOFLAGS: "-buildvcs=false"
     steps:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

/area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Update the golang container version from 1.18 to 1.25 in the validate-local job to align with other CI workflows using Go 1.25.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Ref: #1184 