### PR TITLE
fix(ci): prefer apt.llvm.org packages when installing clang-19

### DIFF
--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -44,6 +44,10 @@ jobs:
 
       - name: Install updated clang version ⛓️
         run: |
+          # Debian 11 reached end of life on August 31st, 2026: the clang-19 binaries were
+          # removed from the bullseye-security pool while the index still lists them, so apt
+          # gets 404s. Prefer the packages from apt.llvm.org, which are still available.
+          printf 'Package: *\nPin: origin apt.llvm.org\nPin-Priority: 1001\n' > /etc/apt/preferences.d/99-apt-llvm-org
           wget https://apt.llvm.org/llvm.sh
           chmod u+x llvm.sh
           ./llvm.sh 19


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Since this morning, every run of `reusable_build_packages.yaml` fails at the `Install updated clang version` step, on both architectures (e.g. https://github.com/falcosecurity/plugins/actions/runs/33859974760):

```text
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/l/llvm-toolchain-19/libclang-cpp19_19.1.7-3%7edeb11u1_amd64.deb  404  Not Found
```

Debian 11 reached end of life on August 31st, 2026. The `bullseye-security` index (last generated that day) still lists `llvm-toolchain-19` `1:19.1.7-3~deb11u1`, but the binaries are gone from the pool. Since that version sorts higher than the one on `apt.llvm.org` (`1:19.1.7~++20250114...`), apt keeps picking the Debian one and gets a 404.

This PR pins `apt.llvm.org` at priority 1001 before running `llvm.sh`, so `clang-19`, `libclang-cpp19`, `llvm-19-dev`, and friends come from the LLVM repository, which still provides bullseye packages for both `amd64` and `arm64`.

Verified locally in a `debian:bullseye` container: with the pin, all the packages are fetched from `apt.llvm.org`, no 404s, and `clang --version` reports `19.1.7`.

N.B. The `bullseye-security` `InRelease` file expires on September 7th, 2026. After that, `apt update` may start complaining in this container too, so we will likely need a follow-up (e.g. dropping the `bullseye-security` source, or moving to `archive.debian.org`). Not addressed here.

**Which issue(s) this PR fixes**:

None. Related to https://github.com/falcosecurity/falco/issues/3967 (the red `main` blocks the container plugin release).

**Special notes for your reviewer**:

Once merged, the `Update Plugins-dev` workflow on `main` will also exercise the `build/registry` fix from #1514 for the first time, since the build jobs failed before reaching it.
