### PR TITLE
fix(k8smeta): accept purely numeric Kubernetes node names

### DIFF
--- a/plugins/k8smeta/src/plugin.cpp
+++ b/plugins/k8smeta/src/plugin.cpp
@@ -122,9 +122,9 @@ falcosecurity::init_schema my_plugin::get_init_schema()
 			"description": "The port used by the plugin to contact the collector (e.g. '45000')."
 		},
 		"nodeName": {
-			"type": "string",
+			"type": ["string", "integer"],
 			"title": "The node on which Falco is deployed",
-			"description": "The plugin collects k8s metadata only for the node on which Falco is deployed so the node name must be specified."
+			"description": "The plugin collects k8s metadata only for the node on which Falco is deployed so the node name must be specified. A purely numeric node name may be substituted as a JSON integer rather than a string, so both types are accepted here."
 		},
 		"caPEMBundle": {
 			"type": "string",
@@ -187,8 +187,20 @@ void my_plugin::parse_init_config(nlohmann::json& config_json)
     if(config_json.contains(nlohmann::json::json_pointer(NODENAME_PATH)))
     {
         std::string nodename_string = "";
-        config_json.at(nlohmann::json::json_pointer(NODENAME_PATH))
-                .get_to(nodename_string);
+        const auto& nodename_json =
+                config_json.at(nlohmann::json::json_pointer(NODENAME_PATH));
+        if(nodename_json.is_number_integer())
+        {
+            // A purely numeric node name (e.g. "123456") is inferred as a
+            // JSON integer by Falco's downward API env var substitution,
+            // even though the schema now also accepts it here. Convert it
+            // back to a string instead of rejecting it.
+            nodename_string = std::to_string(nodename_json.get<int64_t>());
+        }
+        else
+        {
+            nodename_json.get_to(nodename_string);
+        }
 
         // todo!: Solved in Falco 0.37.0 wait until Falco 0.36.2 is barely used
         // This is just a simple workaround until we solve the Falco issue

--- a/plugins/k8smeta/test/src/init_config.cpp
+++ b/plugins/k8smeta/test/src/init_config.cpp
@@ -93,6 +93,22 @@ TEST_F(sinsp_with_test_input, plugin_k8s_env_variable)
     ASSERT_EQ(err, "");
 }
 
+TEST_F(sinsp_with_test_input, plugin_k8s_with_numeric_node_name)
+{
+    auto plugin_owner = m_inspector.register_plugin(PLUGIN_PATH);
+    ASSERT_TRUE(plugin_owner.get());
+    std::string err;
+
+    // A purely numeric Kubernetes node name (e.g. "123456") is inferred as a
+    // JSON integer rather than a string by Falco's downward API env var
+    // substitution. The schema and parser must accept it rather than
+    // rejecting it with a schema validation error.
+    ASSERT_NO_THROW(plugin_owner->init(R"(
+{"collectorHostname":"localhost","collectorPort":45000,"nodeName":123456})",
+                                       err));
+    ASSERT_EQ(err, "");
+}
+
 TEST_F(sinsp_with_test_input, plugin_k8s_with_host_proc)
 {
     auto plugin_owner = m_inspector.register_plugin(PLUGIN_PATH);


### PR DESCRIPTION
## Summary
- Falco's downward API env var substitution infers a JSON **integer** type for a purely numeric value (e.g. a Kubernetes node named `123456`), but the `k8smeta` plugin's init-config JSON schema required `nodeName` to be a `string`. Schema validation rejected the numeric value outright, so the plugin crash-looped on any node with a numeric hostname (`Value type not permitted by 'type' constraint`), even though the CRDs/config were otherwise valid.
- Relaxed the schema so `nodeName` accepts `["string", "integer"]`.
- In `parse_init_config`, an integer value is now converted back to a string (`std::to_string`) before being used, since the rest of the plugin (env-var substitution pattern matching, `m_node_name`) expects a string.

Fixes #1372

## Test plan
- [x] Added `plugin_k8s_with_numeric_node_name` to `test/src/init_config.cpp`, following the existing test pattern in that file (`plugin_owner->init(...)` through the real schema validator and `parse_init_config`).
- [x] Built the full plugin (`libk8smeta.so`) and the `unit-test-libsinsp` test binary per this repo's CI recipe (`cmake` + `make k8smeta` + `make build-tests`), in an `ubuntu:22.04` container matching `.github/workflows/k8smeta-ci.yaml`.
- [x] Ran the `init_config.cpp` test group directly against the built binary — all 7 pass, including the new numeric-node-name case:
  ```
  [ RUN      ] sinsp_with_test_input.plugin_k8s_with_numeric_node_name
  [       OK ] sinsp_with_test_input.plugin_k8s_with_numeric_node_name (0 ms)
  [  PASSED  ] 7 tests.
  ```
  (The gRPC-server-dependent `plugin_k8s_basic_API`-style tests in the same binary need the Go-based mock collector server from `k8s-metacollector`, which wasn't built in this pass since this fix is entirely config-parsing; they're untouched by this change.)
- [x] `clang-format-14 --dry-run --Werror` on both changed files — clean, matches this repo's `formatting-check` CI job.
- [x] Independently validated both halves of the fix in isolation before touching the real code: the draft-04 JSON Schema change against a real validator (accepts int/string, rejects float), and the exact `nlohmann::json` conversion logic (numeric, string, and env-var-pattern node names all convert correctly).