### PR TITLE
feat(ci): verify libcontainer.so links and loads on glibc < 2.34

### DIFF
--- a/.github/workflows/container-ci.yaml
+++ b/.github/workflows/container-ci.yaml
@@ -4,10 +4,12 @@ on:
     branches: [main]
     paths:
       - "plugins/container/**"
+      - ".github/workflows/container-ci.yaml"
   push:
     branches: [main]
     paths:
       - "plugins/container/**"
+      - ".github/workflows/container-ci.yaml"
   workflow_dispatch:
 
 permissions:
@@ -114,7 +116,14 @@ jobs:
             return 0;
           }
           EOF
-          gcc -o /tmp/dlopen_check /tmp/dlopen_check.c -ldl
+          # The plugin pulls pthread_* and dl* from the Go runtime but declares
+          # no DT_NEEDED for them; under Falco they resolve from the global
+          # scope, because the Falco binary links both via libsinsp. Link the
+          # probe the same way so it fails on a genuinely missing dependency
+          # rather than on one Falco would have supplied. --no-as-needed is
+          # required because bullseye's gcc would otherwise drop libpthread,
+          # which the probe's own code never calls.
+          gcc -o /tmp/dlopen_check /tmp/dlopen_check.c -Wl,--no-as-needed -lpthread -ldl
           /tmp/dlopen_check ./libcontainer.so
           echo "loaded against $(ldd --version | head -n1)"
 

--- a/.github/workflows/container-ci.yaml
+++ b/.github/workflows/container-ci.yaml
@@ -84,6 +84,40 @@ jobs:
         working-directory: plugins/container
         run: make
 
+      # Issue #1500 shipped because no job both built against an old glibc and
+      # loaded the result: this one builds on bullseye but never dlopen'd it,
+      # and falco-tests dlopens inside Debian 12 (glibc 2.36), where a missing
+      # DT_NEEDED on libresolv cannot fail. This job is already on bullseye
+      # (glibc 2.31), so both checks cost nothing but the steps themselves.
+      - name: Check libcontainer.so links libresolv
+        working-directory: plugins/container
+        run: |
+          readelf -d libcontainer.so | grep -q 'NEEDED.*libresolv\.so\.2' || {
+            echo "libcontainer.so has no DT_NEEDED entry for libresolv.so.2."
+            echo "It will fail to load on hosts with glibc < 2.34. See #1500."
+            readelf -d libcontainer.so | grep NEEDED
+            exit 1
+          }
+
+      - name: Load libcontainer.so on glibc < 2.34
+        working-directory: plugins/container
+        run: |
+          cat > /tmp/dlopen_check.c <<'EOF'
+          #include <dlfcn.h>
+          #include <stdio.h>
+          int main(int argc, char **argv) {
+            void *handle = dlopen(argv[1], RTLD_NOW);
+            if (!handle) {
+              fprintf(stderr, "dlopen failed: %s\n", dlerror());
+              return 1;
+            }
+            return 0;
+          }
+          EOF
+          gcc -o /tmp/dlopen_check /tmp/dlopen_check.c -ldl
+          /tmp/dlopen_check ./libcontainer.so
+          echo "loaded against $(ldd --version | head -n1)"
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
Fixes #1512

### Why CI missed #1500

No job both built against an old glibc and loaded the result:

- `build-linux` builds inside `debian:bullseye` (glibc 2.31) but never `dlopen`s what it produced.
- `falco-tests` does `dlopen`, but inside `falcosecurity/falco:master-debian` (Debian 12, glibc 2.36), where a missing `DT_NEEDED` on `libresolv.so.2` cannot fail, because those symbols moved into libc in glibc 2.34.

### Change

Both checks go in `build-linux`, which already runs on bullseye, so neither needs a new job, container or matrix entry, and both run for amd64 and arm64.

1. **`readelf -d`** asserts the `DT_NEEDED` entry is present. Fails fast and names the cause.
2. **`dlopen(..., RTLD_NOW)`** loads the built library on glibc 2.31. This is the check that would have caught #1500, and unlike the first it also catches a different symbol going missing on old glibc for an unrelated reason.

`RTLD_NOW` rather than `RTLD_LAZY` so every symbol is bound at load time; lazy binding would defer function resolution and could pass.

`readelf` and `gcc` both come from `build-essential`, already installed by the job.

### Verification

Built a probe library calling `res_search` two ways in `debian:bullseye` and ran both guards against each:

```
glibc: ldd (Debian GLIBC 2.31-13+deb11u14) 2.31

--- built with -lresolv ---
  readelf guard: PASS
  dlopen guard : PASS

--- built without -lresolv ---
  readelf guard: FAIL
  dlopen guard : FAIL
```

The second case is #1500 reproduced: a shared object links fine without `-lresolv` because undefined symbols are permitted at link time, then fails at `dlopen` on any host where `res_search` still lives in `libresolv`.

### Note

The issue also suggested loading on a glibc < 2.34 image as the stronger option. That is what step 2 does, and putting it in `build-linux` rather than a separate job means it runs against the artifact that job just built, rather than a rebuild.

/kind feature
/area plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)
