### PR TITLE
fix(plugins/gcpaudit): populate gcp.policyDelta, which was empty for all resource types

### DIFF
--- a/plugins/gcpaudit/pkg/gcpaudit/extract.go
+++ b/plugins/gcpaudit/pkg/gcpaudit/extract.go
@@ -92,12 +92,7 @@ func (p *Plugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
 
 	case "gcp.policyDelta":
 		resource := string(p.jdata.Get("resource").Get("type").GetStringBytes())
-
-		if resource == "gcs_bucket" {
-			fsval = p.jdata.Get("protoPayload", "serviceData", "policyDelta", "bindingDeltas")
-		} else {
-			fsval = p.jdata.Get("protoPayload", "metadata", "datasetChange", "bindingDeltas")
-		}
+		fsval = p.jdata.Get(policyDeltaPath(resource)...)
 
 	case "gcp.methodName":
 		fsval = p.jdata.Get("protoPayload", "methodName")
@@ -200,4 +195,18 @@ func (p *Plugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
 	}
 
 	return nil
+}
+
+// policyDeltaPath returns the JSON path that contains the bindingDeltas array
+// for a SetIamPolicy audit event on the given resource type. The generic IAM
+// AuditData proto (google.iam.v1.PolicyDelta) is emitted under
+// protoPayload.serviceData.policyDelta for every resource type that uses the
+// shared IAM service. BigQuery's dataset.setIamPolicy is the outlier and emits
+// its deltas under protoPayload.metadata.datasetChange as part of the
+// BigQueryAuditMetadata. See issue #1351.
+func policyDeltaPath(resource string) []string {
+	if resource == "bigquery_dataset" {
+		return []string{"protoPayload", "metadata", "datasetChange", "bindingDeltas"}
+	}
+	return []string{"protoPayload", "serviceData", "policyDelta", "bindingDeltas"}
 }

--- a/plugins/gcpaudit/pkg/gcpaudit/extract.go
+++ b/plugins/gcpaudit/pkg/gcpaudit/extract.go
@@ -91,8 +91,17 @@ func (p *Plugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
 		fsval = p.jdata.Get("protoPayload", "request")
 
 	case "gcp.policyDelta":
-		resource := string(p.jdata.Get("resource").Get("type").GetStringBytes())
-		fsval = p.jdata.Get(policyDeltaPath(resource)...)
+		fsval = policyDelta(p.jdata)
+		if fsval != nil {
+			bindingDeltas := fsval.MarshalTo(nil)
+			if len(bindingDeltas) > 0 {
+				req.SetValue(string(bindingDeltas))
+				if req.WantOffset() {
+					req.SetValueOffset(sdk.PluginEventPayloadOffset+uint32(fsval.Offset()), uint32(fsval.Len()))
+				}
+			}
+		}
+		return nil
 
 	case "gcp.methodName":
 		fsval = p.jdata.Get("protoPayload", "methodName")
@@ -170,7 +179,7 @@ func (p *Plugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
 			if len(resourceLabels) > 0 {
 				req.SetValue(string(resourceLabels))
 				if req.WantOffset() {
-					req.SetValueOffset(sdk.PluginEventPayloadOffset + uint32(fsval.Offset()), uint32(fsval.Len()))
+					req.SetValueOffset(sdk.PluginEventPayloadOffset+uint32(fsval.Offset()), uint32(fsval.Len()))
 				}
 			}
 		}
@@ -191,22 +200,49 @@ func (p *Plugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
 
 	req.SetValue(string(fsval.GetStringBytes()))
 	if req.WantOffset() {
-		req.SetValueOffset(sdk.PluginEventPayloadOffset + uint32(fsval.Offset()), uint32(fsval.Len()))
+		req.SetValueOffset(sdk.PluginEventPayloadOffset+uint32(fsval.Offset()), uint32(fsval.Len()))
 	}
 
 	return nil
 }
 
-// policyDeltaPath returns the JSON path that contains the bindingDeltas array
-// for a SetIamPolicy audit event on the given resource type. The generic IAM
-// AuditData proto (google.iam.v1.PolicyDelta) is emitted under
-// protoPayload.serviceData.policyDelta for every resource type that uses the
-// shared IAM service. BigQuery's dataset.setIamPolicy is the outlier and emits
-// its deltas under protoPayload.metadata.datasetChange as part of the
-// BigQueryAuditMetadata. See issue #1351.
-func policyDeltaPath(resource string) []string {
-	if resource == "bigquery_dataset" {
-		return []string{"protoPayload", "metadata", "datasetChange", "bindingDeltas"}
+// policyDeltaPaths lists, in priority order, the locations that can carry the
+// bindingDeltas array of a SetIamPolicy audit event.
+//
+// protoPayload.serviceData.policyDelta is the documented location for the
+// services that still populate the legacy serviceData field. Google's audit
+// log reference currently lists IAM and Cloud Storage (both
+// google.iam.v1.logging.AuditData) and App Engine, which between them cover
+// the project, folder, organization, service_account and gcs_bucket resource
+// types from #1351.
+//
+// protoPayload.metadata.datasetChange is BigQuery's BigQueryAuditMetadata.
+//
+// protoPayload.metadata.policyDelta covers services that emit the same IAM
+// AuditData under the newer metadata field, which is the migration Google
+// recommends now that serviceData carries a deprecation notice.
+//
+// Probing by payload shape rather than switching on resource.type means new
+// resource types work without a code change, and a serviceData that arrived
+// stripped or empty falls through to metadata instead of yielding an empty
+// field. See issue #1351.
+var policyDeltaPaths = [][]string{
+	{"protoPayload", "serviceData", "policyDelta", "bindingDeltas"},
+	{"protoPayload", "metadata", "datasetChange", "bindingDeltas"},
+	{"protoPayload", "metadata", "policyDelta", "bindingDeltas"},
+}
+
+// policyDelta returns the first non-empty bindingDeltas array found in evt, or
+// nil when none of the known locations carry one.
+func policyDelta(evt *fastjson.Value) *fastjson.Value {
+	for _, path := range policyDeltaPaths {
+		deltas := evt.Get(path...)
+		if deltas == nil {
+			continue
+		}
+		if arr, err := deltas.Array(); err == nil && len(arr) > 0 {
+			return deltas
+		}
 	}
-	return []string{"protoPayload", "serviceData", "policyDelta", "bindingDeltas"}
+	return nil
 }

--- a/plugins/gcpaudit/pkg/gcpaudit/extract_test.go
+++ b/plugins/gcpaudit/pkg/gcpaudit/extract_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2026 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcpaudit
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestPolicyDeltaPath guards against #1351: gcp.policyDelta was returning the
+// BigQuery datasetChange path for every non-gcs_bucket resource type, leaving
+// the field empty for project, folder, organization, service_account, and any
+// other GCP resource that uses the generic IAM SetIamPolicy flow.
+func TestPolicyDeltaPath(t *testing.T) {
+	serviceData := []string{"protoPayload", "serviceData", "policyDelta", "bindingDeltas"}
+	datasetChange := []string{"protoPayload", "metadata", "datasetChange", "bindingDeltas"}
+
+	cases := []struct {
+		resource string
+		want     []string
+	}{
+		{"gcs_bucket", serviceData},
+		{"project", serviceData},
+		{"folder", serviceData},
+		{"organization", serviceData},
+		{"service_account", serviceData},
+		// Unknown / future resource types default to the generic IAM path,
+		// not the BigQuery-specific datasetChange path.
+		{"unknown_type", serviceData},
+		{"", serviceData},
+		{"bigquery_dataset", datasetChange},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.resource, func(t *testing.T) {
+			got := policyDeltaPath(tc.resource)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("policyDeltaPath(%q) = %v, want %v", tc.resource, got, tc.want)
+			}
+		})
+	}
+}

--- a/plugins/gcpaudit/pkg/gcpaudit/extract_test.go
+++ b/plugins/gcpaudit/pkg/gcpaudit/extract_test.go
@@ -18,40 +18,248 @@ limitations under the License.
 package gcpaudit
 
 import (
-	"reflect"
+	"io"
+	"strings"
 	"testing"
+	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
 )
 
-// TestPolicyDeltaPath guards against #1351: gcp.policyDelta was returning the
-// BigQuery datasetChange path for every non-gcs_bucket resource type, leaving
-// the field empty for project, folder, organization, service_account, and any
-// other GCP resource that uses the generic IAM SetIamPolicy flow.
-func TestPolicyDeltaPath(t *testing.T) {
-	serviceData := []string{"protoPayload", "serviceData", "policyDelta", "bindingDeltas"}
-	datasetChange := []string{"protoPayload", "metadata", "datasetChange", "bindingDeltas"}
+// testExtractRequest is a minimal sdk.ExtractRequest that records the value
+// the plugin sets, so a test can assert on what Falco would actually see.
+type testExtractRequest struct {
+	field string
+	value interface{}
+}
 
+func (t *testExtractRequest) FieldID() uint64                   { return 0 }
+func (t *testExtractRequest) FieldType() uint32                 { return sdk.FieldTypeCharBuf }
+func (t *testExtractRequest) Field() string                     { return t.field }
+func (t *testExtractRequest) ArgKey() string                    { return "" }
+func (t *testExtractRequest) ArgIndex() uint64                  { return 0 }
+func (t *testExtractRequest) ArgPresent() bool                  { return false }
+func (t *testExtractRequest) IsList() bool                      { return false }
+func (t *testExtractRequest) SetValue(v interface{})            { t.value = v }
+func (t *testExtractRequest) SetPtr(unsafe.Pointer)             {}
+func (t *testExtractRequest) SetOffsetPtrs(_, _ unsafe.Pointer) {}
+func (t *testExtractRequest) WantOffset() bool                  { return false }
+func (t *testExtractRequest) SetValueOffset(_, _ uint32)        {}
+
+// testEventReader is a minimal sdk.EventReader backed by a JSON string.
+type testEventReader struct {
+	num  uint64
+	data string
+}
+
+func (t *testEventReader) EventNum() uint64      { return t.num }
+func (t *testEventReader) Timestamp() uint64     { return 0 }
+func (t *testEventReader) Reader() io.ReadSeeker { return strings.NewReader(t.data) }
+
+// extractField runs the full Extract path for a single field on a single
+// event, the same way the framework calls it.
+//
+// Event numbers start at 1. Extract caches the parsed event and skips
+// re-parsing when evt.EventNum() equals the plugin's lastEventNum, whose zero
+// value is 0, so a fresh Plugin would not parse an event numbered 0.
+func extractField(t *testing.T, eventNum uint64, field, event string) string {
+	t.Helper()
+
+	p := &Plugin{}
+	req := &testExtractRequest{field: field}
+	if err := p.Extract(req, &testEventReader{num: eventNum + 1, data: event}); err != nil {
+		t.Fatalf("Extract(%s): unexpected error: %v", field, err)
+	}
+	if req.value == nil {
+		return ""
+	}
+	s, ok := req.value.(string)
+	if !ok {
+		t.Fatalf("Extract(%s): expected a string value, got %T", field, req.value)
+	}
+	return s
+}
+
+// The fixtures below are synthetic. They are modelled on the SetIamPolicy
+// entry in Google's audit log reference
+// (https://docs.cloud.google.com/logging/docs/audit/understanding-audit-logs#sample)
+// and on the payload shapes described in #1351, trimmed to the fields the
+// plugin reads. They are not captured production logs.
+
+// serviceDataEvent is the generic IAM shape: google.iam.v1.logging.AuditData
+// under protoPayload.serviceData. This covers project, folder, organization,
+// service_account and gcs_bucket.
+const serviceDataEvent = `{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "serviceName": "cloudresourcemanager.googleapis.com",
+    "methodName": "SetIamPolicy",
+    "serviceData": {
+      "@type": "type.googleapis.com/google.iam.v1.logging.AuditData",
+      "policyDelta": {
+        "bindingDeltas": [
+          {"action": "ADD", "role": "roles/owner", "member": "user:attacker@example.com"}
+        ]
+      }
+    }
+  },
+  "resource": {"type": "project", "labels": {"project_id": "my-project"}}
+}`
+
+// gcsBucketEvent is the one resource type the previous code routed to the
+// serviceData path. It is kept as a regression case because the field came
+// back empty even here, see TestExtractPolicyDelta.
+const gcsBucketEvent = `{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "serviceName": "storage.googleapis.com",
+    "methodName": "storage.setIamPermissions",
+    "serviceData": {
+      "@type": "type.googleapis.com/google.iam.v1.logging.AuditData",
+      "policyDelta": {
+        "bindingDeltas": [
+          {"action": "ADD", "role": "roles/storage.objectViewer", "member": "allUsers"}
+        ]
+      }
+    }
+  },
+  "resource": {"type": "gcs_bucket", "labels": {"bucket_name": "my-bucket"}}
+}`
+
+// datasetChangeEvent is BigQuery's BigQueryAuditMetadata shape.
+const datasetChangeEvent = `{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "serviceName": "bigquery.googleapis.com",
+    "methodName": "google.iam.v1.IAMPolicy.SetIamPolicy",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.audit.BigQueryAuditMetadata",
+      "datasetChange": {
+        "bindingDeltas": [
+          {"action": "REMOVE", "role": "roles/bigquery.dataViewer", "member": "user:someone@example.com"}
+        ]
+      }
+    }
+  },
+  "resource": {"type": "bigquery_dataset", "labels": {"project_id": "my-project"}}
+}`
+
+// metadataPolicyDeltaEvent carries the IAM AuditData under the newer metadata
+// field instead of the deprecated serviceData field.
+const metadataPolicyDeltaEvent = `{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "serviceName": "iam.googleapis.com",
+    "methodName": "SetIamPolicy",
+    "metadata": {
+      "@type": "type.googleapis.com/google.iam.v1.logging.AuditData",
+      "policyDelta": {
+        "bindingDeltas": [
+          {"action": "ADD", "role": "roles/iam.serviceAccountTokenCreator", "member": "user:attacker@example.com"}
+        ]
+      }
+    }
+  },
+  "resource": {"type": "service_account", "labels": {"email_id": "sa@my-project.iam.gserviceaccount.com"}}
+}`
+
+// emptyServiceDataEvent is the stripped-on-export case: the serviceData
+// wrapper survives but policyDelta does not, and no metadata is present.
+const emptyServiceDataEvent = `{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "serviceName": "cloudresourcemanager.googleapis.com",
+    "methodName": "SetIamPolicy",
+    "serviceData": {"@type": "type.googleapis.com/google.iam.v1.logging.AuditData"}
+  },
+  "resource": {"type": "organization", "labels": {}}
+}`
+
+// TestExtractPolicyDelta guards the actual symptom in #1351: gcp.policyDelta
+// came back empty for every resource type that uses the generic IAM
+// SetIamPolicy flow, because the extractor only looked under
+// metadata.datasetChange unless resource.type was gcs_bucket.
+//
+// It exercises Extract end to end rather than the path lookup alone, so it
+// also covers the serialization step. bindingDeltas is a JSON array, and the
+// generic tail of Extract calls GetStringBytes, which returns nil for any
+// non-string value. Selecting the right path is necessary but not sufficient.
+func TestExtractPolicyDelta(t *testing.T) {
 	cases := []struct {
-		resource string
-		want     []string
+		name         string
+		event        string
+		wantContains []string
 	}{
-		{"gcs_bucket", serviceData},
-		{"project", serviceData},
-		{"folder", serviceData},
-		{"organization", serviceData},
-		{"service_account", serviceData},
-		// Unknown / future resource types default to the generic IAM path,
-		// not the BigQuery-specific datasetChange path.
-		{"unknown_type", serviceData},
-		{"", serviceData},
-		{"bigquery_dataset", datasetChange},
+		{
+			name:         "generic IAM serviceData",
+			event:        serviceDataEvent,
+			wantContains: []string{`"action":"ADD"`, `"role":"roles/owner"`, "attacker@example.com"},
+		},
+		{
+			name:         "gcs_bucket serviceData",
+			event:        gcsBucketEvent,
+			wantContains: []string{`"action":"ADD"`, `"role":"roles/storage.objectViewer"`, "allUsers"},
+		},
+		{
+			name:         "bigquery datasetChange",
+			event:        datasetChangeEvent,
+			wantContains: []string{`"action":"REMOVE"`, `"role":"roles/bigquery.dataViewer"`},
+		},
+		{
+			name:         "IAM AuditData under metadata",
+			event:        metadataPolicyDeltaEvent,
+			wantContains: []string{`"action":"ADD"`, `"roles/iam.serviceAccountTokenCreator"`},
+		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.resource, func(t *testing.T) {
-			got := policyDeltaPath(tc.resource)
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("policyDeltaPath(%q) = %v, want %v", tc.resource, got, tc.want)
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractField(t, uint64(i), "gcp.policyDelta", tc.event)
+			if got == "" {
+				t.Fatalf("gcp.policyDelta is empty; this is the #1351 symptom")
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("gcp.policyDelta = %s, want it to contain %s", got, want)
+				}
 			}
 		})
+	}
+}
+
+// TestExtractPolicyDeltaAbsent checks that an event with no usable deltas
+// yields an empty field and no error, rather than a partial or bogus value.
+func TestExtractPolicyDeltaAbsent(t *testing.T) {
+	events := map[string]string{
+		"stripped serviceData": emptyServiceDataEvent,
+		"unrelated event":      `{"protoPayload":{"methodName":"storage.buckets.get"},"resource":{"type":"gcs_bucket"}}`,
+	}
+
+	var i uint64
+	for name, event := range events {
+		t.Run(name, func(t *testing.T) {
+			if got := extractField(t, i, "gcp.policyDelta", event); got != "" {
+				t.Errorf("gcp.policyDelta = %q, want empty", got)
+			}
+		})
+		i++
+	}
+}
+
+// TestPolicyDeltaPathPriority pins the order the payload locations are probed
+// in, so a BigQuery event that also carries an empty serviceData wrapper still
+// resolves to datasetChange.
+func TestPolicyDeltaPathPriority(t *testing.T) {
+	const bothShapes = `{
+	  "protoPayload": {
+	    "serviceData": {"policyDelta": {"bindingDeltas": []}},
+	    "metadata": {"datasetChange": {"bindingDeltas": [{"action": "ADD", "role": "roles/bigquery.admin"}]}}
+	  },
+	  "resource": {"type": "bigquery_dataset"}
+	}`
+
+	got := extractField(t, 0, "gcp.policyDelta", bothShapes)
+	if !strings.Contains(got, "roles/bigquery.admin") {
+		t.Errorf("gcp.policyDelta = %q, want the datasetChange deltas; an empty serviceData array must not win", got)
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## Any specific area of the PR?

/area plugins

## What this PR does / why we need it

`gcp.policyDelta` returns empty on every resource type. There are two causes.

**1. Serialization.** The field resolves to the `bindingDeltas` array, but the generic tail of `Extract` calls `req.SetValue(string(fsval.GetStringBytes()))`. `GetStringBytes` returns nil for any value that isn't a JSON string, so an array always serialized to `""`. This affected `gcs_bucket` too, the one resource type the old allowlist routed to the correct path:

```
UPSTREAM: gcs_bucket gcp.policyDelta = ""
FIXED:    gcs_bucket gcp.policyDelta = "[{\"action\":\"ADD\",\"role\":\"roles/storage.objectViewer\",\"member\":\"allUsers\"}]"
```

Fixed by serializing with `MarshalTo` and setting the value directly, the same treatment `gcp.resourceLabels` already gets.

**2. Path selection.** The old code sent everything except `gcs_bucket` to BigQuery's `metadata.datasetChange`, so `project`, `folder`, `organization` and `service_account` looked in a location that doesn't exist for them. That is the symptom reported in #1351.

Rather than extend the allowlist, the deltas are now located by payload shape:

```go
var policyDeltaPaths = [][]string{
	{"protoPayload", "serviceData", "policyDelta", "bindingDeltas"},
	{"protoPayload", "metadata", "datasetChange", "bindingDeltas"},
	{"protoPayload", "metadata", "policyDelta", "bindingDeltas"},
}
```

First non-empty array wins. New resource types work without a code change, and a `serviceData` that arrives stripped or empty falls through to `metadata` instead of yielding an empty field. The third path covers services that migrate the same `google.iam.v1.logging.AuditData` proto to the newer `metadata` field, per @leogr's review.

## Testing

`extract_test.go` drives `Extract` end to end through a fake `sdk.ExtractRequest` and `sdk.EventReader`, following the `testExtractRequest` pattern in `plugins/k8saudit`. Covering `Extract` rather than the path lookup alone is what surfaced the serialization bug.

Fixtures: `gcs_bucket` and project-level `serviceData.policyDelta`, `bigquery_dataset` `metadata.datasetChange`, and `service_account` IAM `AuditData` under `metadata.policyDelta`. Negative cases assert an empty field and no error for a stripped `serviceData` wrapper and an unrelated event. `TestPolicyDeltaPathPriority` pins the probe order.

All three positive cases fail against `main` and pass with this change.

The fixtures are **synthetic**, modelled on the `SetIamPolicy` sample in [Google's audit log reference](https://docs.cloud.google.com/logging/docs/audit/understanding-audit-logs#sample) and the shapes described in #1351. They are not captured production logs, and I don't have a GCP org with an exporting Pub/Sub sink to capture one. They prove routing and serialization, not what a real exported event carries on the wire.

## Which issue(s) this PR fixes

Fixes #1351

```release-note
fix(plugins/gcpaudit): gcp.policyDelta returned an empty value for every resource type. The bindingDeltas array is now serialized to JSON, and its location is resolved by payload shape so project, folder, organization and service_account events are populated.
```
