### PR TITLE
fix(plugins/container): link libresolv on Linux so the plugin loads on glibc < 2.34

### DIFF
--- a/plugins/container/CMakeLists.txt
+++ b/plugins/container/CMakeLists.txt
@@ -9,7 +9,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 # project metadata
 project(
         container
-        VERSION 0.7.1
+        VERSION 0.7.2
         DESCRIPTION "Falco container metadata enrichment Plugin"
         LANGUAGES CXX)
 
@@ -65,7 +65,7 @@ endif()
 target_include_directories(container PRIVATE ${CMAKE_BINARY_DIR}/src/ src/ ${PLUGIN_SDK_INCLUDE} ${PLUGIN_SDK_DEPS_INCLUDE} ${WORKER_INCLUDE})
 
 # project linked libraries
-target_link_libraries(container PRIVATE fmt::fmt-header-only ReflexLibStatic ${WORKER_DEP} ${WORKER_LIB})
+target_link_libraries(container PRIVATE fmt::fmt-header-only ReflexLibStatic ${WORKER_LIB} ${WORKER_DEP})
 
 option(ENABLE_TESTS "Enable build of unit tests" ON)
 

--- a/plugins/container/cmake/modules/go-worker.cmake
+++ b/plugins/container/cmake/modules/go-worker.cmake
@@ -25,6 +25,15 @@ if(APPLE)
     find_library(RESOLV resolv REQUIRED)
     find_library(CORE CoreFoundation REQUIRED)
     set(WORKER_DEP ${SECURITY_FRAMEWORK} ${RESOLV} ${CORE})
+elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+    # The same Go >= 1.20 cgo-resolver requirement applies on Linux: the net
+    # package references res_search from libresolv. On glibc >= 2.34 the
+    # symbol happens to resolve through libc's compat exports, which masks a
+    # missing dependency; on older glibc (Debian 11, RHEL/Rocky/Alma 8,
+    # Ubuntu 20.04) it lives only in libresolv.so.2, and without a DT_NEEDED
+    # entry the plugin fails to dlopen with:
+    #   undefined symbol: __res_search
+    set(WORKER_DEP resolv)
 endif()
 set(WORKER_LIB ${CMAKE_SOURCE_DIR}/go-worker/libworker.a)
 set(WORKER_INCLUDE ${CMAKE_SOURCE_DIR}/go-worker)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

Makes `libcontainer.so` loadable on hosts with glibc < 2.34 (Debian 11, RHEL/Rocky/AlmaLinux 8, Ubuntu 20.04, ...), where it currently fails with `undefined symbol: __res_search` — which, combined with the default Falco ruleset requiring the container plugin, prevents stock Falco from starting at all on those distros.

The go-worker library's cgo resolver references `res_search` from libresolv (Go >= 1.20), but the resolv link dependency was only declared in the `if(APPLE)` branch of `go-worker.cmake`. The shipped Linux `.so` therefore has an undefined `__res_search` and no `DT_NEEDED` entry for `libresolv.so.2`. On glibc >= 2.34 the symbol resolves via libc's compat exports, masking the bug on modern hosts; on older glibc it lives only in `libresolv.so.2`, which is never loaded.

Two changes (both linkage-only, no code changes):

1. `cmake/modules/go-worker.cmake`: set `WORKER_DEP` to `resolv` on Linux, mirroring the existing APPLE branch. `libresolv.so.2` exists on all glibc versions (real library before 2.34, compat stub after), so the added dependency is safe everywhere.
2. `CMakeLists.txt`: link `${WORKER_LIB} ${WORKER_DEP}` (archive before its dependencies). With the previous order, GNU ld processes `-lresolv` before anything references its symbols and discards it, so change (1) alone silently has no effect. ld64 is order-insensitive, which is why the macOS branch works as-is.

Also bumps the plugin version to 0.7.2.

Verification performed (details and full logs in the linked issue):

- Rebuilt v0.7.1 with this patch in `debian:bullseye` (the release CI baseline): the `.so` gains `NEEDED: libresolv.so.2` and the symbol becomes properly versioned (`__res_search@GLIBC_2.2.5` on x86_64, `@GLIBC_2.17` on aarch64).
- Debian 11 (glibc 2.31): stock Falco 0.44.1 with only the plugin binary replaced — default ruleset validates, service runs under systemd, rules fire, events are enriched. Before the patch: immediate crash loop.
- Ubuntu 24.04 (glibc 2.39): patched plugin behaves identically to stock — no regression.
- Linux aarch64: builds clean with the same result.
- The `LD_PRELOAD=libresolv.so.2` experiment in the issue independently confirms the missing-DT_NEEDED mechanism on the shipped binary.

**Which issue(s) this PR fixes**:

Fixes #1500

(Also addresses the symptoms previously reported in falcosecurity/falco#3719 and falcosecurity/falco#3728, which went stale.)

**Special notes for your reviewer**:

The link-order half of the fix is easy to lose: if `-lresolv` is added but placed before the go-worker archive, GNU ld silently drops it and the resulting `.so` is byte-for-byte as broken as before. `readelf -d libcontainer.so | grep resolv` is the quick check that the fix actually took.

```release-note
fix(plugins/container): link libresolv on Linux so libcontainer.so loads on hosts with glibc < 2.34 (Debian 11, RHEL/Rocky/Alma 8, Ubuntu 20.04)
```
