### PR TITLE
fix(ci): use cosign v2 for legacy tag-based (.sig) signatures

### DIFF
--- a/.github/workflows/reusable-publish-oci-artifacts.yaml
+++ b/.github/workflows/reusable-publish-oci-artifacts.yaml
@@ -82,11 +82,6 @@ jobs:
       packages: write
 
     steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-
-      - run: cosign version
-
       - name: Log into ghcr.io
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
@@ -94,8 +89,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sign the artifacts with GitHub OIDC Token (OCI 1.1 referrers)
-        run: cosign sign --yes ${{ matrix.value.repository.ref }}@${{ matrix.value.artifact.digest }}
+      - name: Install Cosign v2
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: v2.6.2
 
       - name: Sign the artifacts with GitHub OIDC Token (legacy tag-based)
-        run: cosign sign --yes --registry-referrers-mode=legacy ${{ matrix.value.repository.ref }}@${{ matrix.value.artifact.digest }}
+        run: |
+          cosign version
+          cosign sign --yes ${{ matrix.value.repository.ref }}@${{ matrix.value.artifact.digest }}
+
+      - name: Install Cosign v3
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      - name: Sign the artifacts with GitHub OIDC Token (OCI 1.1 referrers)
+        run: |
+          cosign version
+          cosign sign --yes ${{ matrix.value.repository.ref }}@${{ matrix.value.artifact.digest }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area plugins

> /area registry

/area build

> /area documentation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The `sign-oci-artifacts` job uses `cosign-installer@v4.0.0` which installs cosign **v3.0.2**. In cosign v3, the default signing behavior changed: signatures are **always** written as OCI 1.1 referrers (using the new `sigstore.bundle.v0.3+json` format), regardless of the `--registry-referrers-mode=legacy` flag. That flag only controls how signatures are **discovered/read**, not how they are **written**.

As a result, the "legacy tag-based" signing step was silently producing a second OCI referrer instead of the expected `.sig` tag. This was confirmed on `container:0.6.3`: two OCI referrers exist but no `sha256-<digest>.sig` tag was created.

This PR fixes the issue by installing cosign **v2.6.2** before the legacy signing step. Cosign v2 defaults to writing signatures as `.sig` tags, which is the intended behavior.

Both signature types coexist on ghcr.io without conflicts — the registry uses the OCI Referrers Tag Fallback scheme, storing OCI referrers under `sha256-<digest>` and legacy signatures under `sha256-<digest>.sig` as two independent tags.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Verified on `ghcr.io/falcosecurity/plugins/plugin/container:0.6.3`:
- OCI referrers: 2 present (both `sigstore.bundle.v0.3+json`) ✅
- `.sig` tag: missing ❌ — this is what this PR fixes