### PR TITLE
fix(okta) field okta.target.displayName was never extracted

### DIFF
--- a/plugins/okta/pkg/okta/okta.go
+++ b/plugins/okta/pkg/okta/okta.go
@@ -375,6 +375,10 @@ func (oktaPlugin *Plugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) e
 		req.SetValue(data.SecurityContext.Domain)
 	case "okta.security.isproxy":
 		req.SetValue(data.SecurityContext.IsProxy)
+	case "okta.target.displayName":
+		if len(data.Target) > 0 {
+			req.SetValue(data.Target[0].DisplayName)
+		}
 	case "okta.target.user.id":
 		for _, i := range data.Target {
 			if i.Type == "User" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**: It fixes a bug: the field `okta.target.displayName` was previously added, but it was never extracted, leaving it empty.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
