### PR TITLE
fix(plugins/container): guard against nil RuntimeSpec in CNI fallback

### DIFF
--- a/plugins/container/go-worker/pkg/container/cri.go
+++ b/plugins/container/go-worker/pkg/container/cri.go
@@ -240,8 +240,10 @@ func (c *criEngine) ctrToInfo(ctx context.Context, ctr *v1.ContainerStatus, podS
 				if err != nil {
 					cniJson = string(bytes)
 				}
-			} else if val, ok := cniInfo.RuntimeSpec.Annotations["io.kubernetes.cri-o.CNIResult"]; ok {
-				cniJson = val
+			} else if cniInfo.RuntimeSpec != nil {
+				if val, ok := cniInfo.RuntimeSpec.Annotations["io.kubernetes.cri-o.CNIResult"]; ok {
+					cniJson = val
+				}
 			}
 
 			if len(cniJson) > maxCNILen {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

containerd v2.3.0 (CRI API v0.36) does not populate the \`runtimeSpec\` field in sandbox info JSON. That field is cri-o specific. When \`CNIResult\` is also absent (the common containerd path), the CNI fallback branch at \`plugins/container/go-worker/pkg/container/cri.go:243\` dereferences a nil pointer in \`cniSandboxInfo.RuntimeSpec.Annotations\` and the plugin panics. All Falco DaemonSet pods on a containerd v2.3.0 node go into CrashLoopBackOff (100% crash rate, observed on v0.6.4 and v0.7.0).

The fix wraps the annotation lookup in an \`if cniInfo.RuntimeSpec != nil\` check, matching the pattern the same file already uses for \`info.RuntimeSpec\` at \`cri.go:92\` (\`isPrivileged\`) and \`cri.go:126\` (\`getAnnotation\`).

The reporter included a stack trace and a suggested diff in the issue; the implemented fix matches that diff.

**Test**:

Adds \`TestCRICtrToInfoNilRuntimeSpec\` which drives the real \`ctrToInfo\` with three sandbox info shapes and asserts no panic via \`require.NotPanics\`:

1. containerd v2.3.0 (no \`runtimeSpec\`, no \`cniResult\`) - the regressing case
2. containerd v2.2.x (with \`cniResult\`, no \`runtimeSpec\`)
3. cri-o (with \`runtimeSpec.annotations[\"io.kubernetes.cri-o.CNIResult\"]\`)

**Which issue(s) this PR fixes**:

Fixes #1353

**Special notes for your reviewer**:

The local container test package does not build on macOS due to pre-existing Linux-only build constraints in \`podman_test.go\` that expose helpers used by sibling test files. Confirmed on upstream/main at \`5855f3e\`; not introduced by this PR. CI will exercise the new test on Linux.

**Does this PR introduce a user-facing change?**:

```release-note
fix(plugins/container): guard against nil `runtimeSpec` in the CNI sandbox info fallback so the plugin does not panic on containerd v2.3.0 (CRI API v0.36).
```