### PR TITLE
fix(plugins/container): bound the engine bootstrap and keep looking up unknown containers

### DIFF
--- a/plugins/container/README.md
+++ b/plugins/container/README.md
@@ -137,6 +137,7 @@ plugins:
       label_max_len: 100 # (optional, default: 100; container labels larger than this won't be reported)
       with_size: false # (optional, default: false; whether to enable container size inspection, which is inherently slow)
       hooks: ['create', 'start'] # (optional, default: 'create'. Some fields might not be available in create hook, but we are guaranteed that it gets triggered before first process gets started)
+      engine_timeout: 10 # (optional, default: 10; seconds to wait for a container engine to answer at startup, 0 disables the timeout)
       engines:
         docker:
           enabled: true
@@ -159,6 +160,8 @@ plugins:
 
 load_plugins: [container]
 ```
+
+At startup, the plugin connects to each enabled engine socket and lists the pre-existing containers. An engine that does not answer within `engine_timeout` seconds (default: 10) is skipped with a warning, so that an unresponsive runtime socket (for example a socket-activated service whose backend is gone) cannot block Falco's startup. Setting `engine_timeout` to `0` disables the timeout: the plugin then waits for each engine indefinitely.
 
 ### Rules
 

--- a/plugins/container/README.md
+++ b/plugins/container/README.md
@@ -161,7 +161,7 @@ plugins:
 load_plugins: [container]
 ```
 
-At startup, the plugin connects to each enabled engine socket and lists the pre-existing containers. An engine that does not answer within `engine_timeout` seconds (default: 10) is skipped with a warning, so that an unresponsive runtime socket (for example a socket-activated service whose backend is gone) cannot block Falco's startup. An engine that answers but does not finish listing its containers in time is kept: the containers inspected so far are loaded, and the others are looked up on their first event, like any container the plugin does not know yet, rather than being loaded with partial metadata. Setting `engine_timeout` to `0` disables the timeout: the plugin then waits for each engine indefinitely.
+At startup, the plugin connects to each enabled engine socket and lists the pre-existing containers. An engine that does not answer within `engine_timeout` seconds (default: 10) is skipped with a warning, so that an unresponsive runtime socket (for example a socket-activated service whose backend is gone) cannot block Falco's startup. An engine that answers but does not finish listing its containers in time is kept: the containers inspected so far are loaded, and the others are looked up in the background right after startup, one at a time and behind the lookups the events ask for, rather than being loaded with partial metadata; their events carry no container metadata until then. Setting `engine_timeout` to `0` disables the timeout: the plugin then waits for each engine indefinitely.
 
 N.B. With podman the timeout can be exceeded by up to about 0.6 seconds, since the podman client retries a failed request three times with fixed pauses in between.
 

--- a/plugins/container/README.md
+++ b/plugins/container/README.md
@@ -161,7 +161,9 @@ plugins:
 load_plugins: [container]
 ```
 
-At startup, the plugin connects to each enabled engine socket and lists the pre-existing containers. An engine that does not answer within `engine_timeout` seconds (default: 10) is skipped with a warning, so that an unresponsive runtime socket (for example a socket-activated service whose backend is gone) cannot block Falco's startup. Setting `engine_timeout` to `0` disables the timeout: the plugin then waits for each engine indefinitely.
+At startup, the plugin connects to each enabled engine socket and lists the pre-existing containers. An engine that does not answer within `engine_timeout` seconds (default: 10) is skipped with a warning, so that an unresponsive runtime socket (for example a socket-activated service whose backend is gone) cannot block Falco's startup. An engine that answers but does not finish listing its containers in time is kept: the containers inspected so far are loaded, and the others are looked up on their first event, like any container the plugin does not know yet, rather than being loaded with partial metadata. Setting `engine_timeout` to `0` disables the timeout: the plugin then waits for each engine indefinitely.
+
+N.B. With podman the timeout can be exceeded by up to about 0.6 seconds, since the podman client retries a failed request three times with fixed pauses in between.
 
 ### Rules
 

--- a/plugins/container/README.md
+++ b/plugins/container/README.md
@@ -161,7 +161,9 @@ plugins:
 load_plugins: [container]
 ```
 
-At startup, the plugin connects to each enabled engine socket and lists the pre-existing containers. An engine that does not answer within `engine_timeout` seconds (default: 10) is skipped with a warning, so that an unresponsive runtime socket (for example a socket-activated service whose backend is gone) cannot block Falco's startup. An engine that answers but does not finish listing its containers in time is kept: the containers inspected so far are loaded, and the others are looked up in the background right after startup, one at a time and behind the lookups the events ask for, rather than being loaded with partial metadata; their events carry no container metadata until then. Setting `engine_timeout` to `0` disables the timeout: the plugin then waits for each engine indefinitely.
+At startup, the plugin connects to each enabled engine socket and lists the pre-existing containers. An engine that does not answer within `engine_timeout` seconds (default: 10) is skipped with a warning, so that an unresponsive runtime socket (for example a socket-activated service whose backend is gone) cannot block Falco's startup. An engine that answers but does not finish listing its containers in time is kept: the containers inspected so far are loaded, and the others are looked up in the background right after startup, one at a time and behind the lookups the events ask for; their events carry no container metadata until then.
+
+For containerd, this also includes namespaces whose container listing was interrupted or had not started. Their listing is retried in the background until it succeeds, without requiring a new process event. Each attempt uses `engine_timeout` and stops when capture stops. Setting `engine_timeout` to `0` disables the timeout: startup and background namespace listings then wait indefinitely unless cancelled.
 
 N.B. With podman the timeout can be exceeded by up to about 0.6 seconds, since the podman client retries a failed request three times with fixed pauses in between.
 

--- a/plugins/container/go-worker/bootstrap_test.go
+++ b/plugins/container/go-worker/bootstrap_test.go
@@ -25,7 +25,8 @@ type listEngine struct {
 	unresponsive bool
 	// notInspected, when set, makes List wait for the context to be done and
 	// return the events with a ListIncompleteError for these containers.
-	notInspected []container.ContainerRef
+	notInspected  []container.ContainerRef
+	notEnumerated []string
 }
 
 func (e *listEngine) Name() string { return e.name }
@@ -37,9 +38,9 @@ func (e *listEngine) List(ctx context.Context) ([]event.Event, error) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
-	if len(e.notInspected) > 0 {
+	if len(e.notInspected) > 0 || len(e.notEnumerated) > 0 {
 		<-ctx.Done()
-		return e.events, &container.ListIncompleteError{NotInspected: e.notInspected, Err: context.Cause(ctx)}
+		return e.events, &container.ListIncompleteError{NotInspected: e.notInspected, NotEnumerated: e.notEnumerated, Err: context.Cause(ctx)}
 	}
 	return e.events, e.err
 }
@@ -135,4 +136,17 @@ func TestBootstrapEnginesKeepsEngineFailingToList(t *testing.T) {
 	assert.Equal(t, map[string][]string{"containerd": {"/run/containerd/containerd.sock"}}, sockets)
 	assert.Zero(t, delivered)
 	assert.Empty(t, deferred)
+}
+
+func TestBootstrapEnginesKeepsUnenumeratedNamespaces(t *testing.T) {
+	setEngineTimeout(t, 1)
+	slow := &listEngine{name: "containerd", socket: "/run/containerd/containerd.sock", notEnumerated: []string{"alpha", "beta"}}
+	engines, _, deferred := bootstrapEngines(context.Background(), []container.EngineGenerator{generatorOf(slow)}, func(string, bool, bool) {
+		t.Fatal("an unenumerated container must not be published at startup")
+	})
+	assert.Equal(t, []container.Engine{slow}, engines)
+	require.Len(t, deferred, 1)
+	assert.Same(t, slow, deferred[0].Engine)
+	assert.Empty(t, deferred[0].Containers)
+	assert.Equal(t, slow.notEnumerated, deferred[0].Namespaces)
 }

--- a/plugins/container/go-worker/bootstrap_test.go
+++ b/plugins/container/go-worker/bootstrap_test.go
@@ -25,7 +25,7 @@ type listEngine struct {
 	unresponsive bool
 	// notInspected, when set, makes List wait for the context to be done and
 	// return the events with a ListIncompleteError for these containers.
-	notInspected []string
+	notInspected []container.ContainerRef
 }
 
 func (e *listEngine) Name() string { return e.name }
@@ -97,7 +97,7 @@ func TestBootstrapEnginesSkipsUnresponsiveEngine(t *testing.T) {
 func TestBootstrapEnginesKeepsEngineWithIncompleteListing(t *testing.T) {
 	setEngineTimeout(t, 1)
 
-	notInspected := []string{"def456def456", "0123456789ab", "fedcba987654", "aabbccddeeff"}
+	notInspected := []container.ContainerRef{{ID: "def456def456"}, {ID: "0123456789ab"}, {ID: "fedcba987654"}, {ID: "aabbccddeeff"}}
 	slow := &listEngine{name: "podman", socket: "/run/podman/podman.sock", events: []event.Event{
 		{Info: event.Info{Container: event.Container{ID: "abc123abc123", Name: "inspected"}}, IsCreate: true},
 	}, notInspected: notInspected}
@@ -118,7 +118,9 @@ func TestBootstrapEnginesKeepsEngineWithIncompleteListing(t *testing.T) {
 	assert.Equal(t, map[string][]string{"podman": {"/run/podman/podman.sock"}}, sockets)
 	require.Len(t, delivered, 1)
 	assert.Contains(t, delivered[0], "abc123abc123")
-	assert.Equal(t, notInspected, deferred)
+	require.Len(t, deferred, 1)
+	assert.Same(t, slow, deferred[0].Engine)
+	assert.Equal(t, notInspected, deferred[0].Containers)
 }
 
 func TestBootstrapEnginesKeepsEngineFailingToList(t *testing.T) {

--- a/plugins/container/go-worker/bootstrap_test.go
+++ b/plugins/container/go-worker/bootstrap_test.go
@@ -24,8 +24,8 @@ type listEngine struct {
 	err          error
 	unresponsive bool
 	// notInspected, when set, makes List wait for the context to be done and
-	// return the events with a ListIncompleteError for that many containers.
-	notInspected int
+	// return the events with a ListIncompleteError for these containers.
+	notInspected []string
 }
 
 func (e *listEngine) Name() string { return e.name }
@@ -37,9 +37,9 @@ func (e *listEngine) List(ctx context.Context) ([]event.Event, error) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
-	if e.notInspected > 0 {
+	if len(e.notInspected) > 0 {
 		<-ctx.Done()
-		return e.events, &container.ListIncompleteError{Remaining: e.notInspected, Err: context.Cause(ctx)}
+		return e.events, &container.ListIncompleteError{NotInspected: e.notInspected, Err: context.Cause(ctx)}
 	}
 	return e.events, e.err
 }
@@ -78,7 +78,7 @@ func TestBootstrapEnginesSkipsUnresponsiveEngine(t *testing.T) {
 
 	var delivered []string
 	start := time.Now()
-	engines, sockets := bootstrapEngines(context.Background(), generators, func(json string, added, initialState bool) {
+	engines, sockets, deferred := bootstrapEngines(context.Background(), generators, func(json string, added, initialState bool) {
 		assert.True(t, added)
 		assert.True(t, initialState)
 		delivered = append(delivered, json)
@@ -91,18 +91,20 @@ func TestBootstrapEnginesSkipsUnresponsiveEngine(t *testing.T) {
 	assert.Equal(t, []container.Engine{healthy}, engines)
 	assert.Equal(t, map[string][]string{"docker": {"/var/run/docker.sock"}}, sockets)
 	assert.Len(t, delivered, 2)
+	assert.Empty(t, deferred)
 }
 
 func TestBootstrapEnginesKeepsEngineWithIncompleteListing(t *testing.T) {
 	setEngineTimeout(t, 1)
 
+	notInspected := []string{"def456def456", "0123456789ab", "fedcba987654", "aabbccddeeff"}
 	slow := &listEngine{name: "podman", socket: "/run/podman/podman.sock", events: []event.Event{
 		{Info: event.Info{Container: event.Container{ID: "abc123abc123", Name: "inspected"}}, IsCreate: true},
-	}, notInspected: 4}
+	}, notInspected: notInspected}
 
 	var delivered []string
 	start := time.Now()
-	engines, sockets := bootstrapEngines(context.Background(), []container.EngineGenerator{generatorOf(slow)}, func(json string, added, initialState bool) {
+	engines, sockets, deferred := bootstrapEngines(context.Background(), []container.EngineGenerator{generatorOf(slow)}, func(json string, added, initialState bool) {
 		assert.True(t, added)
 		assert.True(t, initialState)
 		delivered = append(delivered, json)
@@ -110,23 +112,25 @@ func TestBootstrapEnginesKeepsEngineWithIncompleteListing(t *testing.T) {
 	elapsed := time.Since(start)
 
 	// The engine answers, so it stays in use: the containers it inspected in
-	// time are delivered, the others wait for their first event.
+	// time are delivered, the others are deferred to the fetcher.
 	assert.GreaterOrEqual(t, elapsed, time.Second)
 	assert.Equal(t, []container.Engine{slow}, engines)
 	assert.Equal(t, map[string][]string{"podman": {"/run/podman/podman.sock"}}, sockets)
 	require.Len(t, delivered, 1)
 	assert.Contains(t, delivered[0], "abc123abc123")
+	assert.Equal(t, notInspected, deferred)
 }
 
 func TestBootstrapEnginesKeepsEngineFailingToList(t *testing.T) {
 	failing := &listEngine{name: "containerd", socket: "/run/containerd/containerd.sock", err: errors.New("permission denied")}
 
 	delivered := 0
-	engines, sockets := bootstrapEngines(context.Background(), []container.EngineGenerator{generatorOf(failing)}, func(string, bool, bool) {
+	engines, sockets, deferred := bootstrapEngines(context.Background(), []container.EngineGenerator{generatorOf(failing)}, func(string, bool, bool) {
 		delivered++
 	})
 
 	assert.Equal(t, []container.Engine{failing}, engines)
 	assert.Equal(t, map[string][]string{"containerd": {"/run/containerd/containerd.sock"}}, sockets)
 	assert.Zero(t, delivered)
+	assert.Empty(t, deferred)
 }

--- a/plugins/container/go-worker/bootstrap_test.go
+++ b/plugins/container/go-worker/bootstrap_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/config"
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/container"
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
+)
+
+// listEngine is an Engine whose List returns canned events or an error, or
+// blocks until the context is done when unresponsive.
+type listEngine struct {
+	name, socket string
+	events       []event.Event
+	err          error
+	unresponsive bool
+}
+
+func (e *listEngine) Name() string { return e.name }
+
+func (e *listEngine) Sock() string { return e.socket }
+
+func (e *listEngine) List(ctx context.Context) ([]event.Event, error) {
+	if e.unresponsive {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return e.events, e.err
+}
+
+func (e *listEngine) Listen(context.Context, *sync.WaitGroup) (<-chan event.Event, error) {
+	return nil, errors.New("not implemented")
+}
+
+func generatorOf(engine container.Engine) container.EngineGenerator {
+	return func(context.Context) (container.Engine, error) { return engine, nil }
+}
+
+// setEngineTimeout sets the engine timeout, in seconds, for the test duration.
+func setEngineTimeout(t *testing.T, seconds int) {
+	t.Helper()
+	previous := config.Get().EngineTimeout
+	require.NoError(t, config.Load(fmt.Sprintf(`{"engine_timeout": %d}`, seconds)))
+	t.Cleanup(func() {
+		require.NoError(t, config.Load(fmt.Sprintf(`{"engine_timeout": %d}`, previous)))
+	})
+}
+
+func TestBootstrapEnginesSkipsUnresponsiveEngine(t *testing.T) {
+	setEngineTimeout(t, 1)
+
+	unresponsive := &listEngine{name: "podman", socket: "/run/podman/podman.sock", unresponsive: true}
+	healthy := &listEngine{name: "docker", socket: "/var/run/docker.sock", events: []event.Event{
+		{Info: event.Info{Container: event.Container{ID: "abc123abc123"}}, IsCreate: true},
+		{Info: event.Info{Container: event.Container{ID: "def456def456"}}, IsCreate: true},
+	}}
+	generators := []container.EngineGenerator{
+		generatorOf(unresponsive),
+		func(context.Context) (container.Engine, error) { return nil, errors.New("connection refused") },
+		generatorOf(healthy),
+	}
+
+	var delivered []string
+	start := time.Now()
+	engines, sockets := bootstrapEngines(context.Background(), generators, func(json string, added, initialState bool) {
+		assert.True(t, added)
+		assert.True(t, initialState)
+		delivered = append(delivered, json)
+	})
+	elapsed := time.Since(start)
+
+	// The unresponsive engine is given up after the engine timeout, not before.
+	assert.GreaterOrEqual(t, elapsed, time.Second)
+	assert.Less(t, elapsed, 5*time.Second)
+	assert.Equal(t, []container.Engine{healthy}, engines)
+	assert.Equal(t, map[string][]string{"docker": {"/var/run/docker.sock"}}, sockets)
+	assert.Len(t, delivered, 2)
+}
+
+func TestBootstrapEnginesKeepsEngineFailingToList(t *testing.T) {
+	failing := &listEngine{name: "containerd", socket: "/run/containerd/containerd.sock", err: errors.New("permission denied")}
+
+	delivered := 0
+	engines, sockets := bootstrapEngines(context.Background(), []container.EngineGenerator{generatorOf(failing)}, func(string, bool, bool) {
+		delivered++
+	})
+
+	assert.Equal(t, []container.Engine{failing}, engines)
+	assert.Equal(t, map[string][]string{"containerd": {"/run/containerd/containerd.sock"}}, sockets)
+	assert.Zero(t, delivered)
+}

--- a/plugins/container/go-worker/bootstrap_test.go
+++ b/plugins/container/go-worker/bootstrap_test.go
@@ -23,6 +23,9 @@ type listEngine struct {
 	events       []event.Event
 	err          error
 	unresponsive bool
+	// notInspected, when set, makes List wait for the context to be done and
+	// return the events with a ListIncompleteError for that many containers.
+	notInspected int
 }
 
 func (e *listEngine) Name() string { return e.name }
@@ -33,6 +36,10 @@ func (e *listEngine) List(ctx context.Context) ([]event.Event, error) {
 	if e.unresponsive {
 		<-ctx.Done()
 		return nil, ctx.Err()
+	}
+	if e.notInspected > 0 {
+		<-ctx.Done()
+		return e.events, &container.ListIncompleteError{Remaining: e.notInspected, Err: context.Cause(ctx)}
 	}
 	return e.events, e.err
 }
@@ -84,6 +91,31 @@ func TestBootstrapEnginesSkipsUnresponsiveEngine(t *testing.T) {
 	assert.Equal(t, []container.Engine{healthy}, engines)
 	assert.Equal(t, map[string][]string{"docker": {"/var/run/docker.sock"}}, sockets)
 	assert.Len(t, delivered, 2)
+}
+
+func TestBootstrapEnginesKeepsEngineWithIncompleteListing(t *testing.T) {
+	setEngineTimeout(t, 1)
+
+	slow := &listEngine{name: "podman", socket: "/run/podman/podman.sock", events: []event.Event{
+		{Info: event.Info{Container: event.Container{ID: "abc123abc123", Name: "inspected"}}, IsCreate: true},
+	}, notInspected: 4}
+
+	var delivered []string
+	start := time.Now()
+	engines, sockets := bootstrapEngines(context.Background(), []container.EngineGenerator{generatorOf(slow)}, func(json string, added, initialState bool) {
+		assert.True(t, added)
+		assert.True(t, initialState)
+		delivered = append(delivered, json)
+	})
+	elapsed := time.Since(start)
+
+	// The engine answers, so it stays in use: the containers it inspected in
+	// time are delivered, the others wait for their first event.
+	assert.GreaterOrEqual(t, elapsed, time.Second)
+	assert.Equal(t, []container.Engine{slow}, engines)
+	assert.Equal(t, map[string][]string{"podman": {"/run/podman/podman.sock"}}, sockets)
+	require.Len(t, delivered, 1)
+	assert.Contains(t, delivered[0], "abc123abc123")
 }
 
 func TestBootstrapEnginesKeepsEngineFailingToList(t *testing.T) {

--- a/plugins/container/go-worker/go.mod
+++ b/plugins/container/go-worker/go.mod
@@ -163,8 +163,8 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.83.2 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
+	google.golang.org/grpc v1.83.2
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.35.0 // indirect

--- a/plugins/container/go-worker/pkg/config/config.go
+++ b/plugins/container/go-worker/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
+	"time"
 )
 
 const (
@@ -13,6 +14,9 @@ const (
 	HookRemove
 
 	defaultLabelMaxLen = 100
+	// defaultEngineTimeout is how many seconds a container runtime gets to
+	// answer while the worker connects to it and lists the existing containers.
+	defaultEngineTimeout = 10
 )
 
 type SocketsEngine struct {
@@ -27,6 +31,9 @@ type EngineCfg struct {
 	HostRoot       string                   `json:"host_root"`
 	Hooks          byte                     `json:"hooks"`
 	LogLevel       logLevel                 `json:"log_level"`
+	// EngineTimeout bounds, in seconds, each connection to a container runtime
+	// and the listing of its containers at startup. Zero disables the bound.
+	EngineTimeout int `json:"engine_timeout"`
 }
 
 // logLevel wraps slog.Level to support JSON unmarshaling from string
@@ -71,6 +78,7 @@ func init() {
 	// By default, for go-worker executable (make exe) and go-worker tests,
 	// we attach remove hook too.
 	c.Hooks = HookCreate | HookRemove
+	c.EngineTimeout = defaultEngineTimeout
 	// Set default slog handler with Falco log format
 	// Format: Thu Nov 06 11:46:17 2025: [container-engine] [info]: message
 	updateSlogHandler()
@@ -101,6 +109,15 @@ func GetWithSize() bool {
 
 func GetHostRoot() string {
 	return c.HostRoot
+}
+
+// GetEngineTimeout returns how long a container runtime gets to answer while
+// the worker connects to it and lists its containers. Zero means no bound.
+func GetEngineTimeout() time.Duration {
+	if c.EngineTimeout <= 0 {
+		return 0
+	}
+	return time.Duration(c.EngineTimeout) * time.Second
 }
 
 func IsHookEnabled(hook byte) bool {

--- a/plugins/container/go-worker/pkg/config/config_test.go
+++ b/plugins/container/go-worker/pkg/config/config_test.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,7 +108,8 @@ func TestEngineCfg_UnmarshalJSON(t *testing.T) {
 				"with_size": true,
 				"host_root": "/host",
 				"hooks": 7,
-				"log_level": "trace"
+				"log_level": "trace",
+				"engine_timeout": 5
 			}`,
 			wantCfg: EngineCfg{
 				SocketsEngines: map[string]SocketsEngine{
@@ -115,11 +118,12 @@ func TestEngineCfg_UnmarshalJSON(t *testing.T) {
 						Sockets: []string{"/var/run/cri.sock"},
 					},
 				},
-				LabelMaxLen: 200,
-				WithSize:    true,
-				HostRoot:    "/host",
-				Hooks:       7,
-				LogLevel:    logLevel(LevelTrace),
+				LabelMaxLen:   200,
+				WithSize:      true,
+				HostRoot:      "/host",
+				Hooks:         7,
+				LogLevel:      logLevel(LevelTrace),
+				EngineTimeout: 5,
 			},
 			wantError: false,
 		},
@@ -224,6 +228,9 @@ func TestEngineCfg_UnmarshalJSON(t *testing.T) {
 				if len(tt.wantCfg.SocketsEngines) > 0 {
 					assert.Equal(t, tt.wantCfg.SocketsEngines, cfg.SocketsEngines)
 				}
+				if tt.wantCfg.EngineTimeout != 0 {
+					assert.Equal(t, tt.wantCfg.EngineTimeout, cfg.EngineTimeout)
+				}
 			}
 		})
 	}
@@ -257,4 +264,27 @@ func TestLogLevel_Level(t *testing.T) {
 			assert.Equal(t, tt.want, tt.logLevel.Level())
 		})
 	}
+}
+
+func TestGetEngineTimeout(t *testing.T) {
+	t.Cleanup(func() {
+		require.NoError(t, Load(fmt.Sprintf(`{"engine_timeout": %d, "label_max_len": %d}`, defaultEngineTimeout, defaultLabelMaxLen)))
+	})
+
+	// Default.
+	require.NoError(t, Load(fmt.Sprintf(`{"engine_timeout": %d}`, defaultEngineTimeout)))
+	assert.Equal(t, time.Duration(defaultEngineTimeout)*time.Second, GetEngineTimeout())
+
+	// Seconds from the config.
+	require.NoError(t, Load(`{"engine_timeout": 3}`))
+	assert.Equal(t, 3*time.Second, GetEngineTimeout())
+
+	// Zero disables the bound.
+	require.NoError(t, Load(`{"engine_timeout": 0}`))
+	assert.Equal(t, time.Duration(0), GetEngineTimeout())
+
+	// A config that leaves the key out keeps the current value.
+	require.NoError(t, Load(`{"engine_timeout": 7}`))
+	require.NoError(t, Load(`{"label_max_len": 50}`))
+	assert.Equal(t, 7*time.Second, GetEngineTimeout())
 }

--- a/plugins/container/go-worker/pkg/container/containerd.go
+++ b/plugins/container/go-worker/pkg/container/containerd.go
@@ -272,14 +272,30 @@ func (c *containerdEngine) List(ctx context.Context) ([]event.Event, error) {
 	for _, namespace := range namespacesList {
 		namespacedContext := namespaces.WithNamespace(ctx, namespace)
 		containersList, err := c.client.Containers(namespacedContext)
+		// Once the caller's context is done every request fails: leave the
+		// remaining containers to the lookups on their first event instead of
+		// returning them with partial metadata, or skipping whole namespaces.
+		if cut := listCut(ctx); cut != nil {
+			return evts, &ListIncompleteError{Err: cut}
+		}
 		if err != nil {
 			continue
 		}
-		for _, container := range containersList {
-			evts = append(evts, event.Event{
+		for idx, container := range containersList {
+			if cut := listCut(ctx); cut != nil {
+				return evts, &ListIncompleteError{Remaining: len(containersList) - idx, Err: cut}
+			}
+			evt := event.Event{
 				Info:     c.ctrToInfo(namespacedContext, container),
 				IsCreate: true,
-			})
+			}
+			// ctrToInfo falls back to an empty info and spec on error: a
+			// context done meanwhile is such an error, so do not return this
+			// container either.
+			if cut := listCut(ctx); cut != nil {
+				return evts, &ListIncompleteError{Remaining: len(containersList) - idx, Err: cut}
+			}
+			evts = append(evts, evt)
 		}
 	}
 	return evts, nil

--- a/plugins/container/go-worker/pkg/container/containerd.go
+++ b/plugins/container/go-worker/pkg/container/containerd.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -268,6 +269,21 @@ func (c *containerdEngine) Sock() string {
 	return c.socket
 }
 
+// listNamespace discovers the full identities that a cut startup listing
+// could not enumerate. Inspection remains separate so requests and retries
+// can run between containers.
+func (c *containerdEngine) listNamespace(ctx context.Context, namespace string) ([]ContainerRef, error) {
+	ctrs, err := c.client.Containers(namespaces.WithNamespace(ctx, namespace))
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]ContainerRef, 0, len(ctrs))
+	for _, ctr := range ctrs {
+		refs = append(refs, ContainerRef{ID: ctr.ID(), Namespace: namespace})
+	}
+	return refs, nil
+}
+
 func (c *containerdEngine) List(ctx context.Context) ([]event.Event, error) {
 	namespacesList, err := c.client.NamespaceService().List(ctx)
 	if err != nil {
@@ -290,14 +306,20 @@ func (c *containerdEngine) List(ctx context.Context) ([]event.Event, error) {
 		}
 		return &ListIncompleteError{NotInspected: refs, Err: cut}
 	}
-	for _, namespace := range namespacesList {
+	for idx, namespace := range namespacesList {
 		namespacedContext := namespaces.WithNamespace(ctx, namespace)
 		containersList, err := c.client.Containers(namespacedContext)
-		// Once the caller's context is done every request fails: the
-		// containers enumerated so far are left to the background lookups,
-		// those of the namespaces not enumerated yet to their first event.
-		if cut := listCut(ctx); cut != nil {
-			return nil, incomplete(0, cut)
+		// The RPC can report a deadline before ctx.Err() observes it. Keep
+		// both known IDs and unfinished namespaces for background recovery:
+		// process events only carry short IDs, which containerd cannot load.
+		cut := listCut(ctx)
+		if cut == nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)) {
+			cut = err
+		}
+		if cut != nil {
+			pending := incomplete(0, cut)
+			pending.NotEnumerated = namespacesList[idx:]
+			return nil, pending
 		}
 		if err != nil {
 			continue

--- a/plugins/container/go-worker/pkg/container/containerd.go
+++ b/plugins/container/go-worker/pkg/container/containerd.go
@@ -243,16 +243,21 @@ func (c *containerdEngine) get(ctx context.Context, containerId string) (*event.
 		return nil, err
 	}
 	for _, namespace := range namespacesList {
-		namespacedContext := namespaces.WithNamespace(ctx, namespace)
-		container, err := c.client.LoadContainer(namespacedContext, containerId)
-		if err == nil {
-			return &event.Event{
-				Info:     c.ctrToInfo(namespacedContext, container),
-				IsCreate: true,
-			}, nil
+		if evt, err := c.getInNamespace(ctx, namespace, containerId); err == nil {
+			return evt, nil
 		}
 	}
 	return nil, nil
+}
+
+// getInNamespace preserves the identity obtained during startup enumeration.
+func (c *containerdEngine) getInNamespace(ctx context.Context, namespace, containerID string) (*event.Event, error) {
+	ctx = namespaces.WithNamespace(ctx, namespace)
+	ctr, err := c.client.LoadContainer(ctx, containerID)
+	if err != nil {
+		return nil, err
+	}
+	return &event.Event{Info: c.ctrToInfo(ctx, ctr), IsCreate: true}, nil
 }
 
 func (c *containerdEngine) Name() string {
@@ -272,13 +277,18 @@ func (c *containerdEngine) List(ctx context.Context) ([]event.Event, error) {
 	// that a listing cut by the caller can report the ones not inspected.
 	type namespaced struct {
 		ctx       context.Context
+		namespace string
 		container containerd.Container
 	}
 	enumerated := make([]namespaced, 0)
 	// incomplete reports the enumerated containers from index from on as not
 	// inspected.
 	incomplete := func(from int, cut error) *ListIncompleteError {
-		return &ListIncompleteError{NotInspected: notInspectedFrom(len(enumerated), from, func(i int) string { return enumerated[i].container.ID() }), Err: cut}
+		refs := make([]ContainerRef, 0, len(enumerated)-from)
+		for _, nc := range enumerated[from:] {
+			refs = append(refs, ContainerRef{ID: nc.container.ID(), Namespace: nc.namespace})
+		}
+		return &ListIncompleteError{NotInspected: refs, Err: cut}
 	}
 	for _, namespace := range namespacesList {
 		namespacedContext := namespaces.WithNamespace(ctx, namespace)
@@ -293,7 +303,7 @@ func (c *containerdEngine) List(ctx context.Context) ([]event.Event, error) {
 			continue
 		}
 		for _, container := range containersList {
-			enumerated = append(enumerated, namespaced{ctx: namespacedContext, container: container})
+			enumerated = append(enumerated, namespaced{ctx: namespacedContext, namespace: namespace, container: container})
 		}
 	}
 	evts := make([]event.Event, 0, len(enumerated))

--- a/plugins/container/go-worker/pkg/container/containerd.go
+++ b/plugins/container/go-worker/pkg/container/containerd.go
@@ -268,35 +268,52 @@ func (c *containerdEngine) List(ctx context.Context) ([]event.Event, error) {
 	if err != nil {
 		return nil, err
 	}
-	evts := make([]event.Event, 0)
+	// Enumerate the containers of every namespace before inspecting any, so
+	// that a listing cut by the caller can report the ones not inspected.
+	type namespaced struct {
+		ctx       context.Context
+		container containerd.Container
+	}
+	enumerated := make([]namespaced, 0)
+	// incomplete reports the enumerated containers from index from on as not
+	// inspected.
+	incomplete := func(from int, cut error) *ListIncompleteError {
+		return &ListIncompleteError{NotInspected: notInspectedFrom(len(enumerated), from, func(i int) string { return enumerated[i].container.ID() }), Err: cut}
+	}
 	for _, namespace := range namespacesList {
 		namespacedContext := namespaces.WithNamespace(ctx, namespace)
 		containersList, err := c.client.Containers(namespacedContext)
-		// Once the caller's context is done every request fails: leave the
-		// remaining containers to the lookups on their first event instead of
-		// returning them with partial metadata, or skipping whole namespaces.
+		// Once the caller's context is done every request fails: the
+		// containers enumerated so far are left to the background lookups,
+		// those of the namespaces not enumerated yet to their first event.
 		if cut := listCut(ctx); cut != nil {
-			return evts, &ListIncompleteError{Err: cut}
+			return nil, incomplete(0, cut)
 		}
 		if err != nil {
 			continue
 		}
-		for idx, container := range containersList {
-			if cut := listCut(ctx); cut != nil {
-				return evts, &ListIncompleteError{Remaining: len(containersList) - idx, Err: cut}
-			}
-			evt := event.Event{
-				Info:     c.ctrToInfo(namespacedContext, container),
-				IsCreate: true,
-			}
-			// ctrToInfo falls back to an empty info and spec on error: a
-			// context done meanwhile is such an error, so do not return this
-			// container either.
-			if cut := listCut(ctx); cut != nil {
-				return evts, &ListIncompleteError{Remaining: len(containersList) - idx, Err: cut}
-			}
-			evts = append(evts, evt)
+		for _, container := range containersList {
+			enumerated = append(enumerated, namespaced{ctx: namespacedContext, container: container})
 		}
+	}
+	evts := make([]event.Event, 0, len(enumerated))
+	for idx, nc := range enumerated {
+		// Leave the remaining containers to the background lookups instead of
+		// returning them with partial metadata.
+		if cut := listCut(ctx); cut != nil {
+			return evts, incomplete(idx, cut)
+		}
+		evt := event.Event{
+			Info:     c.ctrToInfo(nc.ctx, nc.container),
+			IsCreate: true,
+		}
+		// ctrToInfo falls back to an empty info and spec on error: a context
+		// done meanwhile is such an error, so do not return this container
+		// either.
+		if cut := listCut(ctx); cut != nil {
+			return evts, incomplete(idx, cut)
+		}
+		evts = append(evts, evt)
 	}
 	return evts, nil
 }

--- a/plugins/container/go-worker/pkg/container/containerd_deferred_test.go
+++ b/plugins/container/go-worker/pkg/container/containerd_deferred_test.go
@@ -1,0 +1,179 @@
+package container
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	containersapi "github.com/containerd/containerd/api/services/containers/v1"
+	namespacesapi "github.com/containerd/containerd/api/services/namespaces/v1"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
+)
+
+type deferredNamespaces struct {
+	namespacesapi.UnimplementedNamespacesServer
+	lists atomic.Int32
+}
+
+func (s *deferredNamespaces) List(context.Context, *namespacesapi.ListNamespacesRequest) (*namespacesapi.ListNamespacesResponse, error) {
+	s.lists.Add(1)
+	return &namespacesapi.ListNamespacesResponse{Namespaces: []*namespacesapi.Namespace{{Name: "alpha"}, {Name: "beta"}}}, nil
+}
+
+type deferredContainerService struct {
+	containersapi.UnimplementedContainersServer
+	mu         sync.Mutex
+	containers map[string]*containersapi.Container
+	stall      bool
+	misses     map[string]int
+	wrongIDs   int
+}
+
+func (s *deferredContainerService) List(ctx context.Context, _ *containersapi.ListContainersRequest) (*containersapi.ListContainersResponse, error) {
+	ns, _ := namespaces.Namespace(ctx)
+	return &containersapi.ListContainersResponse{Containers: []*containersapi.Container{s.containers[ns]}}, nil
+}
+
+func (s *deferredContainerService) Get(ctx context.Context, req *containersapi.GetContainerRequest) (*containersapi.GetContainerResponse, error) {
+	ns, _ := namespaces.Namespace(ctx)
+	s.mu.Lock()
+	if s.stall {
+		s.stall = false
+		s.mu.Unlock()
+		<-ctx.Done()
+		return nil, status.FromContextError(ctx.Err()).Err()
+	}
+	defer s.mu.Unlock()
+	ctr := s.containers[ns]
+	// Containerd Get requires the exact ID within its namespace.
+	if ctr == nil || req.ID != ctr.ID {
+		s.wrongIDs++
+		return nil, status.Error(codes.NotFound, "unknown container")
+	}
+	if s.misses[ns] > 0 {
+		s.misses[ns]--
+		return nil, status.Error(codes.NotFound, "container temporarily unavailable")
+	}
+	return &containersapi.GetContainerResponse{Container: ctr}, nil
+}
+
+type unrelatedEngine struct {
+	selfEngine
+	calls atomic.Int32
+}
+
+func (*unrelatedEngine) Name() string { return "unrelated" }
+
+func (e *unrelatedEngine) copy(context.Context) (Engine, error) { return e, nil }
+
+func (e *unrelatedEngine) get(context.Context, string) (*event.Event, error) {
+	e.calls.Add(1)
+	return nil, nil
+}
+
+func TestContainerdDeferredRecovery(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		requested bool
+		retry     bool
+	}{{"background", false, false}, {"background_retry", false, true}, {"request_retry", true, true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			socket := filepath.Join(t.TempDir(), "runtime.sock")
+			listener, err := net.Listen("unix", socket)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = listener.Close() })
+			nsService := &deferredNamespaces{}
+			ctrService := &deferredContainerService{
+				containers: make(map[string]*containersapi.Container), stall: true, misses: make(map[string]int),
+			}
+			for i, ns := range []string{"alpha", "beta"} {
+				ctrService.containers[ns] = &containersapi.Container{
+					ID: strings.Repeat(string(rune('a'+i)), 64), Labels: map[string]string{"namespace": ns},
+					Spec: &anypb.Any{TypeUrl: "types.containerd.io/opencontainers/runtime-spec/1/Spec", Value: []byte(`{"process":{"user":{"uid":0}},"linux":{}}`)},
+				}
+			}
+			server := grpc.NewServer()
+			namespacesapi.RegisterNamespacesServer(server, nsService)
+			containersapi.RegisterContainersServer(server, ctrService)
+			go func() { _ = server.Serve(listener) }()
+			t.Cleanup(server.Stop)
+			engine, err := newContainerdEngine(context.Background(), slog.Default(), socket)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = engine.(*containerdEngine).client.Close() })
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			evts, err := engine.List(ctx)
+			cancel()
+			var incomplete *ListIncompleteError
+			require.ErrorAs(t, err, &incomplete)
+			require.Empty(t, evts)
+			require.Len(t, incomplete.NotInspected, 2)
+			for _, ref := range incomplete.NotInspected {
+				require.Contains(t, ctrService.containers, ref.Namespace)
+				require.Equal(t, ctrService.containers[ref.Namespace].ID, ref.ID)
+			}
+			if tc.retry {
+				ctrService.mu.Lock()
+				ctrService.misses["alpha"], ctrService.misses["beta"] = 1, 1
+				ctrService.mu.Unlock()
+			}
+			fetchCh := make(chan string, 100)
+			if tc.requested {
+				for _, ref := range incomplete.NotInspected {
+					// Process requests carry only the cache ID. Duplicate
+					// requests must share the pending full-ID lookup.
+					fetchCh <- shortContainerID(ref.ID)
+					fetchCh <- shortContainerID(ref.ID)
+				}
+			}
+			unrelated := &unrelatedEngine{}
+			f := NewFetcherEngine(context.Background(), fetchCh, []Engine{unrelated, engine},
+				[]DeferredContainers{{Engine: engine, Containers: incomplete.NotInspected}}).(*fetcher)
+			f.retryBackoff = fastBackoff
+			for _, g := range f.getters {
+				if c, ok := g.(*containerdEngine); ok {
+					t.Cleanup(func() { _ = c.client.Close() })
+				}
+			}
+			fetchCtx, stop := context.WithCancel(context.Background())
+			var wg sync.WaitGroup
+			out, err := f.Listen(fetchCtx, &wg)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				stop()
+				wg.Wait()
+				close(fetchCh)
+			})
+			found := make(map[string]event.Event)
+			for len(found) < 2 {
+				evt := waitOnChannelOrTimeout(t, out)
+				found[evt.ID] = evt
+			}
+			assertNoEvent(t, out, 20*time.Millisecond)
+			for ns, ctr := range ctrService.containers {
+				evt := found[shortContainerID(ctr.ID)]
+				assert.Equal(t, ctr.ID, evt.FullID)
+				assert.Equal(t, ns, evt.Labels["namespace"])
+				assert.True(t, evt.Privileged)
+			}
+			assert.Zero(t, unrelated.calls.Load(), "deferred lookup probed another runtime")
+			assert.EqualValues(t, 1, nsService.lists.Load(), "deferred lookup rediscovered known namespaces")
+			ctrService.mu.Lock()
+			assert.Zero(t, ctrService.wrongIDs)
+			ctrService.mu.Unlock()
+		})
+	}
+}

--- a/plugins/container/go-worker/pkg/container/containerd_enumeration_test.go
+++ b/plugins/container/go-worker/pkg/container/containerd_enumeration_test.go
@@ -1,0 +1,188 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	containersapi "github.com/containerd/containerd/api/services/containers/v1"
+	namespacesapi "github.com/containerd/containerd/api/services/namespaces/v1"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
+)
+
+// slowEnumeration stalls the first listing of one namespace, then fails a
+// configurable number of attempts before recovering. Get requires full IDs,
+// as containerd does; process requests alone cannot recover these containers.
+type slowEnumeration struct {
+	containersapi.UnimplementedContainersServer
+	containers map[string][]*containersapi.Container
+	stall      string
+	failures   int
+	rpcError   codes.Code
+	mu         sync.Mutex
+	calls      map[string]int
+}
+
+func (s *slowEnumeration) List(ctx context.Context, _ *containersapi.ListContainersRequest) (*containersapi.ListContainersResponse, error) {
+	ns, _ := namespaces.Namespace(ctx)
+	s.mu.Lock()
+	s.calls[ns]++
+	attempt := s.calls[ns]
+	s.mu.Unlock()
+	if ns == s.stall {
+		if attempt == 1 {
+			if s.rpcError != codes.OK {
+				return nil, status.Error(s.rpcError, "listing interrupted by the runtime")
+			}
+			<-ctx.Done()
+			return nil, status.FromContextError(ctx.Err()).Err()
+		}
+		if attempt <= s.failures+1 {
+			return nil, status.Error(codes.Unavailable, "runtime still recovering")
+		}
+	}
+	return &containersapi.ListContainersResponse{Containers: s.containers[ns]}, nil
+}
+
+func (s *slowEnumeration) Get(ctx context.Context, req *containersapi.GetContainerRequest) (*containersapi.GetContainerResponse, error) {
+	ns, _ := namespaces.Namespace(ctx)
+	for _, ctr := range s.containers[ns] {
+		if req.ID == ctr.ID {
+			return &containersapi.GetContainerResponse{Container: ctr}, nil
+		}
+	}
+	return nil, status.Error(codes.NotFound, "exact container ID required")
+}
+
+func TestContainerdRecoversUnenumeratedNamespaces(t *testing.T) {
+	for _, tc := range []struct {
+		name, stall string
+		requests    bool
+		failures    int
+		rpcError    codes.Code
+	}{
+		{name: "first_namespace", stall: "alpha"},
+		{name: "later_namespace", stall: "beta"},
+		{name: "saturated_requests", stall: "beta", requests: true},
+		{name: "namespace_retries_outlive_container_backoff", stall: "alpha", failures: 5},
+		{name: "rpc_deadline_before_context", stall: "alpha", rpcError: codes.DeadlineExceeded},
+		{name: "rpc_cancellation_before_context", stall: "beta", rpcError: codes.Canceled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			service := &slowEnumeration{
+				containers: make(map[string][]*containersapi.Container), calls: make(map[string]int),
+				stall: tc.stall, failures: tc.failures, rpcError: tc.rpcError,
+			}
+			const total = 151 // more than the process request channel can hold
+			for i := 0; i < total; i++ {
+				ns := "beta"
+				if i == 0 {
+					ns = "alpha"
+				}
+				service.containers[ns] = append(service.containers[ns], &containersapi.Container{
+					ID: fmt.Sprintf("%012x", i) + strings.Repeat("a", 52), Image: "alpine:latest",
+					Labels: map[string]string{"namespace": ns},
+					Spec:   &anypb.Any{TypeUrl: "types.containerd.io/opencontainers/runtime-spec/1/Spec", Value: []byte(`{"process":{"user":{"uid":0}},"linux":{}}`)},
+				})
+			}
+			socket := filepath.Join(t.TempDir(), "runtime.sock")
+			listener, err := net.Listen("unix", socket)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = listener.Close() })
+			server := grpc.NewServer()
+			namespacesapi.RegisterNamespacesServer(server, &deferredNamespaces{})
+			containersapi.RegisterContainersServer(server, service)
+			go func() { _ = server.Serve(listener) }()
+			t.Cleanup(server.Stop)
+			engine, err := newContainerdEngine(context.Background(), slog.Default(), socket)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = engine.(*containerdEngine).client.Close() })
+
+			timeout := 50 * time.Millisecond
+			if tc.rpcError != codes.OK {
+				timeout = 5 * time.Second
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			evts, err := engine.List(ctx)
+			if tc.rpcError != codes.OK {
+				require.NoError(t, ctx.Err(), "the RPC error must be handled before caller cancellation")
+			}
+			cancel()
+			require.Empty(t, evts)
+			var incomplete *ListIncompleteError
+			require.ErrorAs(t, err, &incomplete)
+			if tc.stall == "alpha" {
+				assert.Empty(t, incomplete.NotInspected)
+				assert.Equal(t, []string{"alpha", "beta"}, incomplete.NotEnumerated)
+			} else {
+				require.Len(t, incomplete.NotInspected, 1)
+				assert.Equal(t, []string{"beta"}, incomplete.NotEnumerated)
+			}
+
+			fetchCh := make(chan string, 100)
+			if tc.requests {
+				refused := 0
+				for _, ctrs := range service.containers {
+					for _, ctr := range ctrs {
+						select {
+						case fetchCh <- shortContainerID(ctr.ID):
+						default:
+							refused++
+						}
+					}
+				}
+				assert.Equal(t, total-cap(fetchCh), refused)
+			}
+			f := NewFetcherEngine(context.Background(), fetchCh, []Engine{engine}, []DeferredContainers{{
+				Engine: engine, Containers: incomplete.NotInspected, Namespaces: incomplete.NotEnumerated,
+			}}).(*fetcher)
+			f.retryBackoff = []time.Duration{2 * time.Millisecond, 4 * time.Millisecond}
+			for _, g := range f.getters {
+				c := g.(*containerdEngine)
+				t.Cleanup(func() { _ = c.client.Close() })
+			}
+			fetchCtx, stop := context.WithCancel(context.Background())
+			var wg sync.WaitGroup
+			out, err := f.Listen(fetchCtx, &wg)
+			require.NoError(t, err)
+			t.Cleanup(func() { stop(); wg.Wait(); close(fetchCh) })
+			found := make(map[string]event.Event)
+			deadline := time.After(5 * time.Second)
+			for len(found) < total {
+				select {
+				case evt := <-out:
+					found[evt.ID] = evt
+				case <-deadline:
+					t.Fatalf("recovered %d of %d containers", len(found), total)
+				}
+			}
+			for ns, ctrs := range service.containers {
+				for _, ctr := range ctrs {
+					evt := found[shortContainerID(ctr.ID)]
+					assert.Equal(t, ctr.ID, evt.FullID)
+					assert.Equal(t, ctr.Image, evt.Image)
+					assert.Equal(t, ns, evt.Labels["namespace"])
+				}
+			}
+			assertNoEvent(t, out, 20*time.Millisecond)
+			service.mu.Lock()
+			assert.Equal(t, tc.failures+2, service.calls[tc.stall])
+			service.mu.Unlock()
+		})
+	}
+}

--- a/plugins/container/go-worker/pkg/container/cri.go
+++ b/plugins/container/go-worker/pkg/container/cri.go
@@ -424,13 +424,17 @@ func (c *criEngine) List(ctx context.Context) ([]event.Event, error) {
 	if err != nil {
 		return nil, err
 	}
+	// incomplete reports the containers from index from on as not inspected.
+	incomplete := func(from int, cut error) *ListIncompleteError {
+		return &ListIncompleteError{NotInspected: notInspectedFrom(len(ctrs), from, func(i int) string { return ctrs[i].Id }), Err: cut}
+	}
 	evts := make([]event.Event, 0, len(ctrs))
 	for idx, ctr := range ctrs {
 		// Once the caller's context is done every request fails: leave the
-		// remaining containers to the lookups on their first event instead of
-		// returning them with partial metadata.
+		// remaining containers to the background lookups instead of returning
+		// them with partial metadata.
 		if cut := listCut(ctx); cut != nil {
-			return evts, &ListIncompleteError{Remaining: len(ctrs) - idx, Err: cut}
+			return evts, incomplete(idx, cut)
 		}
 		// verbose true to return container.Info
 		container, err := c.client.ContainerStatus(ctx, ctr.Id, true)
@@ -463,7 +467,7 @@ func (c *criEngine) List(ctx context.Context) ([]event.Event, error) {
 		// context done meanwhile is such an error, so do not return this
 		// container either.
 		if cut := listCut(ctx); cut != nil {
-			return evts, &ListIncompleteError{Remaining: len(ctrs) - idx, Err: cut}
+			return evts, incomplete(idx, cut)
 		}
 		evts = append(evts, evt)
 	}

--- a/plugins/container/go-worker/pkg/container/cri.go
+++ b/plugins/container/go-worker/pkg/container/cri.go
@@ -424,12 +424,19 @@ func (c *criEngine) List(ctx context.Context) ([]event.Event, error) {
 	if err != nil {
 		return nil, err
 	}
-	evts := make([]event.Event, len(ctrs))
+	evts := make([]event.Event, 0, len(ctrs))
 	for idx, ctr := range ctrs {
+		// Once the caller's context is done every request fails: leave the
+		// remaining containers to the lookups on their first event instead of
+		// returning them with partial metadata.
+		if cut := listCut(ctx); cut != nil {
+			return evts, &ListIncompleteError{Remaining: len(ctrs) - idx, Err: cut}
+		}
 		// verbose true to return container.Info
 		container, err := c.client.ContainerStatus(ctx, ctr.Id, true)
+		var evt event.Event
 		if err != nil || container.Status == nil {
-			evts[idx] = event.Event{
+			evt = event.Event{
 				IsCreate: true,
 				Info: event.Info{
 					Container: event.Container{
@@ -447,11 +454,18 @@ func (c *criEngine) List(ctx context.Context) ([]event.Event, error) {
 			if podSandboxStatus == nil {
 				podSandboxStatus = &v1.PodSandboxStatusResponse{}
 			}
-			evts[idx] = event.Event{
+			evt = event.Event{
 				IsCreate: true,
 				Info:     c.ctrToInfo(ctx, container.Status, podSandboxStatus.GetStatus(), container.GetInfo(), podSandboxStatus.GetInfo()),
 			}
 		}
+		// The status requests fall back to partial metadata on error: a
+		// context done meanwhile is such an error, so do not return this
+		// container either.
+		if cut := listCut(ctx); cut != nil {
+			return evts, &ListIncompleteError{Remaining: len(ctrs) - idx, Err: cut}
+		}
+		evts = append(evts, evt)
 	}
 	return evts, nil
 }

--- a/plugins/container/go-worker/pkg/container/cri_test.go
+++ b/plugins/container/go-worker/pkg/container/cri_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -736,6 +737,57 @@ func TestCRIListenResubscribes(t *testing.T) {
 
 	cancel()
 	wg.Wait()
+}
+
+// stallingRuntimeService wraps a RuntimeService and hangs the status request
+// at index stallAt, in call order, until its context is done.
+type stallingRuntimeService struct {
+	internalapi.RuntimeService
+	stallAt int
+	calls   atomic.Int32
+}
+
+func (s *stallingRuntimeService) ContainerStatus(ctx context.Context, containerID string, verbose bool) (*v1.ContainerStatusResponse, error) {
+	if int(s.calls.Add(1)) == s.stallAt+1 {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return s.RuntimeService.ContainerStatus(ctx, containerID, verbose)
+}
+
+func TestCRIListStopsInspectingOnceTheContextIsDone(t *testing.T) {
+	endpoint, err := fake.GenerateEndpoint()
+	require.NoError(t, err)
+	fakeRuntime := fake.NewFakeRemoteRuntime()
+	require.NoError(t, fakeRuntime.Start(endpoint))
+	t.Cleanup(fakeRuntime.Stop)
+
+	engine, err := newCriEngine(context.Background(), slog.Default(), endpoint)
+	require.NoError(t, err)
+	criEngine := engine.(*criEngine)
+	for i := 0; i < 6; i++ {
+		containerFor(t, fakeRuntime, fmt.Sprintf("ctr%d", i))
+	}
+	// Six containers, the third status request never answers: with a 200ms
+	// deadline the listing returns the two containers inspected so far, with
+	// their whole metadata, and leaves the other four to their first event.
+	stalling := &stallingRuntimeService{RuntimeService: criEngine.client, stallAt: 2}
+	criEngine.client = stalling
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	evts, err := engine.List(ctx)
+
+	var incomplete *ListIncompleteError
+	require.ErrorAs(t, err, &incomplete)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 4, incomplete.Remaining)
+	require.Len(t, evts, 2)
+	for _, evt := range evts {
+		assert.NotEmpty(t, evt.Name, "a container returned without its status")
+	}
+	// The containers left are not inspected at all.
+	assert.EqualValues(t, 3, stalling.calls.Load())
 }
 
 func containerFor(t *testing.T, fakeRuntime *fake.RemoteRuntime, name string) string {

--- a/plugins/container/go-worker/pkg/container/cri_test.go
+++ b/plugins/container/go-worker/pkg/container/cri_test.go
@@ -765,12 +765,13 @@ func TestCRIListStopsInspectingOnceTheContextIsDone(t *testing.T) {
 	engine, err := newCriEngine(context.Background(), slog.Default(), endpoint)
 	require.NoError(t, err)
 	criEngine := engine.(*criEngine)
+	ids := make(map[string]bool)
 	for i := 0; i < 6; i++ {
-		containerFor(t, fakeRuntime, fmt.Sprintf("ctr%d", i))
+		ids[shortContainerID(containerFor(t, fakeRuntime, fmt.Sprintf("ctr%d", i)))] = true
 	}
 	// Six containers, the third status request never answers: with a 200ms
 	// deadline the listing returns the two containers inspected so far, with
-	// their whole metadata, and leaves the other four to their first event.
+	// their whole metadata, and leaves the other four to the background lookups.
 	stalling := &stallingRuntimeService{RuntimeService: criEngine.client, stallAt: 2}
 	criEngine.client = stalling
 
@@ -781,10 +782,17 @@ func TestCRIListStopsInspectingOnceTheContextIsDone(t *testing.T) {
 	var incomplete *ListIncompleteError
 	require.ErrorAs(t, err, &incomplete)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 4, incomplete.Remaining)
 	require.Len(t, evts, 2)
 	for _, evt := range evts {
 		assert.NotEmpty(t, evt.Name, "a container returned without its status")
+		assert.True(t, ids[evt.ID], "unknown container %q returned", evt.ID)
+		delete(ids, evt.ID)
+	}
+	// The containers left are reported, by short ID, for the background lookups.
+	require.Len(t, incomplete.NotInspected, 4)
+	for _, id := range incomplete.NotInspected {
+		assert.True(t, ids[id], "container %q reported as not inspected was returned or never existed", id)
+		delete(ids, id)
 	}
 	// The containers left are not inspected at all.
 	assert.EqualValues(t, 3, stalling.calls.Load())

--- a/plugins/container/go-worker/pkg/container/cri_test.go
+++ b/plugins/container/go-worker/pkg/container/cri_test.go
@@ -788,9 +788,10 @@ func TestCRIListStopsInspectingOnceTheContextIsDone(t *testing.T) {
 		assert.True(t, ids[evt.ID], "unknown container %q returned", evt.ID)
 		delete(ids, evt.ID)
 	}
-	// The containers left are reported, by short ID, for the background lookups.
+	// The containers left retain their full runtime IDs for background lookups.
 	require.Len(t, incomplete.NotInspected, 4)
-	for _, id := range incomplete.NotInspected {
+	for _, ref := range incomplete.NotInspected {
+		id := shortContainerID(ref.ID)
 		assert.True(t, ids[id], "container %q reported as not inspected was returned or never existed", id)
 		delete(ids, id)
 	}

--- a/plugins/container/go-worker/pkg/container/docker.go
+++ b/plugins/container/go-worker/pkg/container/docker.go
@@ -252,12 +252,19 @@ func (dc *dockerEngine) List(ctx context.Context) ([]event.Event, error) {
 		return nil, err
 	}
 
-	evts := make([]event.Event, len(containers))
+	evts := make([]event.Event, 0, len(containers))
 	for idx, ctr := range containers {
+		// Once the caller's context is done every request fails: leave the
+		// remaining containers to the lookups on their first event instead of
+		// returning them with partial metadata.
+		if cut := listCut(ctx); cut != nil {
+			return evts, &ListIncompleteError{Remaining: len(containers) - idx, Err: cut}
+		}
 		ctrJson, _, err := dc.ContainerInspectWithRaw(ctx, ctr.ID, config.GetWithSize())
+		var evt event.Event
 		if err != nil {
 			// Minimum set of infos
-			evts[idx] = event.Event{
+			evt = event.Event{
 				Info: event.Info{
 					Container: event.Container{
 						Type:        typeDocker.ToCTValue(),
@@ -271,11 +278,18 @@ func (dc *dockerEngine) List(ctx context.Context) ([]event.Event, error) {
 				IsCreate: true,
 			}
 		} else {
-			evts[idx] = event.Event{
+			evt = event.Event{
 				Info:     dc.ctrToInfo(ctx, ctrJson),
 				IsCreate: true,
 			}
 		}
+		// The inspections (ctrToInfo inspects the image too) fall back to
+		// partial metadata on error: a context done meanwhile is such an
+		// error, so do not return this container either.
+		if cut := listCut(ctx); cut != nil {
+			return evts, &ListIncompleteError{Remaining: len(containers) - idx, Err: cut}
+		}
+		evts = append(evts, evt)
 	}
 	return evts, nil
 }

--- a/plugins/container/go-worker/pkg/container/docker.go
+++ b/plugins/container/go-worker/pkg/container/docker.go
@@ -252,13 +252,17 @@ func (dc *dockerEngine) List(ctx context.Context) ([]event.Event, error) {
 		return nil, err
 	}
 
+	// incomplete reports the containers from index from on as not inspected.
+	incomplete := func(from int, cut error) *ListIncompleteError {
+		return &ListIncompleteError{NotInspected: notInspectedFrom(len(containers), from, func(i int) string { return containers[i].ID }), Err: cut}
+	}
 	evts := make([]event.Event, 0, len(containers))
 	for idx, ctr := range containers {
 		// Once the caller's context is done every request fails: leave the
-		// remaining containers to the lookups on their first event instead of
-		// returning them with partial metadata.
+		// remaining containers to the background lookups instead of returning
+		// them with partial metadata.
 		if cut := listCut(ctx); cut != nil {
-			return evts, &ListIncompleteError{Remaining: len(containers) - idx, Err: cut}
+			return evts, incomplete(idx, cut)
 		}
 		ctrJson, _, err := dc.ContainerInspectWithRaw(ctx, ctr.ID, config.GetWithSize())
 		var evt event.Event
@@ -287,7 +291,7 @@ func (dc *dockerEngine) List(ctx context.Context) ([]event.Event, error) {
 		// partial metadata on error: a context done meanwhile is such an
 		// error, so do not return this container either.
 		if cut := listCut(ctx); cut != nil {
-			return evts, &ListIncompleteError{Remaining: len(containers) - idx, Err: cut}
+			return evts, incomplete(idx, cut)
 		}
 		evts = append(evts, evt)
 	}

--- a/plugins/container/go-worker/pkg/container/docker_timeout_test.go
+++ b/plugins/container/go-worker/pkg/container/docker_timeout_test.go
@@ -1,0 +1,94 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newStallingDockerAPI serves a Docker Engine API on a unix socket that lists
+// count containers at once, then answers every inspection but the one at
+// index stallAt, in request order, which hangs until the request is
+// cancelled. It returns the socket path and the count of the inspection
+// requests received.
+func newStallingDockerAPI(t *testing.T, count, stallAt int) (string, *atomic.Int32) {
+	t.Helper()
+	socket := filepath.Join(t.TempDir(), "docker.sock")
+	listener, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	imageID := "sha256:" + strings.Repeat("a", 64)
+	var inspected atomic.Int32
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/_ping"):
+			w.Header().Set("API-Version", "1.47")
+			w.Header().Set("OSType", "linux")
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			ctrs := make([]map[string]any, count)
+			for i := range ctrs {
+				ctrs[i] = map[string]any{"Id": fmt.Sprintf("%064d", i+1), "Image": "alpine:latest", "ImageID": imageID, "Created": 1757376000}
+			}
+			_ = json.NewEncoder(w).Encode(ctrs)
+		case strings.Contains(r.URL.Path, "/images/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"Id": imageID, "RepoTags": []string{"alpine:latest"}, "RepoDigests": []string{"alpine@sha256:" + strings.Repeat("b", 64)}})
+		default: // .../containers/{id}/json
+			if int(inspected.Add(1)) == stallAt+1 {
+				<-r.Context().Done()
+				return
+			}
+			parts := strings.Split(r.URL.Path, "/")
+			id := parts[len(parts)-2]
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"Id": id, "Name": "/healthy-" + shortContainerID(id), "Created": "2026-09-09T00:00:00Z", "Image": imageID,
+				"HostConfig": map[string]any{"Privileged": true},
+				"Config":     map[string]any{"Image": "alpine:latest", "Labels": map[string]string{"app": "critical"}},
+			})
+		}
+	})}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+	return socket, &inspected
+}
+
+func TestDockerListStopsInspectingOnceTheContextIsDone(t *testing.T) {
+	// Six containers, the third inspection never answers: with a 200ms
+	// deadline the listing returns the two containers inspected so far, with
+	// their whole metadata, and leaves the other four to their first event.
+	socket, inspected := newStallingDockerAPI(t, 6, 2)
+	engine, err := newDockerEngine(context.Background(), slog.Default(), socket)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	evts, err := engine.List(ctx)
+	elapsed := time.Since(start)
+
+	var incomplete *ListIncompleteError
+	require.ErrorAs(t, err, &incomplete)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 4, incomplete.Remaining)
+	require.Len(t, evts, 2)
+	for i, evt := range evts {
+		assert.Equal(t, shortContainerID(fmt.Sprintf("%064d", i+1)), evt.ID)
+		assert.Equal(t, "healthy-"+evt.ID, evt.Name)
+		assert.True(t, evt.Privileged)
+		assert.Equal(t, map[string]string{"app": "critical"}, evt.Labels)
+	}
+	// The containers left are not inspected at all.
+	assert.EqualValues(t, 3, inspected.Load())
+	assert.Less(t, elapsed, time.Second)
+}

--- a/plugins/container/go-worker/pkg/container/docker_timeout_test.go
+++ b/plugins/container/go-worker/pkg/container/docker_timeout_test.go
@@ -17,6 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// fakeDockerID returns a 64-character container ID whose short form is i.
+func fakeDockerID(i int) string {
+	return fmt.Sprintf("%012d", i) + strings.Repeat("0", 52)
+}
+
 // newStallingDockerAPI serves a Docker Engine API on a unix socket that lists
 // count containers at once, then answers every inspection but the one at
 // index stallAt, in request order, which hangs until the request is
@@ -39,7 +44,7 @@ func newStallingDockerAPI(t *testing.T, count, stallAt int) (string, *atomic.Int
 		case strings.HasSuffix(r.URL.Path, "/containers/json"):
 			ctrs := make([]map[string]any, count)
 			for i := range ctrs {
-				ctrs[i] = map[string]any{"Id": fmt.Sprintf("%064d", i+1), "Image": "alpine:latest", "ImageID": imageID, "Created": 1757376000}
+				ctrs[i] = map[string]any{"Id": fakeDockerID(i + 1), "Image": "alpine:latest", "ImageID": imageID, "Created": 1757376000}
 			}
 			_ = json.NewEncoder(w).Encode(ctrs)
 		case strings.Contains(r.URL.Path, "/images/"):
@@ -80,10 +85,11 @@ func TestDockerListStopsInspectingOnceTheContextIsDone(t *testing.T) {
 	var incomplete *ListIncompleteError
 	require.ErrorAs(t, err, &incomplete)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 4, incomplete.Remaining)
+	// The containers left are reported, by short ID, for the background lookups.
+	assert.Equal(t, []string{"000000000003", "000000000004", "000000000005", "000000000006"}, incomplete.NotInspected)
 	require.Len(t, evts, 2)
 	for i, evt := range evts {
-		assert.Equal(t, shortContainerID(fmt.Sprintf("%064d", i+1)), evt.ID)
+		assert.Equal(t, shortContainerID(fakeDockerID(i+1)), evt.ID)
 		assert.Equal(t, "healthy-"+evt.ID, evt.Name)
 		assert.True(t, evt.Privileged)
 		assert.Equal(t, map[string]string{"app": "critical"}, evt.Labels)

--- a/plugins/container/go-worker/pkg/container/docker_timeout_test.go
+++ b/plugins/container/go-worker/pkg/container/docker_timeout_test.go
@@ -85,8 +85,8 @@ func TestDockerListStopsInspectingOnceTheContextIsDone(t *testing.T) {
 	var incomplete *ListIncompleteError
 	require.ErrorAs(t, err, &incomplete)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	// The containers left are reported, by short ID, for the background lookups.
-	assert.Equal(t, []string{"000000000003", "000000000004", "000000000005", "000000000006"}, incomplete.NotInspected)
+	// The containers left retain their full runtime IDs for background lookups.
+	assert.Equal(t, []ContainerRef{{ID: fakeDockerID(3)}, {ID: fakeDockerID(4)}, {ID: fakeDockerID(5)}, {ID: fakeDockerID(6)}}, incomplete.NotInspected)
 	require.Len(t, evts, 2)
 	for i, evt := range evts {
 		assert.Equal(t, shortContainerID(fakeDockerID(i+1)), evt.ID)

--- a/plugins/container/go-worker/pkg/container/engine.go
+++ b/plugins/container/go-worker/pkg/container/engine.go
@@ -100,6 +100,34 @@ func WithEngineTimeout(ctx context.Context) (context.Context, context.CancelFunc
 	return context.WithCancel(ctx)
 }
 
+// ListIncompleteError is returned by List, together with the containers it
+// did inspect, when ctx expired while the containers the engine had
+// enumerated were being inspected: the engine answers, it just did not finish
+// in time. The remaining containers are neither inspected nor returned with
+// partial metadata; they are looked up on their first event, like any
+// container the plugin does not know yet.
+type ListIncompleteError struct {
+	// Remaining is how many enumerated containers were not inspected, as far
+	// as the engine could tell.
+	Remaining int
+	// Err is the error of the context that cut the listing.
+	Err error
+}
+
+func (e *ListIncompleteError) Error() string {
+	return fmt.Sprintf("listing cut by the caller, %d containers not inspected: %v", e.Remaining, e.Err)
+}
+
+func (e *ListIncompleteError) Unwrap() error { return e.Err }
+
+// listCut returns the cause of ctx being done, or nil while it is not.
+func listCut(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return context.Cause(ctx)
+	}
+	return nil
+}
+
 type getter interface {
 	// get returns info about a single container
 	get(ctx context.Context, containerId string) (*event.Event, error)

--- a/plugins/container/go-worker/pkg/container/engine.go
+++ b/plugins/container/go-worker/pkg/container/engine.go
@@ -107,10 +107,10 @@ func WithEngineTimeout(ctx context.Context) (context.Context, context.CancelFunc
 // partial metadata: their IDs are reported, for the caller to look them up
 // later, in the background (see NewFetcherEngine).
 type ListIncompleteError struct {
-	// NotInspected holds the IDs, in the short form the plugin uses, of the
-	// enumerated containers that were not inspected. Containers the engine
-	// had not enumerated yet when ctx expired, if any, are not listed.
-	NotInspected []string
+	// NotInspected retains the full runtime identity of the enumerated
+	// containers that were not inspected. Containers the engine had not
+	// enumerated yet when ctx expired, if any, are not listed.
+	NotInspected []ContainerRef
 	// Err is the error of the context that cut the listing.
 	Err error
 }
@@ -121,12 +121,25 @@ func (e *ListIncompleteError) Error() string {
 
 func (e *ListIncompleteError) Unwrap() error { return e.Err }
 
-// notInspectedFrom returns the short IDs of the containers from index from to
-// n-1 of an enumeration, given the ID of its i-th container.
-func notInspectedFrom(n, from int, id func(i int) string) []string {
-	ids := make([]string, 0, n-from)
+// ContainerRef identifies a container in its runtime, before conversion to
+// the short ID used by the plugin cache. Namespace is used by containerd.
+type ContainerRef struct {
+	ID        string
+	Namespace string
+}
+
+// DeferredContainers retains the engine that enumerated these containers.
+// Recovery uses a copy of that engine, without probing unrelated runtimes.
+type DeferredContainers struct {
+	Engine     Engine
+	Containers []ContainerRef
+}
+
+// notInspectedFrom returns the full IDs from index from to n-1.
+func notInspectedFrom(n, from int, id func(i int) string) []ContainerRef {
+	ids := make([]ContainerRef, 0, n-from)
 	for i := from; i < n; i++ {
-		ids = append(ids, shortContainerID(id(i)))
+		ids = append(ids, ContainerRef{ID: id(i)})
 	}
 	return ids
 }

--- a/plugins/container/go-worker/pkg/container/engine.go
+++ b/plugins/container/go-worker/pkg/container/engine.go
@@ -76,12 +76,28 @@ func Generators() ([]EngineGenerator, error) {
 			// try to generate an engine for the socket.
 			if _, statErr := os.Stat(socket); !os.IsNotExist(statErr) {
 				generators = append(generators, func(ctx context.Context) (Engine, error) {
-					return engineGen(ctx, slog.With("engine", engineName), socket)
+					logger := slog.With("engine", engineName)
+					engine, err := engineGen(ctx, logger, socket)
+					if err != nil {
+						logger.LogAttrs(ctx, slog.LevelWarn, "container engine unavailable, skipping it",
+							slog.String("socket", socket), slog.Any("err", err))
+					}
+					return engine, err
 				})
 			}
 		}
 	}
 	return generators, nil
+}
+
+// WithEngineTimeout returns a copy of ctx that expires after the configured
+// engine timeout, so that a container runtime which accepts connections but
+// never answers cannot block the caller. A zero timeout leaves ctx unbounded.
+func WithEngineTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if timeout := config.GetEngineTimeout(); timeout > 0 {
+		return context.WithTimeout(ctx, timeout)
+	}
+	return context.WithCancel(ctx)
 }
 
 type getter interface {

--- a/plugins/container/go-worker/pkg/container/engine.go
+++ b/plugins/container/go-worker/pkg/container/engine.go
@@ -101,22 +101,24 @@ func WithEngineTimeout(ctx context.Context) (context.Context, context.CancelFunc
 }
 
 // ListIncompleteError is returned by List, together with the containers it
-// did inspect, when ctx expired while the containers the engine had
-// enumerated were being inspected: the engine answers, it just did not finish
-// in time. The remaining containers are neither inspected nor returned with
-// partial metadata: their IDs are reported, for the caller to look them up
-// later, in the background (see NewFetcherEngine).
+// did inspect, when a deadline or cancellation interrupted listing. The
+// engine answers, but did not finish. Remaining full IDs and unfinished
+// containerd namespaces are retained for background recovery, without
+// publishing partial metadata (see NewFetcherEngine).
 type ListIncompleteError struct {
 	// NotInspected retains the full runtime identity of the enumerated
 	// containers that were not inspected. Containers the engine had not
 	// enumerated yet when ctx expired, if any, are not listed.
 	NotInspected []ContainerRef
-	// Err is the error of the context that cut the listing.
+	// NotEnumerated retains containerd namespaces whose container listing did
+	// not finish. Their full IDs must be discovered before they can be fetched.
+	NotEnumerated []string
+	// Err is the context or RPC error that cut the listing.
 	Err error
 }
 
 func (e *ListIncompleteError) Error() string {
-	return fmt.Sprintf("listing cut by the caller, %d containers not inspected: %v", len(e.NotInspected), e.Err)
+	return fmt.Sprintf("listing interrupted, %d containers not inspected, %d namespaces not enumerated: %v", len(e.NotInspected), len(e.NotEnumerated), e.Err)
 }
 
 func (e *ListIncompleteError) Unwrap() error { return e.Err }
@@ -128,11 +130,12 @@ type ContainerRef struct {
 	Namespace string
 }
 
-// DeferredContainers retains the engine that enumerated these containers.
+// DeferredContainers retains the engine and its unfinished startup work.
 // Recovery uses a copy of that engine, without probing unrelated runtimes.
 type DeferredContainers struct {
 	Engine     Engine
 	Containers []ContainerRef
+	Namespaces []string
 }
 
 // notInspectedFrom returns the full IDs from index from to n-1.

--- a/plugins/container/go-worker/pkg/container/engine.go
+++ b/plugins/container/go-worker/pkg/container/engine.go
@@ -104,21 +104,32 @@ func WithEngineTimeout(ctx context.Context) (context.Context, context.CancelFunc
 // did inspect, when ctx expired while the containers the engine had
 // enumerated were being inspected: the engine answers, it just did not finish
 // in time. The remaining containers are neither inspected nor returned with
-// partial metadata; they are looked up on their first event, like any
-// container the plugin does not know yet.
+// partial metadata: their IDs are reported, for the caller to look them up
+// later, in the background (see NewFetcherEngine).
 type ListIncompleteError struct {
-	// Remaining is how many enumerated containers were not inspected, as far
-	// as the engine could tell.
-	Remaining int
+	// NotInspected holds the IDs, in the short form the plugin uses, of the
+	// enumerated containers that were not inspected. Containers the engine
+	// had not enumerated yet when ctx expired, if any, are not listed.
+	NotInspected []string
 	// Err is the error of the context that cut the listing.
 	Err error
 }
 
 func (e *ListIncompleteError) Error() string {
-	return fmt.Sprintf("listing cut by the caller, %d containers not inspected: %v", e.Remaining, e.Err)
+	return fmt.Sprintf("listing cut by the caller, %d containers not inspected: %v", len(e.NotInspected), e.Err)
 }
 
 func (e *ListIncompleteError) Unwrap() error { return e.Err }
+
+// notInspectedFrom returns the short IDs of the containers from index from to
+// n-1 of an enumeration, given the ID of its i-th container.
+func notInspectedFrom(n, from int, id func(i int) string) []string {
+	ids := make([]string, 0, n-from)
+	for i := from; i < n; i++ {
+		ids = append(ids, shortContainerID(id(i)))
+	}
+	return ids
+}
 
 // listCut returns the cause of ctx being done, or nil while it is not.
 func listCut(ctx context.Context) error {

--- a/plugins/container/go-worker/pkg/container/fetcher.go
+++ b/plugins/container/go-worker/pkg/container/fetcher.go
@@ -54,10 +54,26 @@ type fetcher struct {
 	maxPending int
 	// The containers the startup listing enumerated but did not inspect
 	// within the engine timeout, waiting for their lookup in the order given,
-	// and the set of them: one found meanwhile through a request leaves the
-	// set and is skipped. Both are only touched by the serving goroutine.
-	deferred    []string
-	deferredSet map[string]struct{}
+	// and their runtime identities. A successful request removes the identity
+	// so its deferred slot is skipped. A miss retains it through retries.
+	// Both are only touched by the serving goroutine.
+	deferred        []string
+	deferredLookups map[string]deferredFetch
+}
+
+// deferredFetch keeps runtime identity until lookup succeeds or retries end.
+// Process requests use the same short-ID key, so they share this lookup too.
+type deferredFetch struct {
+	engine getter
+	ref    ContainerRef
+	queued bool // its background slot has not been consumed yet
+}
+
+func (d deferredFetch) get(ctx context.Context) (*event.Event, error) {
+	if c, ok := d.engine.(*containerdEngine); ok {
+		return c.getInNamespace(ctx, d.ref.Namespace, d.ref.ID)
+	}
+	return d.engine.get(ctx, d.ref.ID)
 }
 
 // NewFetcherEngine returns a fetcher engine.
@@ -65,7 +81,7 @@ type fetcher struct {
 // trying all container engines enabled. Once listening, it also looks up the
 // deferred containers, the ones the startup listing enumerated but did not
 // inspect in time (see ListIncompleteError), in the background.
-func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngines []Engine, deferred []string) Engine {
+func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngines []Engine, deferred []DeferredContainers) Engine {
 	f := fetcher{
 		getters: make([]getter, 0, len(containerEngines)),
 		// Since podman relies upon context to store
@@ -76,15 +92,18 @@ func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngin
 		fetcherChan:  fetcherChan,
 		retryBackoff: containerFetchRetryBackoff,
 		maxPending:   maxPendingFetches,
-		deferred:     make([]string, 0, len(deferred)),
-		deferredSet:  make(map[string]struct{}, len(deferred)),
 	}
-	for _, id := range deferred {
-		if _, dup := f.deferredSet[id]; id == "" || dup {
-			continue
+	// Only construction needs the engine index. The serving goroutine uses
+	// direct getter references, including for normal short-ID requests.
+	var copied map[[2]string]getter
+	if len(deferred) > 0 {
+		copied = make(map[[2]string]getter, len(containerEngines))
+		count := 0
+		for _, group := range deferred {
+			count += len(group.Containers)
 		}
-		f.deferredSet[id] = struct{}{}
-		f.deferred = append(f.deferred, id)
+		f.deferred = make([]string, 0, count)
+		f.deferredLookups = make(map[string]deferredFetch, count)
 	}
 	for _, engine := range containerEngines {
 		copyEngine, ok := engine.(copier)
@@ -101,7 +120,29 @@ func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngin
 			continue
 		}
 		// No type check since Engine interface extends getter.
-		f.getters = append(f.getters, e.(getter))
+		g := e.(getter)
+		f.getters = append(f.getters, g)
+		if copied != nil {
+			copied[[2]string{engine.Name(), engine.Sock()}] = g
+		}
+	}
+	for _, group := range deferred {
+		g := copied[[2]string{group.Engine.Name(), group.Engine.Sock()}]
+		if g == nil {
+			// The failed engine copy was logged above.
+			continue
+		}
+		for _, ref := range group.Containers {
+			id := shortContainerID(ref.ID)
+			if _, dup := f.deferredLookups[id]; id == "" || dup {
+				continue
+			}
+			f.deferredLookups[id] = deferredFetch{engine: g, ref: ref, queued: true}
+			f.deferred = append(f.deferred, id)
+		}
+	}
+	if len(f.deferred) == 0 {
+		f.deferred, f.deferredLookups = nil, nil
 	}
 	return &f
 }
@@ -124,10 +165,10 @@ func (f *fetcher) List(_ context.Context) ([]event.Event, error) {
 // the lookup is retried after each delay of the retry backoff, then given up.
 // On success, publish event on output channel.
 // A single goroutine and a single timer serve the requests, the retries and
-// the deferred containers of the startup listing: the requests first, then
-// one retry or one deferred lookup per wake-up, so that a request never waits
-// behind the others. At most maxPending containers wait for a retry and each
-// deferred container is looked up once: neither goroutines nor memory grow
+// the deferred containers of the startup listing. Requests and due retries
+// share the foreground; one deferred lookup runs when neither is ready.
+// At most maxPending containers wait for a retry and each deferred container
+// is looked up once: neither goroutines nor memory grow
 // with the misses.
 func (f *fetcher) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan event.Event, error) {
 	outCh := make(chan event.Event)
@@ -168,9 +209,8 @@ func (f *fetcher) serve(ctx context.Context, outCh chan<- event.Event) {
 				f.serveRetry(ctx, now, retries, outCh)
 			}
 		} else {
-			// While deferred containers wait, a request goes first: the
-			// process that asked is running now, the leftovers of the startup
-			// listing can wait for one more lookup.
+			// Live requests and their due retries both precede background
+			// startup work. A busy request channel must not starve retries.
 			select {
 			case <-ctx.Done():
 				return
@@ -179,6 +219,8 @@ func (f *fetcher) serve(ctx context.Context, outCh chan<- event.Event) {
 					return
 				}
 				f.serveRequest(ctx, containerId, retries, outCh)
+			case now := <-timerC:
+				f.serveRetry(ctx, now, retries, outCh)
 			default:
 				select {
 				case <-ctx.Done():
@@ -194,6 +236,9 @@ func (f *fetcher) serve(ctx context.Context, outCh chan<- event.Event) {
 					f.serveDeferred(ctx, retries, outCh)
 				}
 			}
+		}
+		if len(f.deferred) == 0 && len(f.deferredLookups) == 0 {
+			f.deferredLookups = nil
 		}
 		// Arm the timer on the earliest retry, if any.
 		if p, _, ok := retries.peek(); ok {
@@ -220,10 +265,13 @@ func (f *fetcher) scheduleRetry(ctx context.Context, containerId string, retries
 	if retries.len() >= f.maxPending {
 		slog.Default().LogAttrs(ctx, slog.LevelDebug, "too many containers waiting for a retry, dropping the request",
 			slog.String("container", containerId), slog.Int("pending", retries.len()))
+		f.forgetFailedDeferred(containerId)
 		return
 	}
 	now := time.Now()
-	retries.add(pendingFetch{id: containerId, since: now}, 0, now)
+	if !retries.add(pendingFetch{id: containerId, since: now}, 0, now) {
+		f.forgetFailedDeferred(containerId)
+	}
 }
 
 // serveRetry looks up the earliest retry due at now, if any, and schedules
@@ -243,6 +291,7 @@ func (f *fetcher) serveRetry(ctx context.Context, now time.Time, retries *retryQ
 	// that a runtime slow to answer gets the whole delay.
 	now = time.Now()
 	if !retries.add(p, step+1, now) {
+		f.forgetFailedDeferred(p.id)
 		slog.Default().LogAttrs(ctx, slog.LevelDebug, "no container engine knows the container, giving up",
 			slog.String("container", p.id), slog.Int("lookups", step+2), slog.Duration("elapsed", now.Sub(p.since)))
 	}
@@ -256,10 +305,13 @@ func (f *fetcher) serveDeferred(ctx context.Context, retries *retryQueue, outCh 
 	id := f.deferred[0]
 	f.deferred[0] = "" // do not retain the id
 	f.deferred = f.deferred[1:]
-	_, waiting := f.deferredSet[id]
-	delete(f.deferredSet, id)
+	d, waiting := f.deferredLookups[id]
+	if waiting {
+		d.queued = false
+		f.deferredLookups[id] = d
+	}
 	if len(f.deferred) == 0 {
-		f.deferred, f.deferredSet = nil, nil
+		f.deferred = nil
 		slog.Default().LogAttrs(ctx, slog.LevelDebug, "looked up every container the startup listing did not inspect in time")
 	}
 	if !waiting || retries.contains(id) || f.lookup(ctx, id, outCh) {
@@ -268,16 +320,31 @@ func (f *fetcher) serveDeferred(ctx context.Context, retries *retryQueue, outCh 
 	f.scheduleRetry(ctx, id, retries)
 }
 
-// lookup asks each engine about the container and publishes the first
-// answer. It reports whether an engine knew the container, which then needs
-// no deferred lookup either.
+// A failed process request must not discard the background attempt still
+// waiting in the startup slice. Once that slot runs, only retries retain it.
+func (f *fetcher) forgetFailedDeferred(id string) {
+	if !f.deferredLookups[id].queued {
+		delete(f.deferredLookups, id)
+	}
+}
+
+// lookup uses the known runtime identity of a deferred container, or probes
+// the engines for an unknown ID. Success publishes the event and releases
+// any deferred identity.
 func (f *fetcher) lookup(ctx context.Context, containerId string, outCh chan<- event.Event) bool {
-	for _, e := range f.getters {
-		evt, _ := e.get(f.ctx, containerId)
-		if evt == nil {
-			continue
+	var evt *event.Event
+	if d, ok := f.deferredLookups[containerId]; ok {
+		evt, _ = d.get(f.ctx)
+	} else {
+		for _, e := range f.getters {
+			evt, _ = e.get(f.ctx, containerId)
+			if evt != nil {
+				break
+			}
 		}
-		delete(f.deferredSet, containerId)
+	}
+	if evt != nil {
+		delete(f.deferredLookups, containerId)
 		select {
 		case outCh <- *evt:
 		case <-ctx.Done():

--- a/plugins/container/go-worker/pkg/container/fetcher.go
+++ b/plugins/container/go-worker/pkg/container/fetcher.go
@@ -150,7 +150,12 @@ func (f *fetcher) serve(ctx context.Context, outCh chan<- event.Event) {
 			retries.pop(step)
 			if f.lookup(ctx, p.id, outCh) {
 				retries.remove(p.id)
-			} else if !retries.add(p, step+1, now) {
+				break
+			}
+			// Pace the next lookup from the end of this one, as for a first
+			// miss, so that a runtime slow to answer gets the whole delay.
+			now = time.Now()
+			if !retries.add(p, step+1, now) {
 				slog.Default().LogAttrs(ctx, slog.LevelDebug, "no container engine knows the container, giving up",
 					slog.String("container", p.id), slog.Int("lookups", step+2), slog.Duration("elapsed", now.Sub(p.since)))
 			}

--- a/plugins/container/go-worker/pkg/container/fetcher.go
+++ b/plugins/container/go-worker/pkg/container/fetcher.go
@@ -2,9 +2,11 @@ package container
 
 import (
 	"context"
-	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
+	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
 )
 
 /*
@@ -26,7 +28,7 @@ type fetcher struct {
 // trying all container engines enabled.
 func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngines []Engine) Engine {
 	f := fetcher{
-		getters: make([]getter, len(containerEngines)),
+		getters: make([]getter, 0, len(containerEngines)),
 		// Since podman relies upon context to store
 		// connection-related info,
 		// we need a unique context for fetcher
@@ -34,17 +36,22 @@ func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngin
 		ctx:         context.Background(),
 		fetcherChan: fetcherChan,
 	}
-	for i, engine := range containerEngines {
+	for _, engine := range containerEngines {
 		copyEngine, ok := engine.(copier)
 		if !ok {
 			// We need all engines to implement the copier interface to be copied by fetcher.
 			panic("not a copier")
 		}
-		e, _ := copyEngine.copy(f.ctx)
-		if e != nil {
-			// No type check since Engine interface extends getter.
-			f.getters[i] = e.(getter)
+		e, err := copyEngine.copy(f.ctx)
+		if e == nil {
+			// Leave the engine out rather than storing a nil getter, which
+			// would make Listen panic on the first lookup.
+			slog.Default().LogAttrs(f.ctx, slog.LevelWarn, "cannot copy container engine for on-demand lookups, skipping it",
+				slog.String("engine", engine.Name()), slog.String("socket", engine.Sock()), slog.Any("err", err))
+			continue
 		}
+		// No type check since Engine interface extends getter.
+		f.getters = append(f.getters, e.(getter))
 	}
 	return &f
 }

--- a/plugins/container/go-worker/pkg/container/fetcher.go
+++ b/plugins/container/go-worker/pkg/container/fetcher.go
@@ -17,10 +17,33 @@ until it succeeds and publish an event to the output channel.
 FetcherChan requests are published through a CGO exposed API: AskForContainerInfo(), in worker_api.
 */
 
+// containerFetchRetryBackoff paces the lookups of a container the engines do
+// not know yet: a container can show up through the runtime API a while after
+// its first process does, in particular under load. A miss is looked up again
+// after each of these delays, about 4s in total, then the request is dropped.
+// The plugin asks again on a later process event, once its own bookkeeping of
+// the asked containers expires (see src/asked_containers.h).
+var containerFetchRetryBackoff = []time.Duration{
+	125 * time.Millisecond,
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	time.Second,
+	2 * time.Second,
+}
+
+// maxPendingFetches bounds the containers waiting for a retry, so that a
+// runtime which keeps missing cannot grow the fetcher state without bound. A
+// miss beyond the bound is dropped; the plugin asks again later.
+const maxPendingFetches = 1024
+
 type fetcher struct {
 	getters     []getter
 	ctx         context.Context
 	fetcherChan chan string
+	// Delays between the lookups of a container the engines do not know yet.
+	retryBackoff []time.Duration
+	// Bound on the containers waiting for a retry.
+	maxPending int
 }
 
 // NewFetcherEngine returns a fetcher engine.
@@ -33,8 +56,10 @@ func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngin
 		// connection-related info,
 		// we need a unique context for fetcher
 		// to avoid tampering with real podman engine context.
-		ctx:         context.Background(),
-		fetcherChan: fetcherChan,
+		ctx:          context.Background(),
+		fetcherChan:  fetcherChan,
+		retryBackoff: containerFetchRetryBackoff,
+		maxPending:   maxPendingFetches,
 	}
 	for _, engine := range containerEngines {
 		copyEngine, ok := engine.(copier)
@@ -70,12 +95,14 @@ func (f *fetcher) List(_ context.Context) ([]event.Event, error) {
 
 // Everytime a containerID is published on the fetcher channel, the fetcher engine loops
 // over all enabled engines and tries to get info about the container.
-// In case the container info is missing, due to a timing issue of the underlying engines
-// a retry is set up every containerFetchRetryInterval until containerFetchRetryTimeout is reached.
+// In case the container info is missing, due to a timing issue of the underlying engines,
+// the lookup is retried after each delay of the retry backoff, then given up.
 // On success, publish event on output channel.
+// A single goroutine and a single timer serve both the requests and the
+// retries, one retry per wake-up so that the requests are never starved, and
+// at most maxPending containers wait for a retry: neither goroutines nor
+// memory grow with the misses.
 func (f *fetcher) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan event.Event, error) {
-	const containerFetchRetryInterval = 30 * time.Millisecond
-	const containerFetchRetryTimeout = 150 * time.Millisecond
 	outCh := make(chan event.Event)
 	wg.Add(1)
 	go func() {
@@ -83,39 +110,149 @@ func (f *fetcher) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan event.
 			close(outCh)
 			wg.Done()
 		}()
-		containerFirstSeen := make(map[string]time.Time)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case containerId := <-f.fetcherChan:
-				found := false
-				now := time.Now()
-				if containerRequestTime, exists := containerFirstSeen[containerId]; exists {
-					if now.Sub(containerRequestTime) > containerFetchRetryTimeout {
-						delete(containerFirstSeen, containerId)
-						break
-					}
-				} else {
-					containerFirstSeen[containerId] = now
-				}
-				for _, e := range f.getters {
-					evt, _ := e.get(f.ctx, containerId)
-					if evt != nil {
-						outCh <- *evt
-						found = true
-						delete(containerFirstSeen, containerId)
-						break
-					}
-				}
-				if !found {
-					go func() {
-						time.Sleep(containerFetchRetryInterval)
-						f.fetcherChan <- containerId
-					}()
-				}
-			}
-		}
+		f.serve(ctx, outCh)
 	}()
 	return outCh, nil
+}
+
+func (f *fetcher) serve(ctx context.Context, outCh chan<- event.Event) {
+	retries := newRetryQueue(f.retryBackoff)
+	// The timer paces the retries. It starts drained and unarmed: timerC is
+	// nil, hence never ready, while nothing is pending.
+	timer := time.NewTimer(0)
+	<-timer.C
+	defer timer.Stop()
+	var timerC <-chan time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case containerId, ok := <-f.fetcherChan:
+			if !ok {
+				return
+			}
+			if retries.contains(containerId) || f.lookup(ctx, containerId, outCh) {
+				break
+			}
+			if retries.len() >= f.maxPending {
+				slog.Default().LogAttrs(ctx, slog.LevelDebug, "too many containers waiting for a retry, dropping the request",
+					slog.String("container", containerId), slog.Int("pending", retries.len()))
+				break
+			}
+			now := time.Now()
+			retries.add(pendingFetch{id: containerId, since: now}, 0, now)
+		case now := <-timerC:
+			p, step, ok := retries.peek()
+			if !ok || p.due.After(now) {
+				// Stale tick
+				break
+			}
+			retries.pop(step)
+			if f.lookup(ctx, p.id, outCh) {
+				retries.remove(p.id)
+			} else if !retries.add(p, step+1, now) {
+				slog.Default().LogAttrs(ctx, slog.LevelDebug, "no container engine knows the container, giving up",
+					slog.String("container", p.id), slog.Int("lookups", step+2), slog.Duration("elapsed", now.Sub(p.since)))
+			}
+		}
+		// Arm the timer on the earliest retry, if any.
+		if p, _, ok := retries.peek(); ok {
+			timer.Reset(time.Until(p.due))
+			timerC = timer.C
+		} else {
+			timerC = nil
+		}
+	}
+}
+
+// lookup asks each engine about the container and publishes the first
+// answer. It reports whether an engine knew the container.
+func (f *fetcher) lookup(ctx context.Context, containerId string, outCh chan<- event.Event) bool {
+	for _, e := range f.getters {
+		evt, _ := e.get(f.ctx, containerId)
+		if evt == nil {
+			continue
+		}
+		select {
+		case outCh <- *evt:
+		case <-ctx.Done():
+		}
+		return true
+	}
+	return false
+}
+
+// pendingFetch is a container whose lookup missed and waits for a retry.
+type pendingFetch struct {
+	id    string
+	since time.Time // first lookup
+	due   time.Time // next lookup
+}
+
+// retryQueue holds the pending fetches, in one FIFO per step of the backoff.
+// Time is monotonic and every container in a step waits the same delay, so
+// each FIFO is sorted by due time and the earliest retry overall is the
+// earliest of the heads. Every operation is O(1) in the number of pending
+// fetches.
+type retryQueue struct {
+	backoff []time.Duration
+	steps   [][]pendingFetch
+	ids     map[string]struct{}
+}
+
+func newRetryQueue(backoff []time.Duration) *retryQueue {
+	return &retryQueue{
+		backoff: backoff,
+		steps:   make([][]pendingFetch, len(backoff)),
+		ids:     make(map[string]struct{}),
+	}
+}
+
+// len returns the number of containers waiting for a retry.
+func (q *retryQueue) len() int {
+	return len(q.ids)
+}
+
+// contains reports whether the container waits for a retry.
+func (q *retryQueue) contains(id string) bool {
+	_, ok := q.ids[id]
+	return ok
+}
+
+// add schedules the given step of the backoff for a container that missed at
+// now. It reports false, and forgets the container, when the backoff has no
+// such step: the container is given up.
+func (q *retryQueue) add(p pendingFetch, step int, now time.Time) bool {
+	if step >= len(q.steps) {
+		delete(q.ids, p.id)
+		return false
+	}
+	p.due = now.Add(q.backoff[step])
+	q.steps[step] = append(q.steps[step], p)
+	q.ids[p.id] = struct{}{}
+	return true
+}
+
+// peek returns the earliest retry and its step, if any.
+func (q *retryQueue) peek() (pendingFetch, int, bool) {
+	var earliest pendingFetch
+	step := -1
+	for i, s := range q.steps {
+		if len(s) > 0 && (step < 0 || s[0].due.Before(earliest.due)) {
+			earliest, step = s[0], i
+		}
+	}
+	return earliest, step, step >= 0
+}
+
+// pop drops the head of the step. The caller either adds the container to
+// the next step or removes it.
+func (q *retryQueue) pop(step int) {
+	q.steps[step][0] = pendingFetch{} // do not retain the id
+	q.steps[step] = q.steps[step][1:]
+}
+
+// remove forgets a container that was found.
+func (q *retryQueue) remove(id string) {
+	delete(q.ids, id)
 }

--- a/plugins/container/go-worker/pkg/container/fetcher.go
+++ b/plugins/container/go-worker/pkg/container/fetcher.go
@@ -36,6 +36,14 @@ var containerFetchRetryBackoff = []time.Duration{
 // miss beyond the bound is dropped; the plugin asks again later.
 const maxPendingFetches = 1024
 
+// ready is a closed channel: receiving from it never blocks. It stands for
+// the deferred containers in the select of serve, while there are some.
+var ready = func() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}()
+
 type fetcher struct {
 	getters     []getter
 	ctx         context.Context
@@ -44,12 +52,20 @@ type fetcher struct {
 	retryBackoff []time.Duration
 	// Bound on the containers waiting for a retry.
 	maxPending int
+	// The containers the startup listing enumerated but did not inspect
+	// within the engine timeout, waiting for their lookup in the order given,
+	// and the set of them: one found meanwhile through a request leaves the
+	// set and is skipped. Both are only touched by the serving goroutine.
+	deferred    []string
+	deferredSet map[string]struct{}
 }
 
 // NewFetcherEngine returns a fetcher engine.
 // The fetcher engine is responsible to allow us to get() single container
-// trying all container engines enabled.
-func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngines []Engine) Engine {
+// trying all container engines enabled. Once listening, it also looks up the
+// deferred containers, the ones the startup listing enumerated but did not
+// inspect in time (see ListIncompleteError), in the background.
+func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngines []Engine, deferred []string) Engine {
 	f := fetcher{
 		getters: make([]getter, 0, len(containerEngines)),
 		// Since podman relies upon context to store
@@ -60,6 +76,15 @@ func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngin
 		fetcherChan:  fetcherChan,
 		retryBackoff: containerFetchRetryBackoff,
 		maxPending:   maxPendingFetches,
+		deferred:     make([]string, 0, len(deferred)),
+		deferredSet:  make(map[string]struct{}, len(deferred)),
+	}
+	for _, id := range deferred {
+		if _, dup := f.deferredSet[id]; id == "" || dup {
+			continue
+		}
+		f.deferredSet[id] = struct{}{}
+		f.deferred = append(f.deferred, id)
 	}
 	for _, engine := range containerEngines {
 		copyEngine, ok := engine.(copier)
@@ -98,10 +123,12 @@ func (f *fetcher) List(_ context.Context) ([]event.Event, error) {
 // In case the container info is missing, due to a timing issue of the underlying engines,
 // the lookup is retried after each delay of the retry backoff, then given up.
 // On success, publish event on output channel.
-// A single goroutine and a single timer serve both the requests and the
-// retries, one retry per wake-up so that the requests are never starved, and
-// at most maxPending containers wait for a retry: neither goroutines nor
-// memory grow with the misses.
+// A single goroutine and a single timer serve the requests, the retries and
+// the deferred containers of the startup listing: the requests first, then
+// one retry or one deferred lookup per wake-up, so that a request never waits
+// behind the others. At most maxPending containers wait for a retry and each
+// deferred container is looked up once: neither goroutines nor memory grow
+// with the misses.
 func (f *fetcher) Listen(ctx context.Context, wg *sync.WaitGroup) (<-chan event.Event, error) {
 	outCh := make(chan event.Event)
 	wg.Add(1)
@@ -123,41 +150,49 @@ func (f *fetcher) serve(ctx context.Context, outCh chan<- event.Event) {
 	<-timer.C
 	defer timer.Stop()
 	var timerC <-chan time.Time
+	if len(f.deferred) > 0 {
+		slog.Default().LogAttrs(ctx, slog.LevelDebug, "looking up the containers the startup listing did not inspect in time",
+			slog.Int("containers", len(f.deferred)))
+	}
 	for {
-		select {
-		case <-ctx.Done():
-			return
-		case containerId, ok := <-f.fetcherChan:
-			if !ok {
+		if len(f.deferred) == 0 {
+			select {
+			case <-ctx.Done():
 				return
+			case containerId, ok := <-f.fetcherChan:
+				if !ok {
+					return
+				}
+				f.serveRequest(ctx, containerId, retries, outCh)
+			case now := <-timerC:
+				f.serveRetry(ctx, now, retries, outCh)
 			}
-			if retries.contains(containerId) || f.lookup(ctx, containerId, outCh) {
-				break
-			}
-			if retries.len() >= f.maxPending {
-				slog.Default().LogAttrs(ctx, slog.LevelDebug, "too many containers waiting for a retry, dropping the request",
-					slog.String("container", containerId), slog.Int("pending", retries.len()))
-				break
-			}
-			now := time.Now()
-			retries.add(pendingFetch{id: containerId, since: now}, 0, now)
-		case now := <-timerC:
-			p, step, ok := retries.peek()
-			if !ok || p.due.After(now) {
-				// Stale tick
-				break
-			}
-			retries.pop(step)
-			if f.lookup(ctx, p.id, outCh) {
-				retries.remove(p.id)
-				break
-			}
-			// Pace the next lookup from the end of this one, as for a first
-			// miss, so that a runtime slow to answer gets the whole delay.
-			now = time.Now()
-			if !retries.add(p, step+1, now) {
-				slog.Default().LogAttrs(ctx, slog.LevelDebug, "no container engine knows the container, giving up",
-					slog.String("container", p.id), slog.Int("lookups", step+2), slog.Duration("elapsed", now.Sub(p.since)))
+		} else {
+			// While deferred containers wait, a request goes first: the
+			// process that asked is running now, the leftovers of the startup
+			// listing can wait for one more lookup.
+			select {
+			case <-ctx.Done():
+				return
+			case containerId, ok := <-f.fetcherChan:
+				if !ok {
+					return
+				}
+				f.serveRequest(ctx, containerId, retries, outCh)
+			default:
+				select {
+				case <-ctx.Done():
+					return
+				case containerId, ok := <-f.fetcherChan:
+					if !ok {
+						return
+					}
+					f.serveRequest(ctx, containerId, retries, outCh)
+				case now := <-timerC:
+					f.serveRetry(ctx, now, retries, outCh)
+				case <-ready:
+					f.serveDeferred(ctx, retries, outCh)
+				}
 			}
 		}
 		// Arm the timer on the earliest retry, if any.
@@ -170,14 +205,79 @@ func (f *fetcher) serve(ctx context.Context, outCh chan<- event.Event) {
 	}
 }
 
+// serveRequest looks up a container the plugin asked for, unless it already
+// waits for a retry, and schedules the retries of a miss.
+func (f *fetcher) serveRequest(ctx context.Context, containerId string, retries *retryQueue, outCh chan<- event.Event) {
+	if retries.contains(containerId) || f.lookup(ctx, containerId, outCh) {
+		return
+	}
+	f.scheduleRetry(ctx, containerId, retries)
+}
+
+// scheduleRetry queues the first retry of a container that just missed, within
+// the bound on the pending retries.
+func (f *fetcher) scheduleRetry(ctx context.Context, containerId string, retries *retryQueue) {
+	if retries.len() >= f.maxPending {
+		slog.Default().LogAttrs(ctx, slog.LevelDebug, "too many containers waiting for a retry, dropping the request",
+			slog.String("container", containerId), slog.Int("pending", retries.len()))
+		return
+	}
+	now := time.Now()
+	retries.add(pendingFetch{id: containerId, since: now}, 0, now)
+}
+
+// serveRetry looks up the earliest retry due at now, if any, and schedules
+// the next retry of a miss, or gives the container up past the backoff.
+func (f *fetcher) serveRetry(ctx context.Context, now time.Time, retries *retryQueue, outCh chan<- event.Event) {
+	p, step, ok := retries.peek()
+	if !ok || p.due.After(now) {
+		// Stale tick
+		return
+	}
+	retries.pop(step)
+	if f.lookup(ctx, p.id, outCh) {
+		retries.remove(p.id)
+		return
+	}
+	// Pace the next lookup from the end of this one, as for a first miss, so
+	// that a runtime slow to answer gets the whole delay.
+	now = time.Now()
+	if !retries.add(p, step+1, now) {
+		slog.Default().LogAttrs(ctx, slog.LevelDebug, "no container engine knows the container, giving up",
+			slog.String("container", p.id), slog.Int("lookups", step+2), slog.Duration("elapsed", now.Sub(p.since)))
+	}
+}
+
+// serveDeferred looks up the next deferred container, unless a request took
+// care of it meanwhile. A miss is retried like a request's: the runtime
+// enumerated the container at startup, so it usually knows it, but it may be
+// gone by now.
+func (f *fetcher) serveDeferred(ctx context.Context, retries *retryQueue, outCh chan<- event.Event) {
+	id := f.deferred[0]
+	f.deferred[0] = "" // do not retain the id
+	f.deferred = f.deferred[1:]
+	_, waiting := f.deferredSet[id]
+	delete(f.deferredSet, id)
+	if len(f.deferred) == 0 {
+		f.deferred, f.deferredSet = nil, nil
+		slog.Default().LogAttrs(ctx, slog.LevelDebug, "looked up every container the startup listing did not inspect in time")
+	}
+	if !waiting || retries.contains(id) || f.lookup(ctx, id, outCh) {
+		return
+	}
+	f.scheduleRetry(ctx, id, retries)
+}
+
 // lookup asks each engine about the container and publishes the first
-// answer. It reports whether an engine knew the container.
+// answer. It reports whether an engine knew the container, which then needs
+// no deferred lookup either.
 func (f *fetcher) lookup(ctx context.Context, containerId string, outCh chan<- event.Event) bool {
 	for _, e := range f.getters {
 		evt, _ := e.get(f.ctx, containerId)
 		if evt == nil {
 			continue
 		}
+		delete(f.deferredSet, containerId)
 		select {
 		case outCh <- *evt:
 		case <-ctx.Done():

--- a/plugins/container/go-worker/pkg/container/fetcher.go
+++ b/plugins/container/go-worker/pkg/container/fetcher.go
@@ -37,7 +37,7 @@ var containerFetchRetryBackoff = []time.Duration{
 const maxPendingFetches = 1024
 
 // ready is a closed channel: receiving from it never blocks. It stands for
-// the deferred containers in the select of serve, while there are some.
+// the deferred startup work in the select of serve, while there is some.
 var ready = func() chan struct{} {
 	ch := make(chan struct{})
 	close(ch)
@@ -59,6 +59,21 @@ type fetcher struct {
 	// Both are only touched by the serving goroutine.
 	deferred        []string
 	deferredLookups map[string]deferredFetch
+	// Namespace enumeration left over from startup, attempted one at a time
+	// after known containers. Failed attempts use the same timer and retry
+	// queue; their count is bounded by the namespaces discovered at startup.
+	namespaces []*deferredNamespace
+}
+
+type namespaceEngine interface {
+	getter
+	listNamespace(context.Context, string) ([]ContainerRef, error)
+}
+
+type deferredNamespace struct {
+	engine namespaceEngine
+	name   string
+	step   int // next backoff step if enumeration fails
 }
 
 // deferredFetch keeps runtime identity until lookup succeeds or retries end.
@@ -79,8 +94,8 @@ func (d deferredFetch) get(ctx context.Context) (*event.Event, error) {
 // NewFetcherEngine returns a fetcher engine.
 // The fetcher engine is responsible to allow us to get() single container
 // trying all container engines enabled. Once listening, it also looks up the
-// deferred containers, the ones the startup listing enumerated but did not
-// inspect in time (see ListIncompleteError), in the background.
+// containers and namespaces the startup listing did not finish in time
+// (see ListIncompleteError), in the background.
 func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngines []Engine, deferred []DeferredContainers) Engine {
 	f := fetcher{
 		getters: make([]getter, 0, len(containerEngines)),
@@ -132,19 +147,33 @@ func NewFetcherEngine(_ context.Context, fetcherChan chan string, containerEngin
 			// The failed engine copy was logged above.
 			continue
 		}
-		for _, ref := range group.Containers {
-			id := shortContainerID(ref.ID)
-			if _, dup := f.deferredLookups[id]; id == "" || dup {
-				continue
+		f.addDeferred(g, group.Containers)
+		if e, ok := g.(namespaceEngine); ok {
+			for _, namespace := range group.Namespaces {
+				f.namespaces = append(f.namespaces, &deferredNamespace{engine: e, name: namespace})
 			}
-			f.deferredLookups[id] = deferredFetch{engine: g, ref: ref, queued: true}
-			f.deferred = append(f.deferred, id)
 		}
 	}
 	if len(f.deferred) == 0 {
 		f.deferred, f.deferredLookups = nil, nil
 	}
 	return &f
+}
+
+// addDeferred is used both at construction and by background enumeration.
+// Retain full runtime identities before process requests or retries run.
+func (f *fetcher) addDeferred(engine getter, refs []ContainerRef) {
+	if len(refs) > 0 && f.deferredLookups == nil {
+		f.deferredLookups = make(map[string]deferredFetch, len(refs))
+	}
+	for _, ref := range refs {
+		id := shortContainerID(ref.ID)
+		if _, dup := f.deferredLookups[id]; id == "" || dup {
+			continue
+		}
+		f.deferredLookups[id] = deferredFetch{engine: engine, ref: ref, queued: true}
+		f.deferred = append(f.deferred, id)
+	}
 }
 
 func (f *fetcher) Name() string {
@@ -196,7 +225,7 @@ func (f *fetcher) serve(ctx context.Context, outCh chan<- event.Event) {
 			slog.Int("containers", len(f.deferred)))
 	}
 	for {
-		if len(f.deferred) == 0 {
+		if len(f.deferred) == 0 && len(f.namespaces) == 0 {
 			select {
 			case <-ctx.Done():
 				return
@@ -283,6 +312,14 @@ func (f *fetcher) serveRetry(ctx context.Context, now time.Time, retries *retryQ
 		return
 	}
 	retries.pop(step)
+	if p.namespace != nil {
+		// A due namespace retry rejoins the background queue. Executing it
+		// here would let slow failing namespaces keep retries perpetually
+		// due and starve both healthy namespaces and container inspections.
+		p.namespace.step = step + 1
+		f.namespaces = append(f.namespaces, p.namespace)
+		return
+	}
 	if f.lookup(ctx, p.id, outCh) {
 		retries.remove(p.id)
 		return
@@ -302,6 +339,18 @@ func (f *fetcher) serveRetry(ctx context.Context, now time.Time, retries *retryQ
 // enumerated the container at startup, so it usually knows it, but it may be
 // gone by now.
 func (f *fetcher) serveDeferred(ctx context.Context, retries *retryQueue, outCh chan<- event.Event) {
+	if len(f.deferred) == 0 {
+		namespace := f.namespaces[0]
+		f.namespaces[0] = nil
+		f.namespaces = f.namespaces[1:]
+		if len(f.namespaces) == 0 {
+			f.namespaces = nil
+		}
+		if !f.enumerateNamespace(ctx, namespace) && ctx.Err() == nil {
+			retries.add(pendingFetch{namespace: namespace}, namespace.step, time.Now())
+		}
+		return
+	}
 	id := f.deferred[0]
 	f.deferred[0] = "" // do not retain the id
 	f.deferred = f.deferred[1:]
@@ -318,6 +367,22 @@ func (f *fetcher) serveDeferred(ctx context.Context, retries *retryQueue, outCh 
 		return
 	}
 	f.scheduleRetry(ctx, id, retries)
+}
+
+// enumerateNamespace only discovers IDs. Each network attempt is bounded and
+// cancelled with the worker; inspecting the returned containers remains one
+// lookup per iteration, alongside the existing requests and retries.
+func (f *fetcher) enumerateNamespace(ctx context.Context, namespace *deferredNamespace) bool {
+	listCtx, cancel := WithEngineTimeout(ctx)
+	defer cancel()
+	refs, err := namespace.engine.listNamespace(listCtx, namespace.name)
+	if err != nil {
+		slog.Default().LogAttrs(ctx, slog.LevelDebug, "cannot enumerate deferred containerd namespace, retrying",
+			slog.String("namespace", namespace.name), slog.Any("err", err))
+		return false
+	}
+	f.addDeferred(namespace.engine, refs)
+	return true
 }
 
 // A failed process request must not discard the background attempt still
@@ -354,15 +419,20 @@ func (f *fetcher) lookup(ctx context.Context, containerId string, outCh chan<- e
 	return false
 }
 
-// pendingFetch is a container whose lookup missed and waits for a retry.
+// pendingFetch is a failed container lookup or namespace enumeration waiting
+// for a retry.
 type pendingFetch struct {
 	id    string
 	since time.Time // first lookup
 	due   time.Time // next lookup
+	// Non-nil for namespace enumeration instead of a container lookup. There
+	// is no short-ID fallback for an undiscovered containerd ID, so these
+	// finite startup jobs retry until enumeration succeeds or capture stops.
+	namespace *deferredNamespace
 }
 
 // retryQueue holds the pending fetches, in one FIFO per step of the backoff.
-// Time is monotonic and every container in a step waits the same delay, so
+// Time is monotonic and every entry in a step waits the same delay, so
 // each FIFO is sorted by due time and the earliest retry overall is the
 // earliest of the heads. Every operation is O(1) in the number of pending
 // fetches.
@@ -391,17 +461,26 @@ func (q *retryQueue) contains(id string) bool {
 	return ok
 }
 
-// add schedules the given step of the backoff for a container that missed at
-// now. It reports false, and forgets the container, when the backoff has no
-// such step: the container is given up.
+// add schedules the given step of the backoff after an attempt at now.
+// Containers exhaust their retries after the last step; namespace jobs keep
+// retrying at the final delay until enumeration succeeds.
 func (q *retryQueue) add(p pendingFetch, step int, now time.Time) bool {
+	if p.namespace != nil && len(q.steps) > 0 {
+		// Namespace failures keep retrying at the final delay. Fixed delays
+		// within each step preserve the FIFO ordering by due time.
+		step = min(step, len(q.steps)-1)
+	}
 	if step >= len(q.steps) {
-		delete(q.ids, p.id)
+		if p.namespace == nil {
+			delete(q.ids, p.id)
+		}
 		return false
 	}
 	p.due = now.Add(q.backoff[step])
 	q.steps[step] = append(q.steps[step], p)
-	q.ids[p.id] = struct{}{}
+	if p.namespace == nil {
+		q.ids[p.id] = struct{}{}
+	}
 	return true
 }
 

--- a/plugins/container/go-worker/pkg/container/fetcher_deferred_test.go
+++ b/plugins/container/go-worker/pkg/container/fetcher_deferred_test.go
@@ -2,7 +2,9 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,6 +18,130 @@ type lookupFunc func(context.Context, string) (*event.Event, error)
 
 func (f lookupFunc) get(ctx context.Context, id string) (*event.Event, error) {
 	return f(ctx, id)
+}
+
+type namespaceLookup struct {
+	lookupFunc
+	list func(context.Context, string) ([]ContainerRef, error)
+}
+
+func (e namespaceLookup) listNamespace(ctx context.Context, namespace string) ([]ContainerRef, error) {
+	return e.list(ctx, namespace)
+}
+
+func TestFetcherRetriesNamespacesWithoutDroppingOtherWork(t *testing.T) {
+	var recovered atomic.Bool
+	g := namespaceLookup{
+		lookupFunc: func(_ context.Context, id string) (*event.Event, error) {
+			return &event.Event{Info: event.Info{Container: event.Container{ID: id}}}, nil
+		},
+		list: func(_ context.Context, namespace string) ([]ContainerRef, error) {
+			if namespace == "slow" && !recovered.Load() {
+				return nil, errors.New("temporarily unavailable")
+			}
+			if namespace == "empty" {
+				return nil, nil
+			}
+			return []ContainerRef{{ID: namespace}}, nil
+		},
+	}
+	// A namespace job must survive even with no container retry slots. Empty
+	// namespaces finish normally, and a failing namespace cannot stall others.
+	f := newTestFetcher(g, make(chan string), fastBackoff, 0, nil)
+	for _, ns := range []string{"slow", "empty", "healthy"} {
+		f.namespaces = append(f.namespaces, &deferredNamespace{engine: g, name: ns})
+	}
+	out := runFetcher(t, f)
+	assert.Equal(t, "healthy", waitOnChannelOrTimeout(t, out).ID)
+	recovered.Store(true)
+	assert.Equal(t, "slow", waitOnChannelOrTimeout(t, out).ID)
+	assertNoEvent(t, out, 2*sumDurations(fastBackoff))
+}
+
+func TestFetcherSlowNamespaceRetriesDoNotStarveLaterNamespaces(t *testing.T) {
+	g := namespaceLookup{
+		lookupFunc: func(_ context.Context, id string) (*event.Event, error) {
+			return &event.Event{Info: event.Info{Container: event.Container{ID: id}}}, nil
+		},
+		list: func(ctx context.Context, namespace string) ([]ContainerRef, error) {
+			if namespace == "healthy" {
+				return []ContainerRef{{ID: namespace}}, nil
+			}
+			// Each failure takes longer than the maximum retry delay. If
+			// retries run ahead of the background queue, these two jobs keep
+			// one another due and the healthy namespace never gets a turn.
+			timer := time.NewTimer(15 * time.Millisecond)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+				return nil, errors.New("slow failure")
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+	f := newTestFetcher(g, make(chan string), []time.Duration{time.Millisecond, 2 * time.Millisecond}, maxPendingFetches, nil)
+	for _, ns := range []string{"slow-one", "slow-two", "healthy"} {
+		f.namespaces = append(f.namespaces, &deferredNamespace{engine: g, name: ns})
+	}
+	assert.Equal(t, "healthy", waitOnChannelOrTimeout(t, runFetcher(t, f)).ID)
+}
+
+func TestFetcherCancelsNamespaceEnumeration(t *testing.T) {
+	for _, timeout := range []int{0, 1} {
+		t.Run(fmt.Sprintf("timeout=%d", timeout), func(t *testing.T) {
+			setEngineTimeout(t, timeout)
+			entered := make(chan context.Context, 1)
+			g := namespaceLookup{list: func(ctx context.Context, _ string) ([]ContainerRef, error) {
+				entered <- ctx
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}}
+			f := newTestFetcher(g, make(chan string), fastBackoff, maxPendingFetches, nil)
+			f.namespaces = []*deferredNamespace{{engine: g, name: "stalled"}}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				f.serve(ctx, make(chan event.Event))
+			}()
+			select {
+			case requestCtx := <-entered:
+				_, bounded := requestCtx.Deadline()
+				assert.Equal(t, timeout > 0, bounded)
+			case <-time.After(time.Second):
+				t.Fatal("namespace enumeration did not start")
+			}
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("namespace enumeration ignored shutdown")
+			}
+		})
+	}
+}
+
+func TestFetcherBoundsNamespaceEnumeration(t *testing.T) {
+	setEngineTimeout(t, 1)
+	calls := 0
+	g := namespaceLookup{list: func(ctx context.Context, _ string) ([]ContainerRef, error) {
+		calls++
+		if calls == 1 {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return []ContainerRef{{ID: "recovered"}}, nil
+	}, lookupFunc: func(context.Context, string) (*event.Event, error) {
+		return &event.Event{Info: event.Info{Container: event.Container{ID: "recovered"}}}, nil
+	}}
+	f := newTestFetcher(g, make(chan string), fastBackoff, maxPendingFetches, nil)
+	f.namespaces = []*deferredNamespace{{engine: g, name: "stalled"}}
+	start := time.Now()
+	out := runFetcher(t, f)
+	assert.Equal(t, "recovered", waitOnChannelOrTimeout(t, out).ID)
+	assert.GreaterOrEqual(t, time.Since(start), time.Second)
 }
 
 func TestFetcherRetriesWhileRequestsAndDeferredWorkWait(t *testing.T) {

--- a/plugins/container/go-worker/pkg/container/fetcher_deferred_test.go
+++ b/plugins/container/go-worker/pkg/container/fetcher_deferred_test.go
@@ -1,0 +1,134 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
+)
+
+type lookupFunc func(context.Context, string) (*event.Event, error)
+
+func (f lookupFunc) get(ctx context.Context, id string) (*event.Event, error) {
+	return f(ctx, id)
+}
+
+func TestFetcherRetriesWhileRequestsAndDeferredWorkWait(t *testing.T) {
+	// A full channel models the initial thread scan. The first container
+	// misses once; newer requests must not prevent its due retry.
+	fetchCh := make(chan string, 100)
+	fetchCh <- "target"
+	for i := 0; i < 99; i++ {
+		fetchCh <- fmt.Sprintf("live-%03d", i)
+	}
+	lookups := 0
+	g := lookupFunc(func(_ context.Context, id string) (*event.Event, error) {
+		time.Sleep(time.Millisecond)
+		if id == "target" {
+			lookups++
+			if lookups == 1 {
+				return nil, nil
+			}
+		}
+		return &event.Event{Info: event.Info{Container: event.Container{ID: id}}, IsCreate: true}, nil
+	})
+	f := newTestFetcher(g, fetchCh, []time.Duration{time.Millisecond}, maxPendingFetches, []string{"quiet"})
+	out := runFetcher(t, f)
+	before := 0
+	for waitOnChannelOrTimeout(t, out).ID != "target" {
+		before++
+	}
+	assert.Less(t, before, 99, "the retry waited for the entire request channel to drain")
+}
+
+func TestFetcherRetainsDeferredIdentityThroughRetry(t *testing.T) {
+	for _, requested := range []bool{false, true} {
+		t.Run(fmt.Sprintf("requested=%t", requested), func(t *testing.T) {
+			fullID := "0123456789abcdef0123456789abcdef"
+			id := shortContainerID(fullID)
+			calls := 0
+			origin := lookupFunc(func(_ context.Context, got string) (*event.Event, error) {
+				assert.Equal(t, fullID, got)
+				calls++
+				if calls == 1 {
+					return nil, nil
+				}
+				return &event.Event{Info: event.Info{Container: event.Container{ID: id, FullID: got}}}, nil
+			})
+			unrelated := lookupFunc(func(context.Context, string) (*event.Event, error) {
+				t.Error("a known startup container was sent to an unrelated runtime")
+				return nil, nil
+			})
+			f := newTestFetcher(unrelated, make(chan string), fastBackoff, maxPendingFetches, []string{id})
+			f.deferredLookups[id] = deferredFetch{engine: origin, ref: ContainerRef{ID: fullID}, queued: true}
+			out := make(chan event.Event, 1)
+			retries := newRetryQueue(f.retryBackoff)
+			if requested {
+				f.serveRequest(context.Background(), id, retries, out)
+				f.serveRequest(context.Background(), id, retries, out)
+			}
+			f.serveDeferred(context.Background(), retries, out)
+			require.Equal(t, 1, calls)
+			require.Empty(t, f.deferred)
+			require.Len(t, f.deferredLookups, 1, "the full ID must survive draining the startup slice")
+			pending, _, ok := retries.peek()
+			require.True(t, ok)
+			f.serveRetry(context.Background(), pending.due, retries, out)
+			assert.Equal(t, fullID, waitOnChannelOrTimeout(t, out).FullID)
+			assert.Equal(t, 2, calls)
+			assert.Empty(t, f.deferredLookups)
+			assert.Zero(t, retries.len())
+		})
+	}
+}
+
+func TestFetcherReleasesFailedDeferredIdentity(t *testing.T) {
+	for _, limit := range []int{0, 1} {
+		t.Run(fmt.Sprintf("pending_limit=%d", limit), func(t *testing.T) {
+			f := newTestFetcher(nopGetter{}, make(chan string), fastBackoff, limit, []string{"gone"})
+			retries := newRetryQueue(f.retryBackoff)
+			out := make(chan event.Event, 1)
+			f.serveDeferred(context.Background(), retries, out)
+			for retries.len() > 0 {
+				pending, _, _ := retries.peek()
+				f.serveRetry(context.Background(), pending.due, retries, out)
+			}
+			assert.Empty(t, f.deferredLookups)
+			assert.Empty(t, out)
+		})
+	}
+}
+
+func TestFetcherKeepsQueuedRecoveryAfterFailedRequest(t *testing.T) {
+	for _, limit := range []int{0, 1} {
+		t.Run(fmt.Sprintf("pending_limit=%d", limit), func(t *testing.T) {
+			found := false
+			g := lookupFunc(func(_ context.Context, id string) (*event.Event, error) {
+				if !found {
+					return nil, nil
+				}
+				return &event.Event{Info: event.Info{Container: event.Container{ID: id}}}, nil
+			})
+			f := newTestFetcher(g, make(chan string), fastBackoff, limit, []string{"late"})
+			retries := newRetryQueue(f.retryBackoff)
+			out := make(chan event.Event, 1)
+			// Either admission fails immediately or all retries fail before
+			// background work gets a turn. The queued attempt must survive.
+			f.serveRequest(context.Background(), "late", retries, out)
+			for retries.len() > 0 {
+				pending, _, _ := retries.peek()
+				f.serveRetry(context.Background(), pending.due, retries, out)
+			}
+			require.Len(t, f.deferredLookups, 1)
+			found = true
+			f.serveDeferred(context.Background(), retries, out)
+			assert.Equal(t, "late", waitOnChannelOrTimeout(t, out).ID)
+			assert.Empty(t, f.deferredLookups)
+		})
+	}
+}

--- a/plugins/container/go-worker/pkg/container/fetcher_test.go
+++ b/plugins/container/go-worker/pkg/container/fetcher_test.go
@@ -289,6 +289,48 @@ func TestFetcherBoundedUnderManyMisses(t *testing.T) {
 		containers, sent, float64(containers)/sent.Seconds(), settled, retried, dropped, total, maxInFlight)
 }
 
+// slowGetter never knows a container and takes delay to say so, like a
+// runtime under load. It records when each lookup started.
+type slowGetter struct {
+	mu     sync.Mutex
+	delay  time.Duration
+	starts []time.Time
+}
+
+func (g *slowGetter) get(context.Context, string) (*event.Event, error) {
+	g.mu.Lock()
+	g.starts = append(g.starts, time.Now())
+	g.mu.Unlock()
+	time.Sleep(g.delay)
+	return nil, errors.New("no such container")
+}
+
+// lookups returns a copy of the lookup start times.
+func (g *slowGetter) lookups() []time.Time {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return append([]time.Time(nil), g.starts...)
+}
+
+// TestFetcherPacesRetriesFromTheEndOfTheLookup checks that the time a lookup
+// takes does not eat into the delay before the next one: a runtime slow to
+// answer gets the whole backoff of rest between two lookups.
+func TestFetcherPacesRetriesFromTheEndOfTheLookup(t *testing.T) {
+	backoff := []time.Duration{20 * time.Millisecond, 40 * time.Millisecond}
+	g := &slowGetter{delay: 30 * time.Millisecond}
+	fetchCh, outCh := startFetcher(t, g, backoff, maxPendingFetches)
+
+	fetchCh <- "slow"
+	assert.Eventually(t, func() bool { return len(g.lookups()) == len(backoff)+1 }, time.Second, time.Millisecond)
+	assertNoEvent(t, outCh, 50*time.Millisecond)
+
+	starts := g.lookups()
+	require.Len(t, starts, len(backoff)+1)
+	for i, delay := range backoff {
+		assert.GreaterOrEqual(t, starts[i+1].Sub(starts[i]), g.delay+delay, "lookup %d started less than its delay after the end of lookup %d", i+1, i)
+	}
+}
+
 type nopGetter struct{}
 
 func (nopGetter) get(context.Context, string) (*event.Event, error) {

--- a/plugins/container/go-worker/pkg/container/fetcher_test.go
+++ b/plugins/container/go-worker/pkg/container/fetcher_test.go
@@ -45,7 +45,7 @@ func testFetcher(t *testing.T, containerEngine Engine, containerId string, expec
 		close(fetchCh)
 	})
 
-	f := NewFetcherEngine(context.Background(), fetchCh, containerEngines)
+	f := NewFetcherEngine(context.Background(), fetchCh, containerEngines, nil)
 	assert.NotNil(t, f)
 
 	// Check that fetcher is able to fetch the container
@@ -122,13 +122,31 @@ func (g *countingGetter) snapshot() map[string][]time.Time {
 func startFetcher(t *testing.T, g getter, backoff []time.Duration, maxPending int) (chan<- string, <-chan event.Event) {
 	t.Helper()
 	fetchCh := make(chan string)
+	return fetchCh, runFetcher(t, newTestFetcher(g, fetchCh, backoff, maxPending, nil))
+}
+
+// newTestFetcher returns a fetcher that serves fetchCh through g, with the
+// given retry backoff, pending bound and deferred containers.
+func newTestFetcher(g getter, fetchCh chan string, backoff []time.Duration, maxPending int, deferred []string) *fetcher {
 	f := &fetcher{
 		getters:      []getter{g},
 		ctx:          context.Background(),
 		fetcherChan:  fetchCh,
 		retryBackoff: backoff,
 		maxPending:   maxPending,
+		deferred:     append([]string(nil), deferred...),
+		deferredSet:  make(map[string]struct{}, len(deferred)),
 	}
+	for _, id := range deferred {
+		f.deferredSet[id] = struct{}{}
+	}
+	return f
+}
+
+// runFetcher runs f until the test ends. It then checks that the fetcher left
+// no goroutine behind.
+func runFetcher(t *testing.T, f *fetcher) <-chan event.Event {
+	t.Helper()
 	goroutines := runtime.NumGoroutine()
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -137,13 +155,13 @@ func startFetcher(t *testing.T, g getter, backoff []time.Duration, maxPending in
 	t.Cleanup(func() {
 		cancel()
 		wg.Wait()
-		close(fetchCh)
+		close(f.fetcherChan)
 		for deadline := time.Now().Add(time.Second); runtime.NumGoroutine() > goroutines && time.Now().Before(deadline); {
 			time.Sleep(10 * time.Millisecond)
 		}
 		assert.LessOrEqual(t, runtime.NumGoroutine(), goroutines, "the fetcher leaked goroutines")
 	})
-	return fetchCh, outCh
+	return outCh
 }
 
 func sumDurations(ds []time.Duration) time.Duration {
@@ -329,6 +347,168 @@ func TestFetcherPacesRetriesFromTheEndOfTheLookup(t *testing.T) {
 	for i, delay := range backoff {
 		assert.GreaterOrEqual(t, starts[i+1].Sub(starts[i]), g.delay+delay, "lookup %d started less than its delay after the end of lookup %d", i+1, i)
 	}
+}
+
+// knownGetter knows every container and answers each lookup after delay, but
+// holds the first one until released, like a runtime slow on its first
+// request. It counts the lookups of each container.
+type knownGetter struct {
+	mu      sync.Mutex
+	once    sync.Once
+	release chan struct{}
+	delay   time.Duration
+	lookups map[string]int
+}
+
+func newKnownGetter(delay time.Duration) *knownGetter {
+	return &knownGetter{release: make(chan struct{}), delay: delay, lookups: make(map[string]int)}
+}
+
+func (g *knownGetter) get(_ context.Context, containerId string) (*event.Event, error) {
+	g.once.Do(func() { <-g.release })
+	g.mu.Lock()
+	g.lookups[containerId]++
+	g.mu.Unlock()
+	time.Sleep(g.delay)
+	return &event.Event{Info: event.Info{Container: event.Container{ID: containerId}}, IsCreate: true}, nil
+}
+
+// count returns the lookups done for the container.
+func (g *knownGetter) count(containerId string) int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.lookups[containerId]
+}
+
+// total returns the lookups done for every container.
+func (g *knownGetter) total() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	total := 0
+	for _, n := range g.lookups {
+		total += n
+	}
+	return total
+}
+
+// TestFetcherLooksUpTheDeferredContainersOnce reproduces the startup of a host
+// with more containers left over from the listing than the request channel
+// holds: the plugin scans the initial thread table and asks for each of them
+// while the first lookup is in flight, so the channel fills up and the further
+// requests are refused, as AskForContainerInfo does. Every container is
+// nonetheless looked up, through the deferred list, and once each, but for
+// the one in flight when the scan asked for it.
+func TestFetcherLooksUpTheDeferredContainersOnce(t *testing.T) {
+	const containers = 150
+	ids := make([]string, containers)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("%012d", i)
+	}
+	g := newKnownGetter(0)
+	fetchCh := make(chan string, 100)
+	outCh := runFetcher(t, newTestFetcher(g, fetchCh, fastBackoff, maxPendingFetches, ids))
+
+	refused := 0
+	for _, id := range ids {
+		select {
+		case fetchCh <- id:
+		default:
+			refused++
+		}
+	}
+	// The scan filled the channel while the first lookup was in flight.
+	assert.Greater(t, refused, 0)
+	close(g.release)
+
+	delivered := make(map[string]int)
+	deadline := time.After(5 * time.Second)
+	for len(delivered) < containers {
+		select {
+		case evt := <-outCh:
+			delivered[evt.ID]++
+		case <-deadline:
+			t.Fatalf("%d of %d containers were never looked up, %d requests refused", containers-len(delivered), containers, refused)
+		}
+	}
+	assertNoEvent(t, outCh, 50*time.Millisecond)
+	for _, id := range ids {
+		assert.GreaterOrEqual(t, g.count(id), 1, "container %s", id)
+	}
+	assert.LessOrEqual(t, g.total(), containers+1)
+}
+
+// TestFetcherServesARequestBeforeTheDeferredContainers checks that a request
+// never waits for the leftovers of the startup listing: it is looked up right
+// after the lookup in flight.
+func TestFetcherServesARequestBeforeTheDeferredContainers(t *testing.T) {
+	deferred := make([]string, 200)
+	for i := range deferred {
+		deferred[i] = fmt.Sprintf("deferred-%03d", i)
+	}
+	g := newKnownGetter(2 * time.Millisecond)
+	close(g.release)
+	fetchCh := make(chan string)
+	outCh := runFetcher(t, newTestFetcher(g, fetchCh, fastBackoff, maxPendingFetches, deferred))
+
+	// Let the deferred lookups start, then ask for a container.
+	for i := 0; i < 3; i++ {
+		waitOnChannelOrTimeout(t, outCh)
+	}
+	sent := make(chan struct{})
+	go func() {
+		fetchCh <- "asked"
+		close(sent)
+	}()
+	before := 0
+	for waitOnChannelOrTimeout(t, outCh).ID != "asked" {
+		before++
+	}
+	<-sent
+	// At most the lookup in flight and one more, if the request came in
+	// between two iterations, precede the request.
+	assert.LessOrEqual(t, before, 2)
+	assert.Less(t, g.total(), len(deferred))
+}
+
+// TestFetcherRetriesADeferredContainerLikeARequest checks that a deferred
+// container the runtime does not know anymore is retried along the backoff,
+// then given up, and one it knows late is found.
+func TestFetcherRetriesADeferredContainerLikeARequest(t *testing.T) {
+	gone := newCountingGetter(0)
+	fetchCh := make(chan string)
+	outCh := runFetcher(t, newTestFetcher(gone, fetchCh, fastBackoff, maxPendingFetches, []string{"gone"}))
+	assert.Eventually(t, func() bool { return gone.count("gone") == len(fastBackoff)+1 }, time.Second, time.Millisecond)
+	assertNoEvent(t, outCh, 50*time.Millisecond)
+	assert.Equal(t, len(fastBackoff)+1, gone.count("gone"))
+
+	late := newCountingGetter(2)
+	lateCh := make(chan string)
+	lateOut := runFetcher(t, newTestFetcher(late, lateCh, fastBackoff, maxPendingFetches, []string{"late"}))
+	assert.Equal(t, "late", waitOnChannelOrTimeout(t, lateOut).ID)
+	assert.Equal(t, 2, late.count("late"))
+	assertNoEvent(t, lateOut, 50*time.Millisecond)
+}
+
+// selfEngine is an Engine that copies to itself and knows no container.
+type selfEngine struct{ nopGetter }
+
+func (selfEngine) Name() string { return "self" }
+
+func (selfEngine) Sock() string { return "" }
+
+func (selfEngine) List(context.Context) ([]event.Event, error) { return nil, nil }
+
+func (selfEngine) Listen(context.Context, *sync.WaitGroup) (<-chan event.Event, error) {
+	return nil, nil
+}
+
+func (e selfEngine) copy(context.Context) (Engine, error) { return e, nil }
+
+func TestNewFetcherEngineDeduplicatesTheDeferredContainers(t *testing.T) {
+	f := NewFetcherEngine(context.Background(), make(chan string), []Engine{selfEngine{}}, []string{"a", "b", "", "a", "c", "b"}).(*fetcher)
+	assert.Equal(t, []string{"a", "b", "c"}, f.deferred)
+	assert.Len(t, f.deferredSet, 3)
+	assert.Len(t, f.getters, 1)
 }
 
 type nopGetter struct{}

--- a/plugins/container/go-worker/pkg/container/fetcher_test.go
+++ b/plugins/container/go-worker/pkg/container/fetcher_test.go
@@ -2,11 +2,18 @@ package container
 
 import (
 	"context"
-	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
-	"github.com/stretchr/testify/assert"
+	"errors"
+	"fmt"
+	"runtime"
+	"sort"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
 )
 
 func TestDockerFetcher(t *testing.T) {
@@ -67,4 +74,272 @@ func testFetcher(t *testing.T, containerEngine Engine, containerId string, expec
 	}
 	expectedEvent.Env = evt.Env
 	assert.Equal(t, expectedEvent, evt)
+}
+
+// countingGetter records every lookup and answers a container from its
+// answerAt-th lookup on; it never answers when answerAt is zero.
+type countingGetter struct {
+	mu       sync.Mutex
+	answerAt int
+	lookups  map[string][]time.Time
+}
+
+func newCountingGetter(answerAt int) *countingGetter {
+	return &countingGetter{answerAt: answerAt, lookups: make(map[string][]time.Time)}
+}
+
+func (g *countingGetter) get(_ context.Context, containerId string) (*event.Event, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.lookups[containerId] = append(g.lookups[containerId], time.Now())
+	if g.answerAt > 0 && len(g.lookups[containerId]) >= g.answerAt {
+		return &event.Event{Info: event.Info{Container: event.Container{ID: containerId}}, IsCreate: true}, nil
+	}
+	return nil, errors.New("no such container")
+}
+
+// count returns the lookups done for the container.
+func (g *countingGetter) count(containerId string) int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.lookups[containerId])
+}
+
+// snapshot returns a copy of the lookups done so far.
+func (g *countingGetter) snapshot() map[string][]time.Time {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	lookups := make(map[string][]time.Time, len(g.lookups))
+	for id, l := range g.lookups {
+		lookups[id] = append([]time.Time(nil), l...)
+	}
+	return lookups
+}
+
+// startFetcher serves the fetch requests through g, with the given retry
+// backoff and pending bound, until the test ends. It then checks that the
+// fetcher left no goroutine behind.
+func startFetcher(t *testing.T, g getter, backoff []time.Duration, maxPending int) (chan<- string, <-chan event.Event) {
+	t.Helper()
+	fetchCh := make(chan string)
+	f := &fetcher{
+		getters:      []getter{g},
+		ctx:          context.Background(),
+		fetcherChan:  fetchCh,
+		retryBackoff: backoff,
+		maxPending:   maxPending,
+	}
+	goroutines := runtime.NumGoroutine()
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	outCh, err := f.Listen(ctx, &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+		close(fetchCh)
+		for deadline := time.Now().Add(time.Second); runtime.NumGoroutine() > goroutines && time.Now().Before(deadline); {
+			time.Sleep(10 * time.Millisecond)
+		}
+		assert.LessOrEqual(t, runtime.NumGoroutine(), goroutines, "the fetcher leaked goroutines")
+	})
+	return fetchCh, outCh
+}
+
+func sumDurations(ds []time.Duration) time.Duration {
+	var sum time.Duration
+	for _, d := range ds {
+		sum += d
+	}
+	return sum
+}
+
+// assertNoEvent fails if ch delivers an event within d.
+func assertNoEvent(t *testing.T, ch <-chan event.Event, d time.Duration) {
+	t.Helper()
+	select {
+	case evt := <-ch:
+		t.Errorf("unexpected event for container %q", evt.ID)
+	case <-time.After(d):
+	}
+}
+
+var fastBackoff = []time.Duration{5 * time.Millisecond, 10 * time.Millisecond, 20 * time.Millisecond}
+
+func TestFetcherRetriesUntilFound(t *testing.T) {
+	g := newCountingGetter(3) // known from the second retry on
+	fetchCh, outCh := startFetcher(t, g, fastBackoff, maxPendingFetches)
+
+	start := time.Now()
+	fetchCh <- "late"
+	evt := waitOnChannelOrTimeout(t, outCh)
+	assert.Equal(t, "late", evt.ID)
+	assert.True(t, evt.IsCreate)
+	assert.Equal(t, 3, g.count("late"))
+	assert.GreaterOrEqual(t, time.Since(start), fastBackoff[0]+fastBackoff[1])
+
+	// Once found, the container is neither looked up nor published again.
+	assertNoEvent(t, outCh, sumDurations(fastBackoff))
+	assert.Equal(t, 3, g.count("late"))
+}
+
+func TestFetcherGivesUpAfterTheBackoff(t *testing.T) {
+	g := newCountingGetter(0) // never known
+	fetchCh, outCh := startFetcher(t, g, fastBackoff, maxPendingFetches)
+
+	fetchCh <- "unknown"
+	assertNoEvent(t, outCh, 2*sumDurations(fastBackoff))
+	// The first lookup, then one per step of the backoff, then nothing.
+	assert.Equal(t, len(fastBackoff)+1, g.count("unknown"))
+
+	// Asked again, e.g. once the plugin bookkeeping expired, it is looked up again.
+	fetchCh <- "unknown"
+	assert.Eventually(t, func() bool { return g.count("unknown") == len(fastBackoff)+2 }, time.Second, time.Millisecond)
+}
+
+func TestFetcherDeduplicatesPendingRequests(t *testing.T) {
+	g := newCountingGetter(0)
+	fetchCh, outCh := startFetcher(t, g, []time.Duration{100 * time.Millisecond}, maxPendingFetches)
+
+	for i := 0; i < 3; i++ {
+		fetchCh <- "dup"
+	}
+	// Only the first request is looked up: the others find a retry pending.
+	assert.Equal(t, 1, g.count("dup"))
+	assert.Eventually(t, func() bool { return g.count("dup") == 2 }, time.Second, time.Millisecond)
+	assertNoEvent(t, outCh, 50*time.Millisecond)
+	assert.Equal(t, 2, g.count("dup"))
+}
+
+// TestFetcherBoundedUnderManyMisses floods the fetcher with containers no
+// engine knows. At most maxPending of them wait for a retry at any time, the
+// others are dropped after their first lookup, every retried one goes through
+// the whole backoff and no lookup is left running afterwards.
+func TestFetcherBoundedUnderManyMisses(t *testing.T) {
+	const (
+		containers = 5000
+		maxPending = 256
+	)
+	backoff := []time.Duration{5 * time.Millisecond, 10 * time.Millisecond, 20 * time.Millisecond, 40 * time.Millisecond, 80 * time.Millisecond}
+	g := newCountingGetter(0)
+	fetchCh, outCh := startFetcher(t, g, backoff, maxPending)
+
+	start := time.Now()
+	for i := 0; i < containers; i++ {
+		fetchCh <- fmt.Sprintf("ctr%05d", i)
+	}
+	sent := time.Since(start)
+
+	// The last container admitted for a retry is admitted while sending, so
+	// by then every retry is over.
+	assertNoEvent(t, outCh, sumDurations(backoff)+200*time.Millisecond)
+	settled := time.Since(start)
+
+	lookups := g.snapshot()
+	require.Len(t, lookups, containers)
+	retried, dropped, total := 0, 0, 0
+	type edge struct {
+		at    time.Time
+		delta int
+	}
+	var edges []edge
+	for id, l := range lookups {
+		total += len(l)
+		switch len(l) {
+		case 1:
+			dropped++
+		case len(backoff) + 1:
+			retried++
+			// A retried container holds a slot from its first lookup, right
+			// before it is admitted, to its last one, right before it is
+			// given up.
+			edges = append(edges, edge{l[0], +1}, edge{l[len(l)-1], -1})
+		default:
+			t.Errorf("container %s: %d lookups, want 1 or %d", id, len(l), len(backoff)+1)
+		}
+	}
+	assert.Equal(t, containers, retried+dropped)
+	assert.GreaterOrEqual(t, retried, maxPending)
+	assert.Equal(t, dropped+retried*(len(backoff)+1), total)
+
+	// At no time more than maxPending containers were waiting for a retry.
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].at.Equal(edges[j].at) {
+			return edges[i].delta < edges[j].delta
+		}
+		return edges[i].at.Before(edges[j].at)
+	})
+	pending, maxInFlight := 0, 0
+	for _, e := range edges {
+		pending += e.delta
+		maxInFlight = max(maxInFlight, pending)
+	}
+	assert.Equal(t, maxPending, maxInFlight)
+
+	// Nothing is left running.
+	assertNoEvent(t, outCh, 2*backoff[len(backoff)-1])
+	assert.Len(t, g.snapshot(), containers)
+	after := 0
+	for _, l := range g.snapshot() {
+		after += len(l)
+	}
+	assert.Equal(t, total, after)
+
+	t.Logf("%d containers sent in %v (%.0f req/s), settled after %v: %d retried, %d dropped, %d lookups, %d max pending",
+		containers, sent, float64(containers)/sent.Seconds(), settled, retried, dropped, total, maxInFlight)
+}
+
+type nopGetter struct{}
+
+func (nopGetter) get(context.Context, string) (*event.Event, error) {
+	return nil, nil
+}
+
+// BenchmarkFetcherMiss measures a request for a container no engine knows,
+// with the default backoff and bound, the retries running in the background.
+func BenchmarkFetcherMiss(b *testing.B) {
+	fetchCh := make(chan string)
+	f := &fetcher{
+		getters:      []getter{nopGetter{}},
+		ctx:          context.Background(),
+		fetcherChan:  fetchCh,
+		retryBackoff: containerFetchRetryBackoff,
+		maxPending:   maxPendingFetches,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	if _, err := f.Listen(ctx, &wg); err != nil {
+		b.Fatal(err)
+	}
+	ids := make([]string, 1<<14)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("ctr%05d", i)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fetchCh <- ids[i%len(ids)]
+	}
+	b.StopTimer()
+	cancel()
+	wg.Wait()
+}
+
+// BenchmarkRetryQueue measures the bookkeeping of one retry while the bound
+// of containers is pending.
+func BenchmarkRetryQueue(b *testing.B) {
+	q := newRetryQueue(containerFetchRetryBackoff)
+	now := time.Now()
+	for i := 0; i < maxPendingFetches; i++ {
+		q.add(pendingFetch{id: fmt.Sprintf("ctr%05d", i), since: now}, 0, now)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p, step, _ := q.peek()
+		q.pop(step)
+		if !q.add(p, step+1, now) {
+			q.add(p, 0, now)
+		}
+	}
 }

--- a/plugins/container/go-worker/pkg/container/fetcher_test.go
+++ b/plugins/container/go-worker/pkg/container/fetcher_test.go
@@ -129,16 +129,16 @@ func startFetcher(t *testing.T, g getter, backoff []time.Duration, maxPending in
 // given retry backoff, pending bound and deferred containers.
 func newTestFetcher(g getter, fetchCh chan string, backoff []time.Duration, maxPending int, deferred []string) *fetcher {
 	f := &fetcher{
-		getters:      []getter{g},
-		ctx:          context.Background(),
-		fetcherChan:  fetchCh,
-		retryBackoff: backoff,
-		maxPending:   maxPending,
-		deferred:     append([]string(nil), deferred...),
-		deferredSet:  make(map[string]struct{}, len(deferred)),
+		getters:         []getter{g},
+		ctx:             context.Background(),
+		fetcherChan:     fetchCh,
+		retryBackoff:    backoff,
+		maxPending:      maxPending,
+		deferred:        append([]string(nil), deferred...),
+		deferredLookups: make(map[string]deferredFetch, len(deferred)),
 	}
 	for _, id := range deferred {
-		f.deferredSet[id] = struct{}{}
+		f.deferredLookups[id] = deferredFetch{engine: g, ref: ContainerRef{ID: id}, queued: true}
 	}
 	return f
 }
@@ -505,9 +505,11 @@ func (selfEngine) Listen(context.Context, *sync.WaitGroup) (<-chan event.Event, 
 func (e selfEngine) copy(context.Context) (Engine, error) { return e, nil }
 
 func TestNewFetcherEngineDeduplicatesTheDeferredContainers(t *testing.T) {
-	f := NewFetcherEngine(context.Background(), make(chan string), []Engine{selfEngine{}}, []string{"a", "b", "", "a", "c", "b"}).(*fetcher)
+	engine := selfEngine{}
+	refs := []ContainerRef{{ID: "a"}, {ID: "b"}, {}, {ID: "a"}, {ID: "c"}, {ID: "b"}}
+	f := NewFetcherEngine(context.Background(), make(chan string), []Engine{engine}, []DeferredContainers{{Engine: engine, Containers: refs}}).(*fetcher)
 	assert.Equal(t, []string{"a", "b", "c"}, f.deferred)
-	assert.Len(t, f.deferredSet, 3)
+	assert.Len(t, f.deferredLookups, 3)
 	assert.Len(t, f.getters, 1)
 }
 

--- a/plugins/container/go-worker/pkg/container/podman.go
+++ b/plugins/container/go-worker/pkg/container/podman.go
@@ -31,8 +31,25 @@ type podmanEngine struct {
 }
 
 func newPodmanEngine(ctx context.Context, _ *slog.Logger, socket string) (Engine, error) {
-	conn, err := bindings.NewConnection(ctx, enforceUnixProtocolIfEmpty(socket))
+	// bindings.NewConnection pings the service and returns a context that
+	// carries the connection; every later request derives from it, so a
+	// deadline on ctx itself would expire the whole engine. Bound the ping
+	// only: cancel the connection context if the engine timeout elapses first,
+	// then detach it once the service has answered.
+	connCtx, cancelConn := context.WithCancelCause(ctx)
+	pingCtx, cancelPing := WithEngineTimeout(ctx)
+	defer cancelPing()
+	stop := context.AfterFunc(pingCtx, func() {
+		cancelConn(context.Cause(pingCtx))
+	})
+	conn, err := bindings.NewConnection(connCtx, enforceUnixProtocolIfEmpty(socket))
+	if !stop() && err == nil {
+		// The timeout fired while the service was answering: the connection
+		// context is cancelled and the engine would never work.
+		err = context.Cause(pingCtx)
+	}
 	if err != nil {
+		cancelConn(err)
 		return nil, err
 	}
 	return &podmanEngine{pCtx: conn, socket: socket}, nil
@@ -41,6 +58,20 @@ func newPodmanEngine(ctx context.Context, _ *slog.Logger, socket string) (Engine
 func (pc *podmanEngine) copy(ctx context.Context) (Engine, error) {
 	// TODO: change to use logger member once handled
 	return newPodmanEngine(ctx, nil, pc.socket)
+}
+
+// requestCtx derives a request context from the connection context, which is
+// what carries the podman client, and ties it to the caller's context so that
+// the deadline and cancellation set by the caller are honoured.
+func (pc *podmanEngine) requestCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	reqCtx, cancel := context.WithCancelCause(pc.pCtx)
+	stop := context.AfterFunc(ctx, func() {
+		cancel(context.Cause(ctx))
+	})
+	return reqCtx, func() {
+		stop()
+		cancel(nil)
+	}
 }
 
 func (pc *podmanEngine) ctrToInfo(ctr *define.InspectContainerData) event.Info {
@@ -164,9 +195,11 @@ func (pc *podmanEngine) ctrToInfo(ctr *define.InspectContainerData) event.Info {
 	}
 }
 
-func (pc *podmanEngine) get(_ context.Context, containerId string) (*event.Event, error) {
+func (pc *podmanEngine) get(ctx context.Context, containerId string) (*event.Event, error) {
+	ctx, cancel := pc.requestCtx(ctx)
+	defer cancel()
 	size := config.GetWithSize()
-	ctrInfo, err := containers.Inspect(pc.pCtx, containerId, &containers.InspectOptions{Size: &size})
+	ctrInfo, err := containers.Inspect(ctx, containerId, &containers.InspectOptions{Size: &size})
 	if err != nil {
 		return nil, err
 	}
@@ -185,16 +218,18 @@ func (pc *podmanEngine) Sock() string {
 	return pc.socket
 }
 
-func (pc *podmanEngine) List(_ context.Context) ([]event.Event, error) {
+func (pc *podmanEngine) List(ctx context.Context) ([]event.Event, error) {
+	ctx, cancel := pc.requestCtx(ctx)
+	defer cancel()
 	evts := make([]event.Event, 0)
 	all := true
 	size := config.GetWithSize()
-	cList, err := containers.List(pc.pCtx, &containers.ListOptions{All: &all})
+	cList, err := containers.List(ctx, &containers.ListOptions{All: &all})
 	if err != nil {
 		return nil, err
 	}
 	for _, c := range cList {
-		ctrInfo, err := containers.Inspect(pc.pCtx, c.ID, &containers.InspectOptions{Size: &size})
+		ctrInfo, err := containers.Inspect(ctx, c.ID, &containers.InspectOptions{Size: &size})
 		if err != nil {
 			evts = append(evts, event.Event{
 				Info: event.Info{

--- a/plugins/container/go-worker/pkg/container/podman.go
+++ b/plugins/container/go-worker/pkg/container/podman.go
@@ -228,8 +228,19 @@ func (pc *podmanEngine) List(ctx context.Context) ([]event.Event, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, c := range cList {
+	for idx, c := range cList {
+		// Once the caller's context is done every request fails, but only
+		// after the three attempts and the fixed pauses of the podman client:
+		// stop here rather than paying them for each remaining container, and
+		// leave those containers to the lookups on their first event instead
+		// of returning them with partial metadata.
+		if cut := listCut(ctx); cut != nil {
+			return evts, &ListIncompleteError{Remaining: len(cList) - idx, Err: cut}
+		}
 		ctrInfo, err := containers.Inspect(ctx, c.ID, &containers.InspectOptions{Size: &size})
+		if cut := listCut(ctx); cut != nil {
+			return evts, &ListIncompleteError{Remaining: len(cList) - idx, Err: cut}
+		}
 		if err != nil {
 			evts = append(evts, event.Event{
 				Info: event.Info{

--- a/plugins/container/go-worker/pkg/container/podman.go
+++ b/plugins/container/go-worker/pkg/container/podman.go
@@ -228,18 +228,22 @@ func (pc *podmanEngine) List(ctx context.Context) ([]event.Event, error) {
 	if err != nil {
 		return nil, err
 	}
+	// incomplete reports the containers from index from on as not inspected.
+	incomplete := func(from int, cut error) *ListIncompleteError {
+		return &ListIncompleteError{NotInspected: notInspectedFrom(len(cList), from, func(i int) string { return cList[i].ID }), Err: cut}
+	}
 	for idx, c := range cList {
 		// Once the caller's context is done every request fails, but only
 		// after the three attempts and the fixed pauses of the podman client:
 		// stop here rather than paying them for each remaining container, and
-		// leave those containers to the lookups on their first event instead
-		// of returning them with partial metadata.
+		// leave those containers to the background lookups instead of
+		// returning them with partial metadata.
 		if cut := listCut(ctx); cut != nil {
-			return evts, &ListIncompleteError{Remaining: len(cList) - idx, Err: cut}
+			return evts, incomplete(idx, cut)
 		}
 		ctrInfo, err := containers.Inspect(ctx, c.ID, &containers.InspectOptions{Size: &size})
 		if cut := listCut(ctx); cut != nil {
-			return evts, &ListIncompleteError{Remaining: len(cList) - idx, Err: cut}
+			return evts, incomplete(idx, cut)
 		}
 		if err != nil {
 			evts = append(evts, event.Event{

--- a/plugins/container/go-worker/pkg/container/podman_deferred_test.go
+++ b/plugins/container/go-worker/pkg/container/podman_deferred_test.go
@@ -35,7 +35,7 @@ func TestPodmanDeferredContainersAreLookedUpAfterTheCutListing(t *testing.T) {
 	require.Len(t, incomplete.NotInspected, count)
 
 	fetchCh := make(chan string, 100)
-	f := NewFetcherEngine(context.Background(), fetchCh, []Engine{engine}, incomplete.NotInspected)
+	f := NewFetcherEngine(context.Background(), fetchCh, []Engine{engine}, []DeferredContainers{{Engine: engine, Containers: incomplete.NotInspected}})
 	ctx, stop := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	outCh, err := f.Listen(ctx, &wg)
@@ -56,7 +56,8 @@ func TestPodmanDeferredContainersAreLookedUpAfterTheCutListing(t *testing.T) {
 			t.Fatalf("only %d of %d deferred containers were looked up", len(recovered), count)
 		}
 	}
-	for _, id := range incomplete.NotInspected {
+	for _, ref := range incomplete.NotInspected {
+		id := shortContainerID(ref.ID)
 		evt, ok := recovered[id]
 		require.True(t, ok, "container %s was not looked up", id)
 		assert.Equal(t, "healthy-"+id, evt.Name)

--- a/plugins/container/go-worker/pkg/container/podman_deferred_test.go
+++ b/plugins/container/go-worker/pkg/container/podman_deferred_test.go
@@ -1,0 +1,68 @@
+//go:build linux
+
+package container
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
+)
+
+// TestPodmanDeferredContainersAreLookedUpAfterTheCutListing runs the startup
+// of a host whose podman stalls on the first inspection: the listing is cut
+// by the engine timeout with every container left over, and the fetcher then
+// looks all of them up in the background, with their whole metadata, without
+// any request from the plugin.
+func TestPodmanDeferredContainersAreLookedUpAfterTheCutListing(t *testing.T) {
+	const count = 150
+	socket, inspected := newStallingLibpodAPI(t, count, 0)
+	engine, err := newPodmanEngine(context.Background(), slog.Default(), socket)
+	require.NoError(t, err)
+
+	listCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	evts, err := engine.List(listCtx)
+	var incomplete *ListIncompleteError
+	require.ErrorAs(t, err, &incomplete)
+	assert.Empty(t, evts)
+	require.Len(t, incomplete.NotInspected, count)
+
+	fetchCh := make(chan string, 100)
+	f := NewFetcherEngine(context.Background(), fetchCh, []Engine{engine}, incomplete.NotInspected)
+	ctx, stop := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	outCh, err := f.Listen(ctx, &wg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		stop()
+		wg.Wait()
+		close(fetchCh)
+	})
+
+	recovered := make(map[string]event.Event, count)
+	deadline := time.After(10 * time.Second)
+	for len(recovered) < count {
+		select {
+		case evt := <-outCh:
+			recovered[evt.ID] = evt
+		case <-deadline:
+			t.Fatalf("only %d of %d deferred containers were looked up", len(recovered), count)
+		}
+	}
+	for _, id := range incomplete.NotInspected {
+		evt, ok := recovered[id]
+		require.True(t, ok, "container %s was not looked up", id)
+		assert.Equal(t, "healthy-"+id, evt.Name)
+		assert.True(t, evt.Privileged)
+		assert.Equal(t, map[string]string{"app": "critical"}, evt.Labels)
+	}
+	// One inspection per container, plus the stalled one of the listing.
+	assert.EqualValues(t, count+1, inspected.Load())
+}

--- a/plugins/container/go-worker/pkg/container/podman_timeout_test.go
+++ b/plugins/container/go-worker/pkg/container/podman_timeout_test.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package container
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPodmanEngineGivesUpOnUnresponsiveSocket(t *testing.T) {
+	setEngineTimeout(t, 1)
+	socket := newUnresponsiveSocket(t)
+
+	start := time.Now()
+	_, err := newPodmanEngine(context.Background(), slog.Default(), socket)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	// The bindings retry a failed request 3 times, sleeping in between.
+	assert.GreaterOrEqual(t, elapsed, time.Second)
+	assert.Less(t, elapsed, 5*time.Second)
+}
+
+func TestPodmanListHonoursContext(t *testing.T) {
+	// A libpod API that answers the ping and then never answers anything else.
+	socket := filepath.Join(t.TempDir(), "podman.sock")
+	listener, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/_ping") {
+			w.Header().Set("Libpod-API-Version", "6.0.0")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		<-r.Context().Done()
+	})}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	engine, err := newPodmanEngine(context.Background(), slog.Default(), socket)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err = engine.List(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 5*time.Second)
+
+	// The connection context of the engine is untouched by the bounded call.
+	assert.NoError(t, engine.(*podmanEngine).pCtx.Err())
+}

--- a/plugins/container/go-worker/pkg/container/podman_timeout_test.go
+++ b/plugins/container/go-worker/pkg/container/podman_timeout_test.go
@@ -4,11 +4,14 @@ package container
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -59,5 +62,80 @@ func TestPodmanListHonoursContext(t *testing.T) {
 	assert.Less(t, time.Since(start), 5*time.Second)
 
 	// The connection context of the engine is untouched by the bounded call.
+	assert.NoError(t, engine.(*podmanEngine).pCtx.Err())
+}
+
+// newStallingLibpodAPI serves a libpod API on a unix socket that answers the
+// ping and lists count containers at once, then answers every inspection but
+// the one at index stallAt, in request order, which hangs until the request
+// is cancelled. It returns the socket path and the count of the inspection
+// requests received.
+func newStallingLibpodAPI(t *testing.T, count, stallAt int) (string, *atomic.Int32) {
+	t.Helper()
+	socket := filepath.Join(t.TempDir(), "podman.sock")
+	listener, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	var inspected atomic.Int32
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/_ping"):
+			w.Header().Set("Libpod-API-Version", "6.0.0")
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			ctrs := make([]map[string]any, count)
+			for i := range ctrs {
+				ctrs[i] = map[string]any{"Id": fmt.Sprintf("%012d", i+1), "Image": "alpine:latest", "Created": "2026-09-09T00:00:00Z"}
+			}
+			_ = json.NewEncoder(w).Encode(ctrs)
+		default: // .../containers/{id}/json
+			if int(inspected.Add(1)) == stallAt+1 {
+				<-r.Context().Done()
+				return
+			}
+			parts := strings.Split(r.URL.Path, "/")
+			id := parts[len(parts)-2]
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"Id": id, "Name": "healthy-" + id, "ImageName": "alpine:latest", "Created": "2026-09-09T00:00:00Z",
+				"HostConfig": map[string]any{"Privileged": true},
+				"Config":     map[string]any{"Labels": map[string]string{"app": "critical"}},
+			})
+		}
+	})}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+	return socket, &inspected
+}
+
+func TestPodmanListStopsInspectingOnceTheContextIsDone(t *testing.T) {
+	// Six containers, the third inspection never answers: with a 200ms
+	// deadline the listing returns the two containers inspected so far, with
+	// their whole metadata, and leaves the other four to their first event.
+	socket, inspected := newStallingLibpodAPI(t, 6, 2)
+	engine, err := newPodmanEngine(context.Background(), slog.Default(), socket)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	evts, err := engine.List(ctx)
+	elapsed := time.Since(start)
+
+	var incomplete *ListIncompleteError
+	require.ErrorAs(t, err, &incomplete)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 4, incomplete.Remaining)
+	require.Len(t, evts, 2)
+	for i, evt := range evts {
+		assert.Equal(t, fmt.Sprintf("%012d", i+1), evt.ID)
+		assert.Equal(t, "healthy-"+evt.ID, evt.Name)
+		assert.True(t, evt.Privileged)
+		assert.Equal(t, map[string]string{"app": "critical"}, evt.Labels)
+	}
+	// The containers left are not inspected at all: the stalled inspection is
+	// the only one to pay the three attempts and the pauses of the podman
+	// client (100, 200 and 300ms) once cancelled.
+	assert.EqualValues(t, 3, inspected.Load())
+	assert.Less(t, elapsed, 1500*time.Millisecond)
 	assert.NoError(t, engine.(*podmanEngine).pCtx.Err())
 }

--- a/plugins/container/go-worker/pkg/container/podman_timeout_test.go
+++ b/plugins/container/go-worker/pkg/container/podman_timeout_test.go
@@ -124,7 +124,8 @@ func TestPodmanListStopsInspectingOnceTheContextIsDone(t *testing.T) {
 	var incomplete *ListIncompleteError
 	require.ErrorAs(t, err, &incomplete)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Equal(t, 4, incomplete.Remaining)
+	// The containers left are reported for the background lookups.
+	assert.Equal(t, []string{"000000000003", "000000000004", "000000000005", "000000000006"}, incomplete.NotInspected)
 	require.Len(t, evts, 2)
 	for i, evt := range evts {
 		assert.Equal(t, fmt.Sprintf("%012d", i+1), evt.ID)

--- a/plugins/container/go-worker/pkg/container/podman_timeout_test.go
+++ b/plugins/container/go-worker/pkg/container/podman_timeout_test.go
@@ -125,7 +125,7 @@ func TestPodmanListStopsInspectingOnceTheContextIsDone(t *testing.T) {
 	require.ErrorAs(t, err, &incomplete)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	// The containers left are reported for the background lookups.
-	assert.Equal(t, []string{"000000000003", "000000000004", "000000000005", "000000000006"}, incomplete.NotInspected)
+	assert.Equal(t, []ContainerRef{{ID: "000000000003"}, {ID: "000000000004"}, {ID: "000000000005"}, {ID: "000000000006"}}, incomplete.NotInspected)
 	require.Len(t, evts, 2)
 	for i, evt := range evts {
 		assert.Equal(t, fmt.Sprintf("%012d", i+1), evt.ID)

--- a/plugins/container/go-worker/pkg/container/unresponsive_socket_test.go
+++ b/plugins/container/go-worker/pkg/container/unresponsive_socket_test.go
@@ -1,0 +1,87 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/config"
+)
+
+// newUnresponsiveSocket starts a unix socket that accepts connections and
+// never answers them, like a socket-activated runtime whose service is gone
+// (falcosecurity/plugins#1487). It returns the socket path.
+func newUnresponsiveSocket(t *testing.T) string {
+	t.Helper()
+	socket := filepath.Join(t.TempDir(), "runtime.sock")
+	listener, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	var (
+		mu    sync.Mutex
+		conns []net.Conn
+	)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			conns = append(conns, conn)
+			mu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		mu.Lock()
+		defer mu.Unlock()
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+	})
+	return socket
+}
+
+// setEngineTimeout sets the engine timeout, in seconds, for the test duration.
+func setEngineTimeout(t *testing.T, seconds int) {
+	t.Helper()
+	previous := config.Get().EngineTimeout
+	require.NoError(t, config.Load(fmt.Sprintf(`{"engine_timeout": %d}`, seconds)))
+	t.Cleanup(func() {
+		require.NoError(t, config.Load(fmt.Sprintf(`{"engine_timeout": %d}`, previous)))
+	})
+}
+
+func TestDockerListHonoursContextOnUnresponsiveSocket(t *testing.T) {
+	socket := newUnresponsiveSocket(t)
+	engine, err := newDockerEngine(context.Background(), slog.Default(), socket)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err = engine.List(ctx)
+	assert.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+func TestContainerdListHonoursContextOnUnresponsiveSocket(t *testing.T) {
+	socket := newUnresponsiveSocket(t)
+	engine, err := newContainerdEngine(context.Background(), slog.Default(), socket)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err = engine.List(ctx)
+	assert.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second)
+}

--- a/plugins/container/go-worker/worker.go
+++ b/plugins/container/go-worker/worker.go
@@ -33,14 +33,15 @@ type asyncCb func(string, bool, bool)
 // containers, and one that does not answer in time is logged and left out.
 // An engine that answers but does not finish inspecting its containers in
 // time is kept: only the containers it did inspect are delivered, the others
-// are looked up on their first event. Delivering them with partial metadata
-// would cache that metadata for good, since a cached container is never asked
-// again.
+// are returned as deferred, for the fetcher to look them up in the background
+// once the worker runs. Delivering them with partial metadata would cache that
+// metadata for good, since a cached container is never asked again.
 // The generators receive the long-lived ctx unbounded on purpose, since an
 // engine keeps it for its whole lifetime; they bound their own connection.
-func bootstrapEngines(ctx context.Context, generators []container.EngineGenerator, cb asyncCb) ([]container.Engine, map[string][]string) {
+func bootstrapEngines(ctx context.Context, generators []container.EngineGenerator, cb asyncCb) ([]container.Engine, map[string][]string, []string) {
 	engines := make([]container.Engine, 0, len(generators))
 	sockets := make(map[string][]string)
+	var deferred []string
 	for _, generator := range generators {
 		engine, err := generator(ctx)
 		if err != nil {
@@ -55,8 +56,9 @@ func bootstrapEngines(ctx context.Context, generators []container.EngineGenerato
 		var incomplete *container.ListIncompleteError
 		switch {
 		case errors.As(err, &incomplete):
-			logger.LogAttrs(ctx, slog.LevelWarn, "listing containers hit the engine timeout: the containers not inspected in time will be looked up on their first event",
-				slog.Duration("timeout", config.GetEngineTimeout()), slog.Int("inspected", len(containers)), slog.Int("not_inspected", incomplete.Remaining))
+			logger.LogAttrs(ctx, slog.LevelWarn, "listing containers hit the engine timeout: the containers not inspected in time are looked up in the background, their events carry no metadata until then",
+				slog.Duration("timeout", config.GetEngineTimeout()), slog.Int("inspected", len(containers)), slog.Int("not_inspected", len(incomplete.NotInspected)))
+			deferred = append(deferred, incomplete.NotInspected...)
 		case err != nil && timedOut:
 			logger.LogAttrs(ctx, slog.LevelWarn, "container engine did not answer within the engine timeout, skipping it for the rest of this run: its containers will have no metadata",
 				slog.Duration("timeout", config.GetEngineTimeout()), slog.Any("err", err))
@@ -71,7 +73,7 @@ func bootstrapEngines(ctx context.Context, generators []container.EngineGenerato
 			cb(ctr.String(), true, true)
 		}
 	}
-	return engines, sockets
+	return engines, sockets, deferred
 }
 
 func workerLoop(ctx context.Context, cb asyncCb, containerEngines []container.Engine, wg *sync.WaitGroup) {

--- a/plugins/container/go-worker/worker.go
+++ b/plugins/container/go-worker/worker.go
@@ -12,15 +12,60 @@ import "C"
 
 import (
 	"context"
-	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/container"
-	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
+	"log/slog"
 	"reflect"
 	"sync"
+
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/config"
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/container"
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
 )
 
 const ctxDoneIdx = 0
 
 type asyncCb func(string, bool, bool)
+
+// bootstrapEngines creates the engine of each generator and hands the
+// containers it already knows about to cb, flagged as initial state.
+// StartWorker runs it on the caller's thread, so no runtime socket may stall
+// it: each engine gets at most the configured engine timeout to list its
+// containers, and one that does not answer in time is logged and left out.
+// The generators receive the long-lived ctx unbounded on purpose, since an
+// engine keeps it for its whole lifetime; they bound their own connection.
+func bootstrapEngines(ctx context.Context, generators []container.EngineGenerator, cb asyncCb) ([]container.Engine, map[string][]string) {
+	engines := make([]container.Engine, 0, len(generators))
+	sockets := make(map[string][]string)
+	for _, generator := range generators {
+		engine, err := generator(ctx)
+		if err != nil {
+			// Already logged by the generator.
+			continue
+		}
+		listCtx, cancel := container.WithEngineTimeout(ctx)
+		containers, err := engine.List(listCtx)
+		timedOut := listCtx.Err() != nil
+		cancel()
+		logger := slog.With("engine", engine.Name(), "socket", engine.Sock())
+		switch {
+		case err != nil && timedOut:
+			logger.LogAttrs(ctx, slog.LevelWarn, "container engine did not answer within the engine timeout, skipping it for the rest of this run: its containers will have no metadata",
+				slog.Duration("timeout", config.GetEngineTimeout()), slog.Any("err", err))
+			continue
+		case err != nil:
+			logger.LogAttrs(ctx, slog.LevelWarn, "cannot list containers", slog.Any("err", err))
+		case timedOut:
+			logger.LogAttrs(ctx, slog.LevelWarn, "listing containers hit the engine timeout, some of them may carry partial metadata",
+				slog.Duration("timeout", config.GetEngineTimeout()))
+		}
+		engines = append(engines, engine)
+		sockets[engine.Name()] = append(sockets[engine.Name()], engine.Sock())
+		// Deliver all pre-existing containers
+		for _, ctr := range containers {
+			cb(ctr.String(), true, true)
+		}
+	}
+	return engines, sockets
+}
 
 func workerLoop(ctx context.Context, cb asyncCb, containerEngines []container.Engine, wg *sync.WaitGroup) {
 	var evt event.Event

--- a/plugins/container/go-worker/worker.go
+++ b/plugins/container/go-worker/worker.go
@@ -38,10 +38,10 @@ type asyncCb func(string, bool, bool)
 // metadata for good, since a cached container is never asked again.
 // The generators receive the long-lived ctx unbounded on purpose, since an
 // engine keeps it for its whole lifetime; they bound their own connection.
-func bootstrapEngines(ctx context.Context, generators []container.EngineGenerator, cb asyncCb) ([]container.Engine, map[string][]string, []string) {
+func bootstrapEngines(ctx context.Context, generators []container.EngineGenerator, cb asyncCb) ([]container.Engine, map[string][]string, []container.DeferredContainers) {
 	engines := make([]container.Engine, 0, len(generators))
 	sockets := make(map[string][]string)
-	var deferred []string
+	var deferred []container.DeferredContainers
 	for _, generator := range generators {
 		engine, err := generator(ctx)
 		if err != nil {
@@ -58,7 +58,7 @@ func bootstrapEngines(ctx context.Context, generators []container.EngineGenerato
 		case errors.As(err, &incomplete):
 			logger.LogAttrs(ctx, slog.LevelWarn, "listing containers hit the engine timeout: the containers not inspected in time are looked up in the background, their events carry no metadata until then",
 				slog.Duration("timeout", config.GetEngineTimeout()), slog.Int("inspected", len(containers)), slog.Int("not_inspected", len(incomplete.NotInspected)))
-			deferred = append(deferred, incomplete.NotInspected...)
+			deferred = append(deferred, container.DeferredContainers{Engine: engine, Containers: incomplete.NotInspected})
 		case err != nil && timedOut:
 			logger.LogAttrs(ctx, slog.LevelWarn, "container engine did not answer within the engine timeout, skipping it for the rest of this run: its containers will have no metadata",
 				slog.Duration("timeout", config.GetEngineTimeout()), slog.Any("err", err))

--- a/plugins/container/go-worker/worker.go
+++ b/plugins/container/go-worker/worker.go
@@ -12,6 +12,7 @@ import "C"
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"reflect"
 	"sync"
@@ -30,6 +31,11 @@ type asyncCb func(string, bool, bool)
 // StartWorker runs it on the caller's thread, so no runtime socket may stall
 // it: each engine gets at most the configured engine timeout to list its
 // containers, and one that does not answer in time is logged and left out.
+// An engine that answers but does not finish inspecting its containers in
+// time is kept: only the containers it did inspect are delivered, the others
+// are looked up on their first event. Delivering them with partial metadata
+// would cache that metadata for good, since a cached container is never asked
+// again.
 // The generators receive the long-lived ctx unbounded on purpose, since an
 // engine keeps it for its whole lifetime; they bound their own connection.
 func bootstrapEngines(ctx context.Context, generators []container.EngineGenerator, cb asyncCb) ([]container.Engine, map[string][]string) {
@@ -46,16 +52,17 @@ func bootstrapEngines(ctx context.Context, generators []container.EngineGenerato
 		timedOut := listCtx.Err() != nil
 		cancel()
 		logger := slog.With("engine", engine.Name(), "socket", engine.Sock())
+		var incomplete *container.ListIncompleteError
 		switch {
+		case errors.As(err, &incomplete):
+			logger.LogAttrs(ctx, slog.LevelWarn, "listing containers hit the engine timeout: the containers not inspected in time will be looked up on their first event",
+				slog.Duration("timeout", config.GetEngineTimeout()), slog.Int("inspected", len(containers)), slog.Int("not_inspected", incomplete.Remaining))
 		case err != nil && timedOut:
 			logger.LogAttrs(ctx, slog.LevelWarn, "container engine did not answer within the engine timeout, skipping it for the rest of this run: its containers will have no metadata",
 				slog.Duration("timeout", config.GetEngineTimeout()), slog.Any("err", err))
 			continue
 		case err != nil:
 			logger.LogAttrs(ctx, slog.LevelWarn, "cannot list containers", slog.Any("err", err))
-		case timedOut:
-			logger.LogAttrs(ctx, slog.LevelWarn, "listing containers hit the engine timeout, some of them may carry partial metadata",
-				slog.Duration("timeout", config.GetEngineTimeout()))
 		}
 		engines = append(engines, engine)
 		sockets[engine.Name()] = append(sockets[engine.Name()], engine.Sock())

--- a/plugins/container/go-worker/worker.go
+++ b/plugins/container/go-worker/worker.go
@@ -56,9 +56,9 @@ func bootstrapEngines(ctx context.Context, generators []container.EngineGenerato
 		var incomplete *container.ListIncompleteError
 		switch {
 		case errors.As(err, &incomplete):
-			logger.LogAttrs(ctx, slog.LevelWarn, "listing containers hit the engine timeout: the containers not inspected in time are looked up in the background, their events carry no metadata until then",
-				slog.Duration("timeout", config.GetEngineTimeout()), slog.Int("inspected", len(containers)), slog.Int("not_inspected", len(incomplete.NotInspected)))
-			deferred = append(deferred, container.DeferredContainers{Engine: engine, Containers: incomplete.NotInspected})
+			logger.LogAttrs(ctx, slog.LevelWarn, "initial container listing interrupted: unfinished containers and namespaces will be recovered in the background, their events carry no metadata until then",
+				slog.Duration("timeout", config.GetEngineTimeout()), slog.Int("inspected", len(containers)), slog.Int("not_inspected", len(incomplete.NotInspected)), slog.Int("namespaces_not_enumerated", len(incomplete.NotEnumerated)))
+			deferred = append(deferred, container.DeferredContainers{Engine: engine, Containers: incomplete.NotInspected, Namespaces: incomplete.NotEnumerated})
 		case err != nil && timedOut:
 			logger.LogAttrs(ctx, slog.LevelWarn, "container engine did not answer within the engine timeout, skipping it for the rest of this run: its containers will have no metadata",
 				slog.Duration("timeout", config.GetEngineTimeout()), slog.Any("err", err))

--- a/plugins/container/go-worker/worker_api.go
+++ b/plugins/container/go-worker/worker_api.go
@@ -62,14 +62,16 @@ func StartWorker(cb C.async_cb, initCfg *C.cchar_t, enabledSocks **C.cchar_t) un
 	}
 
 	// Create the engines and deliver all pre-existing containers through
-	// `goCb`. This runs synchronously on the caller's thread, hence bounded.
-	containerEngines, enabledEngines := bootstrapEngines(ctx, generators, goCb)
+	// `goCb`. This runs synchronously on the caller's thread, hence bounded:
+	// the containers not inspected in time are deferred to the fetcher.
+	containerEngines, enabledEngines, deferred := bootstrapEngines(ctx, generators, goCb)
 
 	pluginCtx.fetchCh = make(chan string, fetchChSize)
 
 	// Always append the dummy engine that is required to
 	// be able to fetch container infos on the fly given other enabled engines.
-	containerEngines = append(containerEngines, container.NewFetcherEngine(ctx, pluginCtx.fetchCh, containerEngines))
+	// It also looks up the deferred containers in the background.
+	containerEngines = append(containerEngines, container.NewFetcherEngine(ctx, pluginCtx.fetchCh, containerEngines, deferred))
 
 	// Store json of attached sockets in `enabledSocks`
 	bytes, _ := json.Marshal(enabledEngines)

--- a/plugins/container/go-worker/worker_api.go
+++ b/plugins/container/go-worker/worker_api.go
@@ -61,26 +61,9 @@ func StartWorker(cb C.async_cb, initCfg *C.cchar_t, enabledSocks **C.cchar_t) un
 		return nil
 	}
 
-	containerEngines := make([]container.Engine, 0)
-	enabledEngines := make(map[string][]string)
-	for _, generator := range generators {
-		engine, err := generator(ctx)
-		if err != nil {
-			continue
-		}
-		containerEngines = append(containerEngines, engine)
-		if _, ok := enabledEngines[engine.Name()]; !ok {
-			enabledEngines[engine.Name()] = make([]string, 0)
-		}
-		enabledEngines[engine.Name()] = append(enabledEngines[engine.Name()], engine.Sock())
-		// List all pre-existing containers and run `goCb` on all of them
-		containers, err := engine.List(ctx)
-		if err == nil {
-			for _, ctr := range containers {
-				goCb(ctr.String(), true, true)
-			}
-		}
-	}
+	// Create the engines and deliver all pre-existing containers through
+	// `goCb`. This runs synchronously on the caller's thread, hence bounded.
+	containerEngines, enabledEngines := bootstrapEngines(ctx, generators, goCb)
 
 	pluginCtx.fetchCh = make(chan string, fetchChSize)
 

--- a/plugins/container/src/asked_containers.h
+++ b/plugins/container/src/asked_containers.h
@@ -1,0 +1,104 @@
+/*
+Copyright (C) 2026 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <chrono>
+#include <deque>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+// How long a container stays asked before it can be asked again. The
+// go-worker retries a missed lookup for about 4s (containerFetchRetryBackoff
+// in go-worker/pkg/container/fetcher.go), so by then it has given up on the
+// container.
+constexpr auto ASKED_CONTAINERS_TTL = std::chrono::seconds(10);
+
+// The containers whose metadata has been asked to the go-worker through
+// AskForContainerInfo(). It avoids asking again while a request may still be
+// in flight, and lets a container be asked again once the go-worker has
+// given up on it, since the container engine may know it by then.
+// Entries expire after ttl and are purged lazily, so that every operation is
+// O(1): add() purges at most two expired entries, the oldest first, and
+// pending() drops only the expired entry it looks up. The size is thus
+// bounded by the insertions of the last ttl window plus the expired entries
+// that later insertions have not purged yet: a burst lingers, in m_asked and
+// m_order, until enough insertions have followed it, and it is never purged
+// if none does. erase() removes from m_asked only; m_order keeps the entry
+// until the purge reaches it.
+class asked_containers
+{
+    public:
+    using clock = std::chrono::steady_clock;
+
+    explicit asked_containers(clock::duration ttl = ASKED_CONTAINERS_TTL):
+            m_ttl(ttl)
+    {
+    }
+
+    // Returns whether the container was asked less than ttl ago. An expired
+    // entry is dropped on the way.
+    bool pending(const std::string& id, clock::time_point now = clock::now())
+    {
+        auto it = m_asked.find(id);
+        if(it == m_asked.end())
+        {
+            return false;
+        }
+        if(now - it->second < m_ttl)
+        {
+            return true;
+        }
+        m_asked.erase(it);
+        return false;
+    }
+
+    // Records that the container has been asked at now, which must not go
+    // backwards across calls.
+    void add(const std::string& id, clock::time_point now = clock::now())
+    {
+        // Purge a couple of expired entries per insertion. The order is the
+        // insertion order, so the expired entries are at the front.
+        for(int i = 0;
+            i < 2 && !m_order.empty() && now - m_order.front().first >= m_ttl;
+            i++)
+        {
+            auto it = m_asked.find(m_order.front().second);
+            // An entry asked again or erased in the meantime is not ours.
+            if(it != m_asked.end() && it->second == m_order.front().first)
+            {
+                m_asked.erase(it);
+            }
+            m_order.pop_front();
+        }
+        m_asked[id] = now;
+        m_order.emplace_back(now, id);
+    }
+
+    // Forgets the container, e.g. once its metadata arrived or it went away.
+    void erase(const std::string& id) { m_asked.erase(id); }
+
+    size_t size() const { return m_asked.size(); }
+
+    private:
+    clock::duration m_ttl;
+    // When each container was last asked.
+    std::unordered_map<std::string, clock::time_point> m_asked;
+    // The insertions, hence the expiries, in order.
+    std::deque<std::pair<clock::time_point, std::string>> m_order;
+};

--- a/plugins/container/src/caps/parse/parse.cpp
+++ b/plugins/container/src/caps/parse/parse.cpp
@@ -106,6 +106,7 @@ bool my_plugin::parse_async_event(const falcosecurity::parse_event_input& in)
         // event to extract metadata for the being-removed container.
         m_last_container = {evt.get_num(), cinfo};
         m_containers.erase(cinfo->m_id);
+        m_asked_containers.erase(cinfo->m_id);
     }
 
     // Update n_containers metric

--- a/plugins/container/src/plugin.cpp
+++ b/plugins/container/src/plugin.cpp
@@ -383,10 +383,12 @@ void my_plugin::on_new_process(const falcosecurity::table_entry& thread_entry,
                                      container_id),
                          falcosecurity::_internal::SS_PLUGIN_LOG_SEV_DEBUG);
 #ifdef _HAS_ASYNC
-            // Check if already asked
+            // Check if already asked. A request expires once the go-worker
+            // has given up on the container (it retries for a few seconds,
+            // see fetcher.go), so a container the engines did not know in
+            // time is asked again.
             if(m_async_ctx != nullptr &&
-               m_asked_containers.find(container_id) ==
-                       m_asked_containers.end())
+               !m_asked_containers.pending(container_id))
             {
                 m_logger.log(
                         fmt::format("asking the go-worker to fetch info for "
@@ -396,7 +398,7 @@ void my_plugin::on_new_process(const falcosecurity::table_entry& thread_entry,
                 // Implemented by GO worker.go
                 if(AskForContainerInfo(m_async_ctx, container_id.c_str()))
                 {
-                    m_asked_containers.insert(container_id);
+                    m_asked_containers.add(container_id);
                 }
                 else
                 {

--- a/plugins/container/src/plugin.h
+++ b/plugins/container/src/plugin.h
@@ -15,11 +15,11 @@ limitations under the License.
 
 */
 
+#include <asked_containers.h>
 #include <consts.h>
 #include <macros.h>
 #include <matchers/matcher.h>
 #include <unordered_map>
-#include <unordered_set>
 
 enum command_category
 {
@@ -125,9 +125,10 @@ class my_plugin
     // Last container enriched from an async event parsing.
     // Used to extract container info from aforementioned async events.
     std::pair<uint64_t, std::shared_ptr<const container_info>> m_last_container;
-    // Cache being asked containers to go-worker through AskForContainerInfo()
-    // API. Avoids repeatedly calling the API.
-    std::unordered_set<std::string> m_asked_containers;
+    // Containers asked to the go-worker through the AskForContainerInfo()
+    // API. Avoids asking again while a request may be in flight, and lets a
+    // container be asked again once the go-worker has given up on it.
+    asked_containers m_asked_containers;
 
     std::vector<falcosecurity::metric> m_metrics;
 

--- a/plugins/container/src/plugin_config.cpp
+++ b/plugins/container/src/plugin_config.cpp
@@ -37,6 +37,14 @@ void from_json(const nlohmann::json& j, PluginConfig& cfg)
 {
     cfg.label_max_len = j.value("label_max_len", DEFAULT_LABEL_MAX_LEN);
     cfg.with_size = j.value("with_size", false);
+    cfg.engine_timeout = j.value("engine_timeout", DEFAULT_ENGINE_TIMEOUT);
+    // libs already rejects a negative value through the init config schema
+    // (minimum: 0 in plugin_config_schema.h). Defensive only: a negative value
+    // would otherwise disable the timeout like 0 does.
+    if(cfg.engine_timeout < 0)
+    {
+        cfg.engine_timeout = DEFAULT_ENGINE_TIMEOUT;
+    }
     cfg.log_level = j.value("log_level", std::string{"warn"});
 
     std::vector<std::string> hooks =
@@ -128,6 +136,7 @@ void to_json(nlohmann::json& j, const PluginConfig& cfg)
 {
     j["label_max_len"] = cfg.label_max_len;
     j["with_size"] = cfg.with_size;
+    j["engine_timeout"] = cfg.engine_timeout;
     j["host_root"] = cfg.host_root;
     j["hooks"] = cfg.hooks;
     j["log_level"] = cfg.log_level;

--- a/plugins/container/src/plugin_config.h
+++ b/plugins/container/src/plugin_config.h
@@ -5,6 +5,9 @@
 #include <falcosecurity/sdk.h>
 
 #define DEFAULT_LABEL_MAX_LEN 100
+// Seconds a container engine gets to answer while the plugin connects to it
+// and lists the pre-existing containers at startup. 0 disables the timeout.
+#define DEFAULT_ENGINE_TIMEOUT 10
 
 #define HOOK_CREATE 1
 #define HOOK_START 2
@@ -61,6 +64,7 @@ struct PluginConfig
     int label_max_len;
     bool with_size;
     uint8_t hooks;
+    int engine_timeout;
     std::string host_root;
     std::string log_level;
     Engines engines;
@@ -70,6 +74,7 @@ struct PluginConfig
         label_max_len = DEFAULT_LABEL_MAX_LEN;
         with_size = false;
         hooks = HOOK_CREATE;
+        engine_timeout = DEFAULT_ENGINE_TIMEOUT;
         log_level = "info";
         if(const char* hroot = std::getenv("HOST_ROOT"))
         {

--- a/plugins/container/src/plugin_config_schema.h
+++ b/plugins/container/src/plugin_config_schema.h
@@ -41,6 +41,12 @@ const char plugin_schema_string[] = LONG_STRING_CONST(
       "title": "Log level",
       "description": "Log level for the go-worker. Valid values: trace, debug, info, warn, error. Defaults to 'warn'."
     },
+    "engine_timeout": {
+      "type": "integer",
+      "minimum": 0,
+      "title": "Container engine timeout",
+      "description": "Seconds to wait for a container engine to answer while connecting to it and listing the pre-existing containers at startup. An engine that does not answer in time is skipped, so that an unresponsive runtime socket cannot block Falco's startup. 0 disables the timeout. Defaults to 10."
+    },
     "engines": {
       "$ref": "#/definitions/Engines",
       "title": "The plugin per-engine configuration",

--- a/plugins/container/test/CMakeLists.txt
+++ b/plugins/container/test/CMakeLists.txt
@@ -10,6 +10,7 @@ configure_file(
 )
 
 add_executable(test src/extract.cpp
+    asked_containers.cpp
     config.cpp
     container_info_json.cpp
     lru.cpp

--- a/plugins/container/test/asked_containers.cpp
+++ b/plugins/container/test/asked_containers.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+#include <asked_containers.h>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+const auto t0 = asked_containers::clock::time_point(1h);
+}
+
+TEST(asked_containers, pending_until_ttl)
+{
+    asked_containers asked(10s);
+    EXPECT_FALSE(asked.pending("abc", t0));
+
+    asked.add("abc", t0);
+    EXPECT_TRUE(asked.pending("abc", t0));
+    EXPECT_TRUE(asked.pending("abc", t0 + 9s));
+    EXPECT_EQ(asked.size(), 1u);
+
+    // Expired: dropped, and can be asked again
+    EXPECT_FALSE(asked.pending("abc", t0 + 10s));
+    EXPECT_EQ(asked.size(), 0u);
+    asked.add("abc", t0 + 10s);
+    EXPECT_TRUE(asked.pending("abc", t0 + 19s));
+    EXPECT_FALSE(asked.pending("abc", t0 + 20s));
+}
+
+TEST(asked_containers, erase)
+{
+    asked_containers asked(10s);
+    asked.add("abc", t0);
+    asked.erase("abc");
+    EXPECT_FALSE(asked.pending("abc", t0));
+    EXPECT_EQ(asked.size(), 0u);
+    // Unknown containers are fine
+    asked.erase("def");
+    EXPECT_EQ(asked.size(), 0u);
+}
+
+TEST(asked_containers, add_purges_expired_entries)
+{
+    asked_containers asked(10s);
+    for(int i = 0; i < 100; i++)
+    {
+        asked.add(std::to_string(i), t0);
+    }
+    EXPECT_EQ(asked.size(), 100u);
+
+    // Nothing has expired yet
+    asked.add("a", t0 + 5s);
+    EXPECT_EQ(asked.size(), 101u);
+
+    // Two expired entries go per insertion
+    asked.add("b", t0 + 10s);
+    EXPECT_EQ(asked.size(), 100u);
+    asked.add("c", t0 + 10s);
+    EXPECT_EQ(asked.size(), 99u);
+
+    // The entries that did not expire are untouched
+    EXPECT_TRUE(asked.pending("a", t0 + 10s));
+    EXPECT_TRUE(asked.pending("b", t0 + 10s));
+    EXPECT_TRUE(asked.pending("c", t0 + 10s));
+    EXPECT_TRUE(asked.pending("99", t0 + 9s));
+}
+
+TEST(asked_containers, purge_skips_entries_asked_again)
+{
+    asked_containers asked(10s);
+    asked.add("x", t0);
+    asked.add("x", t0 + 1s);
+    EXPECT_EQ(asked.size(), 1u);
+
+    // The stale record of the first insertion is skipped, the entry stays
+    asked.add("y", t0 + 10s);
+    EXPECT_EQ(asked.size(), 2u);
+    EXPECT_TRUE(asked.pending("x", t0 + 10s));
+    EXPECT_FALSE(asked.pending("x", t0 + 11s));
+
+    // The stale record of an erased entry is skipped as well
+    asked.add("z", t0 + 11s);
+    asked.erase("z");
+    asked.add("w", t0 + 21s);
+    EXPECT_EQ(asked.size(), 1u);
+    EXPECT_TRUE(asked.pending("w", t0 + 21s));
+}

--- a/plugins/container/test/config.cpp
+++ b/plugins/container/test/config.cpp
@@ -39,7 +39,8 @@ TEST(plugin_config, from_json)
   },
   "label_max_len": 120,
   "with_size": true,
-  "hooks": ["start"]
+  "hooks": ["start"],
+  "engine_timeout": 5
 })";
     auto config_json = nlohmann::json::parse(config);
 
@@ -56,6 +57,7 @@ TEST(plugin_config, from_json)
     EXPECT_TRUE(cfg.with_size);
     EXPECT_EQ(cfg.label_max_len, 120);
     EXPECT_EQ(cfg.hooks, HOOK_START);
+    EXPECT_EQ(cfg.engine_timeout, 5);
 }
 
 TEST(plugin_config, from_json_missing_engines)
@@ -101,11 +103,27 @@ TEST(plugin_config, from_json_empty_json)
     EXPECT_FALSE(cfg.with_size);
     EXPECT_EQ(cfg.label_max_len, DEFAULT_LABEL_MAX_LEN);
     EXPECT_EQ(cfg.hooks, HOOK_CREATE);
+    EXPECT_EQ(cfg.engine_timeout, DEFAULT_ENGINE_TIMEOUT);
+}
+
+TEST(plugin_config, from_json_engine_timeout_bounds)
+{
+    // 0 disables the timeout and is kept as is.
+    auto cfg = nlohmann::json::parse(R"({"engine_timeout": 0})")
+                       .get<PluginConfig>();
+    EXPECT_EQ(cfg.engine_timeout, 0);
+
+    // A negative value is rejected by the init config schema; from_json falls
+    // back to the default anyway instead of disabling the timeout.
+    cfg = nlohmann::json::parse(R"({"engine_timeout": -5})")
+                  .get<PluginConfig>();
+    EXPECT_EQ(cfg.engine_timeout, DEFAULT_ENGINE_TIMEOUT);
 }
 
 TEST(plugin_config, to_json)
 {
     std::string expected_config = R"({
+  "engine_timeout": 10,
   "engines": {
     "containerd": {
       "enabled": true,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

Two fixes for the container plugin, cumulated here so they ship together in `0.7.3` 👇

**1. Bound the engine bootstrap (#1487)**

`StartWorker` bootstraps every enabled engine synchronously with a context that has no deadline, and the podman client has no timeout either: a runtime socket that accepts the connection but never answers blocks the call forever, and since libs calls it from `sinsp::open_common()` on the main thread, Falco hangs at startup and ignores SIGTERM.

- new `engine_timeout` init config key (seconds, default `10`, `0` disables it), documented in the README
- each engine's initial `List` runs under the timeout; an engine that does not answer is logged and skipped
- an engine that answers but does not finish in time is kept: the containers inspected so far are loaded, the others (and, for containerd, the namespaces not enumerated yet) are looked up in the background right after startup, one at a time and behind the lookups the events ask for, so no partial metadata ever enters the cache
- the podman `/_ping` is bounded, and podman `List`/`get` honour the caller's context

**2. Keep looking up a container the runtime does not know yet (#1269)**

The go-worker retried a missed lookup every 30 ms for 150 ms and then dropped it, and the plugin never asked again: a container the runtime did not know yet (e.g. a loaded CRI) stayed without metadata for the whole plugin lifetime.

- the fetcher retries with an exponential backoff (125 ms to 2 s, about 4 s in total), with a single goroutine and a single timer, deduplicating pending ids and capping them at 1024
- the plugin's "already asked" set expires after 10 s, so an unknown container is asked again on its next process event; entries are also dropped on `container_removed`
- two latent shutdown races in the old fetcher are gone as a side effect

Hot path: `on_new_process` stays O(1), and goroutines, timers and memory are bounded. Unit tests cover the black-hole socket, the cut listing for every engine, the background recovery (including native containerd with full ids across namespaces), the retry schedule, dedup and a 5000-miss stress test; benchmarks live in `fetcher_test.go`. Verified end to end with Falco in `nodriver` mode against a socket that accepts and never answers.

N.B. `engine_timeout` bounds the whole initial listing per engine: on hosts with a huge number of containers, the ones not inspected in time get their metadata a little later, as the background lookups reach them; raise it (or set `0`) to have them all at startup. With podman the timeout can be exceeded by up to about 0.6 s, since its client retries a failed request three times.

**Which issue(s) this PR fixes**:

Fixes #1487
Fixes #1269
Ref falcosecurity/falco#3953

**Special notes for your reviewer**:

The PR went through an independent correctness and performance review and four more review rounds on the startup path; each round's fix is its own commit. The suggestions that change runtime behaviour beyond these two fixes (global vs per-engine timeout, retrying an engine that timed out on `List`, a growing TTL for ids that never resolve, a deadline on steady-state lookups) are tracked in #1535, so that `0.7.3` ships the two fixes as reviewed.

- the backoff schedule, the pending cap and the 10 s TTL are constants on purpose (a knob can come later if a real use case shows up); the TTL must stay above the go-worker retry window
- containers that never resolve are re-asked every 10 s (up to 6 lookups per engine per ask) instead of once ever: bounded, miss path only
- native containerd lookups are exact-id, so the containers left over by a cut listing keep their full id, namespace and engine for the background lookups

**Does this PR introduce a user-facing change?**:

```release-note
fix(plugins/container): bound the startup connection to each container engine with the new `engine_timeout` init config (default 10s, 0 disables it); an engine that does not answer in time is skipped with a warning instead of hanging Falco startup
fix(plugins/container): keep looking up a container the runtime does not know yet (exponential backoff up to about 4s, then ask again after 10s) instead of leaving it without metadata forever
```
