### PR TITLE
fix(plugins/cloudtrail): imageid not shown for RequestSpotInstances

### DIFF
--- a/plugins/cloudtrail/pkg/cloudtrail/extract.go
+++ b/plugins/cloudtrail/pkg/cloudtrail/extract.go
@@ -303,6 +303,9 @@ func getImageIds(jdata *fastjson.Value, argIndex *int) (bool, []string, int, int
 	if fsval := jdata.Get("requestParameters", "DescribeFastLaunchImagesRequest", "ImageId", "content"); fsval != nil {
 		return true, []string{string(fsval.GetStringBytes())}, fsval.Offset(), fsval.Len()
 	}
+	if fsval := jdata.Get("requestParameters", "launchSpecification", "imageId"); fsval != nil {
+		return true, []string{string(fsval.GetStringBytes())}, fsval.Offset(), fsval.Len()
+	}
 	return false, nil, 0, 0
 }
 


### PR DESCRIPTION
RequestSpotInstances cloudtrail entry specifies the AMI in `/requestParameters/launchSpecification/imageId`. It was missing and this PR adds that.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**: Fixes field extraction for `ec2.imageid(s)` supporting another API call.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
