### PR TITLE
fix(plugins/container): set healthcheck defaults in podman test spec

### DIFF
--- a/plugins/container/go-worker/pkg/container/podman_test.go
+++ b/plugins/container/go-worker/pkg/container/podman_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"go.podman.io/podman/v6/libpod/define"
 	"go.podman.io/podman/v6/pkg/bindings"
 	"go.podman.io/podman/v6/pkg/bindings/containers"
 	"go.podman.io/podman/v6/pkg/bindings/images"
@@ -78,6 +79,14 @@ func testPodman(t *testing.T, withFetcher bool) {
 					Cpus:  "0-1",
 				},
 			},
+		},
+		// Mirror the defaults set by specgen.NewSpecGenerator(): these fields are
+		// serialized without omitempty, and Podman >= 5.5.0 rejects an empty
+		// HealthLogDestination at container creation.
+		ContainerHealthCheckConfig: specgen.ContainerHealthCheckConfig{
+			HealthLogDestination: define.DefaultHealthCheckLocalDestination,
+			HealthMaxLogCount:    define.DefaultHealthMaxLogCount,
+			HealthMaxLogSize:     define.DefaultHealthMaxLogSize,
 		},
 	}, nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

`TestPodman` and `TestPodmanFetcher` fail against any Podman server >= 5.5.0 (atm, the GitHub `ubuntu-24.04` runners ship Podman 5.8.4) with:

```
HealthCheck Log '' destination error: stat : no such file or directory
```

Our `go.podman.io/podman/v6` bindings serialize `HealthLogDestination`, `HealthMaxLogCount`, and `HealthMaxLogSize` without `omitempty` (see https://github.com/containers/podman/blob/v6.0.2/pkg/specgen/specgen.go#L612-L624), so the bare `SpecGenerator{}` literal in the test sends `"healthLogDestination":""`, which newer servers reject at container creation (see https://github.com/containers/podman/blob/v5.8.4/libpod/define/healthchecks.go#L295-L303). Podman 4.9.3 simply ignored that field.

This PR sets the same defaults that `specgen.NewSpecGenerator()` would set (see https://github.com/containers/podman/blob/v6.0.2/pkg/specgen/specgen.go#L692-L699), so the container creation works with any Podman version.

N.B. This is a test-only change. The plugin itself never creates containers.

**Which issue(s) this PR fixes**:

Related to #1510 (see there for the full context, including the libs e2e part, which is not addressed here)

**Special notes for your reviewer**:

I could not run the test against a Podman >= 5.5 socket locally, so I initially verified only that the package compiles and that the serialized spec now carries `"healthLogDestination":"local"`.

However, the CI did the real check for us: both `test-amd64` and `test-arm64` on this PR landed on runner image `20260819.586` (the Podman 5.8.4 one, the same image that fails the other PRs), and `TestPodman` / `TestPodmanFetcher` pass on both arches 👉 https://github.com/falcosecurity/plugins/actions/runs/33752434352

N.B. GitHub is rolling Podman back to 4.9.3 on the runners (https://github.com/actions/runner-images/issues/14642), so a re-run may land on the new image. That does not change the above: the fix has been exercised against 5.8.4.
