### PR TITLE
fix(plugins/container): recognize systemd nerdctl cgroups

### DIFF
--- a/plugins/container/src/matchers/cri.cpp
+++ b/plugins/container/src/matchers/cri.cpp
@@ -10,6 +10,7 @@ constexpr const cgroup_layout CRI_CGROUP_LAYOUT[] = {
         {"/crio-", ".scope"},           // systemd cri-o
         {":cri-containerd:", ""}, // containerd without "SystemdCgroup = true"
         {"/docker-", ".scope"},   // systemd docker in cri-dockerd scenario
+        {"/nerdctl-", ".scope"},  // systemd nerdctl (managed containerd)
         {nullptr, nullptr}};
 
 bool cri::resolve(const std::string& cgroup, std::string& container_id)

--- a/plugins/container/test/matchers.cpp
+++ b/plugins/container/test/matchers.cpp
@@ -165,6 +165,19 @@ INSTANTIATE_TEST_SUITE_P(
                  .expected_container_id = "7951fb549ab9",
                  .should_match = true},
 
+                // nerdctl (containerd backend) with the systemd cgroup driver:
+                // /system.slice/nerdctl-<64-hex-id>.scope . The 64-hex id is
+                // wrapped by the "nerdctl-" prefix and ".scope" suffix and must
+                // be stripped like the cri-containerd / docker systemd scopes.
+                {.name = "nerdctl_systemd_scope",
+                 .cgroup = "/system.slice/"
+                           "nerdctl-"
+                           "0123456789abcdef0123456789abcdef0123456789abcdef012"
+                           "3456789abcdef."
+                           "scope",
+                 .expected_container_id = "0123456789ab",
+                 .should_match = true},
+
                 // Edge cases and failures
                 {.name = "empty_cgroup", .cgroup = "/", .should_match = false},
                 {.name = "container_id_too_long",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugins

> /area registry

> /area build

> /area documentation

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Containers started with nerdctl on systemd-managed containerd run under `/system.slice/nerdctl-<id>.scope`. The container plugin discovers them from the containerd runtime event, but syscall events were still attributed to `container.id=host`, since no matcher recognized that leaf - the 64-hex id is wrapped by the `nerdctl-` prefix and `.scope` suffix, so the `runc` extractor discards it.

This adds a single `{"/nerdctl-", ".scope"}` entry to `CRI_CGROUP_LAYOUT`, mirroring the existing `cri-containerd-/docker- systemd` scopes, plus a `nerdctl_systemd_scope` unit test. No new logic, it just reuses the existing 64-hex `runc` extractor.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
