### PR TITLE
container: resubscribe to the CRI container events stream

### DIFF
--- a/plugins/container/go-worker/pkg/container/cri.go
+++ b/plugins/container/go-worker/pkg/container/cri.go
@@ -456,6 +456,17 @@ func (c *criEngine) List(ctx context.Context) ([]event.Event, error) {
 	return evts, nil
 }
 
+// resubscribeWait returns how long to wait before the next subscription
+// attempt. A subscription that outlived the ceiling was healthy, so the wait
+// starts over from the minimum instead of inheriting a backoff grown by
+// earlier restarts; otherwise the caller's current value stands.
+func resubscribeWait(current, lived time.Duration) time.Duration {
+	if lived > maxResubscribeBackoff {
+		return minResubscribeBackoff
+	}
+	return current
+}
+
 // Listen set up container created event loop by call to GetContainerEvents of the criEngine client
 // In case events have been disabled in the criEngine,
 // an error will be captured and passed to the caller.
@@ -469,6 +480,7 @@ func (c *criEngine) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan even
 		defer wg.Done()
 		backoff := minResubscribeBackoff
 		for first := true; ; first = false {
+			started := time.Now()
 			err := c.client.GetContainerEvents(ctx, containerEventsCh, nil)
 			if first {
 				containerEventsErrorCh <- err
@@ -476,10 +488,17 @@ func (c *criEngine) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan even
 			if ctx.Err() != nil {
 				return
 			}
+			backoff = resubscribeWait(backoff, time.Since(started))
 			// The stream ended without the context being cancelled, which is what
 			// a runtime restart looks like from here. Nothing resubscribes for us,
-			// so retry until the context goes away.
-			c.logger.LogAttrs(ctx, slog.LevelInfo, "container events stream ended, resubscribing",
+			// so retry until the context goes away. Only the first attempt is
+			// worth an operator's attention; a runtime that stays away would
+			// otherwise log every backoff period forever.
+			level := config.LevelTrace
+			if first {
+				level = slog.LevelInfo
+			}
+			c.logger.LogAttrs(ctx, level, "container events stream ended, resubscribing",
 				slog.String("socket", c.socket), slog.Duration("backoff", backoff), slog.Any("err", err))
 			select {
 			case <-ctx.Done():

--- a/plugins/container/go-worker/pkg/container/cri.go
+++ b/plugins/container/go-worker/pkg/container/cri.go
@@ -20,6 +20,13 @@ import (
 
 const maxCNILen = 4096
 
+// How long to wait before resubscribing to the container events stream, and the
+// ceiling the wait doubles up to. Variables so the tests can shorten them.
+var (
+	minResubscribeBackoff = 1 * time.Second
+	maxResubscribeBackoff = 30 * time.Second
+)
+
 func init() {
 	engineGenerators[typeCri] = newCriEngine
 }
@@ -454,20 +461,42 @@ func (c *criEngine) List(ctx context.Context) ([]event.Event, error) {
 // an error will be captured and passed to the caller.
 func (c *criEngine) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan event.Event, error) {
 	containerEventsCh := make(chan *v1.ContainerEventResponse)
-	containerEventsErrorCh := make(chan error, 1) // Buffered to prevent blocking
+	// Buffered to prevent blocking; only the first subscription reports through it.
+	containerEventsErrorCh := make(chan error, 1)
 	wg.Add(1)
 	go func() {
 		defer close(containerEventsCh)
-		defer close(containerEventsErrorCh)
 		defer wg.Done()
-		containerEventsErrorCh <- c.client.GetContainerEvents(ctx, containerEventsCh, nil)
+		backoff := minResubscribeBackoff
+		for first := true; ; first = false {
+			err := c.client.GetContainerEvents(ctx, containerEventsCh, nil)
+			if first {
+				containerEventsErrorCh <- err
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			// The stream ended without the context being cancelled, which is what
+			// a runtime restart looks like from here. Nothing resubscribes for us,
+			// so retry until the context goes away.
+			c.logger.LogAttrs(ctx, slog.LevelInfo, "container events stream ended, resubscribing",
+				slog.String("socket", c.socket), slog.Duration("backoff", backoff), slog.Any("err", err))
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+			backoff = min(backoff*2, maxResubscribeBackoff)
+		}
 	}()
 
 	// Catch error on initialization containerEventsErrorCh
 	const containerEventsErrorTimeout = 10 * time.Millisecond
 	select {
 	case err := <-containerEventsErrorCh:
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	case <-time.After(containerEventsErrorTimeout):
 		break
 	}
@@ -481,15 +510,10 @@ func (c *criEngine) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan even
 			select {
 			case <-ctx.Done():
 				return
-			case _, ok := <-containerEventsErrorCh:
-				if !ok {
-					// containerEventsErrorCh has been closed - block further reads from channel
-					containerEventsErrorCh = nil
-				}
 			case evt, ok := <-containerEventsCh:
 				if !ok {
 					// containerEventsCh has been closed - kill the goroutine.
-					// It happens only if the producer goroutine leaves because of errors.
+					// It happens only once the producer goroutine is done retrying.
 					return
 				}
 				if evt == nil {

--- a/plugins/container/go-worker/pkg/container/cri_test.go
+++ b/plugins/container/go-worker/pkg/container/cri_test.go
@@ -703,9 +703,10 @@ func TestCRIListenResubscribes(t *testing.T) {
 	config.Load(fmt.Sprintf(`{"hooks": %d}`, config.HookCreate|config.HookStart|config.HookRemove))
 
 	// Keep the test from waiting out the production backoff.
+	origMin, origMax := minResubscribeBackoff, maxResubscribeBackoff
 	minResubscribeBackoff, maxResubscribeBackoff = time.Millisecond, time.Millisecond
 	t.Cleanup(func() {
-		minResubscribeBackoff, maxResubscribeBackoff = time.Second, 30*time.Second
+		minResubscribeBackoff, maxResubscribeBackoff = origMin, origMax
 	})
 
 	before, after := containerFor(t, fakeRuntime, "before_restart"), containerFor(t, fakeRuntime, "after_restart")
@@ -758,4 +759,38 @@ func containerFor(t *testing.T, fakeRuntime *fake.RemoteRuntime, name string) st
 	})
 	require.NoError(t, err)
 	return ctr.ContainerId
+}
+
+func TestResubscribeWait(t *testing.T) {
+	origMin, origMax := minResubscribeBackoff, maxResubscribeBackoff
+	minResubscribeBackoff, maxResubscribeBackoff = time.Second, 30*time.Second
+	t.Cleanup(func() {
+		minResubscribeBackoff, maxResubscribeBackoff = origMin, origMax
+	})
+
+	for name, tc := range map[string]struct {
+		current time.Duration
+		lived   time.Duration
+		want    time.Duration
+	}{
+		"stream died immediately keeps the grown backoff": {
+			current: 16 * time.Second,
+			lived:   time.Millisecond,
+			want:    16 * time.Second,
+		},
+		"stream that outlived the ceiling starts over": {
+			current: 30 * time.Second,
+			lived:   31 * time.Second,
+			want:    time.Second,
+		},
+		"stream shorter than the ceiling is not healthy yet": {
+			current: 8 * time.Second,
+			lived:   29 * time.Second,
+			want:    8 * time.Second,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, resubscribeWait(tc.current, tc.lived))
+		})
+	}
 }

--- a/plugins/container/go-worker/pkg/container/cri_test.go
+++ b/plugins/container/go-worker/pkg/container/cri_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -652,4 +653,109 @@ func TestCRIListen(t *testing.T) {
 			wg.Wait()
 		})
 	}
+}
+
+// restartingRuntimeService serves one batch of events per call to
+// GetContainerEvents, then ends the stream the way a runtime restart does.
+type restartingRuntimeService struct {
+	internalapi.RuntimeService
+	mu     sync.Mutex
+	rounds [][]*v1.ContainerEventResponse
+	calls  int
+}
+
+func (r *restartingRuntimeService) GetContainerEvents(ctx context.Context, containerEventsCh chan *v1.ContainerEventResponse, _ func(v1.RuntimeService_GetContainerEventsClient)) error {
+	r.mu.Lock()
+	call := r.calls
+	r.calls++
+	var events []*v1.ContainerEventResponse
+	if call < len(r.rounds) {
+		events = r.rounds[call]
+	}
+	r.mu.Unlock()
+
+	for _, evt := range events {
+		select {
+		case containerEventsCh <- evt:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if call == 0 {
+		return errors.New("rpc error: code = Unavailable desc = error reading from server: EOF")
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestCRIListenResubscribes(t *testing.T) {
+	endpoint, err := fake.GenerateEndpoint()
+	require.NoError(t, err)
+
+	fakeRuntime := fake.NewFakeRemoteRuntime()
+	require.NoError(t, fakeRuntime.Start(endpoint))
+	t.Cleanup(fakeRuntime.Stop)
+
+	engine, err := newCriEngine(context.Background(), slog.Default(), endpoint)
+	require.NoError(t, err)
+	criEngine := engine.(*criEngine)
+
+	config.Load(fmt.Sprintf(`{"hooks": %d}`, config.HookCreate|config.HookStart|config.HookRemove))
+
+	// Keep the test from waiting out the production backoff.
+	minResubscribeBackoff, maxResubscribeBackoff = time.Millisecond, time.Millisecond
+	t.Cleanup(func() {
+		minResubscribeBackoff, maxResubscribeBackoff = time.Second, 30*time.Second
+	})
+
+	before, after := containerFor(t, fakeRuntime, "before_restart"), containerFor(t, fakeRuntime, "after_restart")
+	criEngine.client = &restartingRuntimeService{
+		RuntimeService: criEngine.client,
+		rounds: [][]*v1.ContainerEventResponse{
+			{{ContainerId: before, ContainerEventType: v1.ContainerEventType_CONTAINER_CREATED_EVENT, CreatedAt: time.Now().UnixNano()}},
+			{{ContainerId: after, ContainerEventType: v1.ContainerEventType_CONTAINER_CREATED_EVENT, CreatedAt: time.Now().UnixNano()}},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wg := sync.WaitGroup{}
+	outCh, err := criEngine.Listen(ctx, &wg)
+	require.NoError(t, err)
+
+	for _, want := range []string{before, after} {
+		select {
+		case evt, ok := <-outCh:
+			require.True(t, ok, "event channel closed instead of resubscribing after the stream ended")
+			assert.Equal(t, want, evt.Info.Container.FullID)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timeout waiting for the event for container %s", want)
+		}
+	}
+
+	cancel()
+	wg.Wait()
+}
+
+func containerFor(t *testing.T, fakeRuntime *fake.RemoteRuntime, name string) string {
+	t.Helper()
+	sandbox, err := fakeRuntime.RunPodSandbox(context.Background(), &v1.RunPodSandboxRequest{
+		Config: &v1.PodSandboxConfig{
+			Metadata: &v1.PodSandboxMetadata{
+				Name:      name + "_sandbox",
+				Uid:       uuid.New().String(),
+				Namespace: "default",
+			},
+		},
+	})
+	require.NoError(t, err)
+	ctr, err := fakeRuntime.CreateContainer(context.Background(), &v1.CreateContainerRequest{
+		Config: &v1.ContainerConfig{
+			Metadata: &v1.ContainerMetadata{Name: name},
+			Image:    &v1.ImageSpec{Image: "alpine:3.20.3"},
+		},
+		PodSandboxId: sandbox.PodSandboxId,
+	})
+	require.NoError(t, err)
+	return ctr.ContainerId
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

`criEngine.Listen` subscribes to `GetContainerEvents` exactly once. When the runtime restarts, the stream ends, the producer goroutine closes `containerEventsCh`, the consumer returns and closes `outCh`, and `workerLoop` drops the case with a "Remove the stopped goroutine" comment. Nothing resubscribes, so from that point on the plugin never sees another create, start or delete event, and every container started after the restart stays `<NA>` for its whole life.

The producer now loops instead of returning: when `GetContainerEvents` comes back and the context is still alive, it logs and resubscribes after a backoff that starts at one second and doubles up to thirty. The events channel is only closed once the producer is really done, so the consumer keeps running across a restart.

Two smaller things fell out of that. Only the first subscription reports through `containerEventsErrorCh`, so the initialization check still returns the error a caller gets when events are disabled on the runtime, and that check now returns early only when the error is non-nil (before, a stream that ended cleanly inside the 10ms window made `Listen` return `nil, nil`). The consumer no longer needs its `containerEventsErrorCh` case, since that channel is no longer closed to signal the producer leaving.

This does not cover the second half of #1499, re-listing running containers after a reconnect so anything created during the gap is picked up. That needs a call on whether replaying containers the plugin may already know about is acceptable, and I would rather not guess at it here.

**Which issue(s) this PR fixes**:

Fixes #1499

**Special notes for your reviewer**:

`TestCRIListenResubscribes` drives the real `Listen` with a runtime service that serves one event, ends the stream the way a dropped gRPC connection does, then serves a second event on the next subscription. It asserts both events arrive. On main it fails at the second one with "event channel closed instead of resubscribing after the stream ended". The backoff bounds are variables so the test can shorten them.

`go test -tags containers_image_openpgp -race ./pkg/container/ -run TestCRIListen` passes, existing subtests included. `TestContainerd` fails in my environment with or without this change, since it wants a live containerd socket.

**Does this PR introduce a user-facing change?**:

```release-note
fix(plugins/container): resubscribe to the CRI container events stream when it ends, so containers created after a runtime restart are still enriched
```
