### PR TITLE
fix(ci): take bullseye-security from the snapshot mirror

### DIFF
--- a/.github/workflows/container-ci.yaml
+++ b/.github/workflows/container-ci.yaml
@@ -62,7 +62,17 @@ jobs:
     container: debian:bullseye
     steps:
       - name: Install deps
-        run: apt-get update && apt-get install -y --no-install-recommends build-essential zip unzip ninja-build ca-certificates curl git
+        run: |
+          # Debian 11 reached end of life on August 31st, 2026: the Debian archive is removing
+          # the bullseye-security binaries while its index still lists them, so apt gets 404s.
+          # Take bullseye-security from the snapshot.debian.org mirror the image was built from
+          # (the image ships the URL as a commented line) and accept its expired Release file.
+          sed -i -e 's|^# \(deb http://snapshot.debian.org/archive/debian-security/[^ ]* bullseye-security main\)|\1|' \
+                 -e '\|^deb http://deb.debian.org/debian-security|d' /etc/apt/sources.list
+          grep -q '^deb http://snapshot.debian.org/archive/debian-security/' /etc/apt/sources.list
+          echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99snapshot
+          apt-get update
+          apt-get install -y --no-install-recommends build-essential zip unzip ninja-build ca-certificates curl git
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/reusable_build_packages.yaml
+++ b/.github/workflows/reusable_build_packages.yaml
@@ -24,6 +24,14 @@ jobs:
     steps:
       - name: Install deps
         run: |
+          # Debian 11 reached end of life on August 31st, 2026: the Debian archive is removing
+          # the bullseye-security binaries while its index still lists them, so apt gets 404s.
+          # Take bullseye-security from the snapshot.debian.org mirror the image was built from
+          # (the image ships the URL as a commented line) and accept its expired Release file.
+          sed -i -e 's|^# \(deb http://snapshot.debian.org/archive/debian-security/[^ ]* bullseye-security main\)|\1|' \
+                 -e '\|^deb http://deb.debian.org/debian-security|d' /etc/apt/sources.list
+          grep -q '^deb http://snapshot.debian.org/archive/debian-security/' /etc/apt/sources.list
+          echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99snapshot
           apt update
           apt install -y --no-install-recommends awscli build-essential autoconf libelf-dev libtool autotools-dev \
             automake zip unzip ninja-build wget lsb-release software-properties-common gnupg ca-certificates curl git


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Since this afternoon, every build on `main` fails at the very first `Install deps` step, on both architectures (e.g. https://github.com/falcosecurity/plugins/actions/runs/33886598084 and https://github.com/falcosecurity/plugins/actions/runs/33885552038):

```text
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/g/gnupg2/gpgconf_2.2.27-2%2bdeb11u3_arm64.deb  404  Not Found
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/p/python3.9/libpython3.9-minimal_3.9.2-1%2bdeb11u7_arm64.deb  404  Not Found
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/p/perl/libperl5.32_5.32.1-4%2bdeb11u5_amd64.deb  404  Not Found
```

This is the same root cause as #1515, just wider: Debian 11 reached end of life on August 31st, 2026, and the Debian archive is now removing the `bullseye-security` binaries while the index still lists them. This morning it was only `llvm-toolchain-19`, now it is ordinary packages too, so `apt install` fails before we even reach the clang step. Since `reusable_build_packages.yaml` is shared with the release workflow, this also blocks tagging plugins atm.

Simply dropping the `bullseye-security` source does not work: the `debian:bullseye` image already ships the security versions of `libc6`, `perl-base` and `gpgv`, and the plain `bullseye` suite cannot satisfy their dependencies (`libc6-dev`, `perl`, `gnupg` end up unmet). `archive.debian.org` does not have `bullseye-security` yet.

This PR takes `bullseye-security` from the `snapshot.debian.org` mirror the image itself was built from (the image ships the URL as a commented line in `/etc/apt/sources.list`, identical for `amd64` and `arm64`), drops the live source, and tells apt to accept the expired `Release` file (`Acquire::Check-Valid-Until "false"`). The `main` and `bullseye-updates` suites are not affected and stay on `deb.debian.org`. The same change is applied to `container-ci.yaml`, whose `build-linux` job runs in the same image.

Verified locally in a `debian:bullseye` container: `apt update` succeeds, the full dependency list of `reusable_build_packages.yaml` installs (`gpgconf 2.2.27`, `python3 3.9.2`, ...), and the `llvm.sh 19` step from #1515 still ends with `clang 19.1.7`.

N.B. This is a stopgap to unblock the release. The base image needs a proper decision (e.g. moving to `archive.debian.org` once `bullseye-security` lands there, or a different base with an old enough glibc). Also, `snapshot.debian.org` is known to be slow and rate limited, so if we see 503s in CI we may need a retry or a different mirror.

**Which issue(s) this PR fixes**:

None. Related to https://github.com/falcosecurity/falco/issues/3967 (the red `main` blocks the container plugin release).

**Special notes for your reviewer**:

The `grep -q` guard after the `sed` makes the step fail loudly if the image ever stops shipping the commented snapshot line, instead of silently building without the security suite.
