### PR TITLE
fix(ci): sign OCI artifacts with both OCI 1.1 and legacy formats

### DIFF
--- a/.github/workflows/reusable-publish-oci-artifacts.yaml
+++ b/.github/workflows/reusable-publish-oci-artifacts.yaml
@@ -94,5 +94,8 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sign the artifacts with GitHub OIDC Token
+      - name: Sign the artifacts with GitHub OIDC Token (OCI 1.1 referrers)
         run: cosign sign --yes ${{ matrix.value.repository.ref }}@${{ matrix.value.artifact.digest }}
+
+      - name: Sign the artifacts with GitHub OIDC Token (legacy tag-based)
+        run: cosign sign --yes --registry-referrers-mode=legacy ${{ matrix.value.repository.ref }}@${{ matrix.value.artifact.digest }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

> /area registry

/area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

After PR #1033 upgraded cosign-installer from v3 to v4, cosign v3 is now used which defaults to OCI 1.1 referrers format for signatures. This PR adds an additional signing step with `--registry-referrers-mode=legacy` to also produce signatures in the legacy tag-based format (`sha256-<digest>.sig`).

This ensures backward compatibility for consumers using older cosign versions or tools that expect the legacy signature format

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
