### PR TITLE
fix(plugins/container): recover interrupted containerd inspections

### DIFF
--- a/plugins/container/go-worker/pkg/container/containerd.go
+++ b/plugins/container/go-worker/pkg/container/containerd.go
@@ -42,13 +42,15 @@ func (c *containerdEngine) copy(ctx context.Context) (Engine, error) {
 	return newContainerdEngine(ctx, nil, c.socket)
 }
 
-func (c *containerdEngine) ctrToInfo(namespacedContext context.Context, container containerd.Container) event.Info {
-	info, err := container.Info(namespacedContext)
-	if err != nil {
+// ctrToInfo retains best-effort metadata on error. Return inspection errors too:
+// an RPC can report a deadline before the caller's context observes it.
+func (c *containerdEngine) ctrToInfo(namespacedContext context.Context, container containerd.Container) (event.Info, error) {
+	info, infoErr := container.Info(namespacedContext)
+	if infoErr != nil {
 		info = containers.Container{}
 	}
-	spec, err := container.Spec(namespacedContext)
-	if err != nil {
+	spec, specErr := container.Spec(namespacedContext)
+	if specErr != nil {
 		spec = &oci.Spec{
 			Process: &specs.Process{},
 			Mounts:  nil,
@@ -235,7 +237,7 @@ func (c *containerdEngine) ctrToInfo(namespacedContext context.Context, containe
 			Mounts:           mounts,
 			Size:             imageSize,
 		},
-	}
+	}, errors.Join(infoErr, specErr)
 }
 
 func (c *containerdEngine) get(ctx context.Context, containerId string) (*event.Event, error) {
@@ -258,7 +260,11 @@ func (c *containerdEngine) getInNamespace(ctx context.Context, namespace, contai
 	if err != nil {
 		return nil, err
 	}
-	return &event.Event{Info: c.ctrToInfo(ctx, ctr), IsCreate: true}, nil
+	info, err := c.ctrToInfo(ctx, ctr)
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return nil, err
+	}
+	return &event.Event{Info: info, IsCreate: true}, nil
 }
 
 func (c *containerdEngine) Name() string {
@@ -335,17 +341,15 @@ func (c *containerdEngine) List(ctx context.Context) ([]event.Event, error) {
 		if cut := listCut(ctx); cut != nil {
 			return evts, incomplete(idx, cut)
 		}
-		evt := event.Event{
-			Info:     c.ctrToInfo(nc.ctx, nc.container),
-			IsCreate: true,
+		info, err := c.ctrToInfo(nc.ctx, nc.container)
+		cut := listCut(ctx)
+		if cut == nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)) {
+			cut = err
 		}
-		// ctrToInfo falls back to an empty info and spec on error: a context
-		// done meanwhile is such an error, so do not return this container
-		// either.
-		if cut := listCut(ctx); cut != nil {
+		if cut != nil {
 			return evts, incomplete(idx, cut)
 		}
-		evts = append(evts, evt)
+		evts = append(evts, event.Event{Info: info, IsCreate: true})
 	}
 	return evts, nil
 }
@@ -421,7 +425,7 @@ func (c *containerdEngine) Listen(ctx context.Context, wg *sync.WaitGroup) (<-ch
 						},
 					}
 				} else {
-					info = c.ctrToInfo(namespacedContext, container)
+					info, _ = c.ctrToInfo(namespacedContext, container)
 				}
 				outCh <- event.Event{
 					Info:     info,

--- a/plugins/container/go-worker/pkg/container/containerd_inspection_test.go
+++ b/plugins/container/go-worker/pkg/container/containerd_inspection_test.go
@@ -1,0 +1,149 @@
+package container
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	containersapi "github.com/containerd/containerd/api/services/containers/v1"
+	namespacesapi "github.com/containerd/containerd/api/services/namespaces/v1"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// An RPC error need not cancel the caller's context. Fail Get deterministically
+// at Info (the first Get) or Spec (the second), without relying on timer order.
+type interruptedInspection struct {
+	deferredContainerService
+	mu        sync.Mutex
+	namespace string
+	failAt    int
+	failAfter bool
+	calls     int
+	code      codes.Code
+}
+
+func (s *interruptedInspection) Get(ctx context.Context, req *containersapi.GetContainerRequest) (*containersapi.GetContainerResponse, error) {
+	ns, _ := namespaces.Namespace(ctx)
+	s.mu.Lock()
+	fail := false
+	if ns == s.namespace {
+		s.calls++
+		fail = s.failAt > 0 && (s.calls == s.failAt || (s.failAfter && s.calls > s.failAt))
+	}
+	s.mu.Unlock()
+	if fail {
+		return nil, status.Error(s.code, "inspection interrupted before caller cancellation")
+	}
+	return s.deferredContainerService.Get(ctx, req)
+}
+
+func TestContainerdListInspectionRPCError(t *testing.T) {
+	for _, phase := range []struct {
+		name      string
+		get       int
+		failAfter bool
+	}{{"info", 1, false}, {"spec", 2, false}, {"info_and_spec", 1, true}} {
+		for _, code := range []codes.Code{codes.DeadlineExceeded, codes.Canceled, codes.NotFound} {
+			for _, namespace := range []string{"alpha", "beta"} {
+				t.Run(phase.name+"/"+code.String()+"/"+namespace, func(t *testing.T) {
+					service := &interruptedInspection{
+						deferredContainerService: deferredContainerService{containers: make(map[string]*containersapi.Container)},
+						namespace:                namespace, failAt: phase.get, failAfter: phase.failAfter, code: code,
+					}
+					for i, ns := range []string{"alpha", "beta"} {
+						service.containers[ns] = &containersapi.Container{
+							ID:    strings.Repeat(string(rune('a'+i)), 64),
+							Image: "alpine:latest", Labels: map[string]string{"namespace": ns},
+							Spec: &anypb.Any{TypeUrl: "types.containerd.io/opencontainers/runtime-spec/1/Spec", Value: []byte(`{"process":{"user":{"uid":123}},"linux":{}}`)},
+						}
+					}
+					socket := filepath.Join(t.TempDir(), "runtime.sock")
+					listener, err := net.Listen("unix", socket)
+					require.NoError(t, err)
+					t.Cleanup(func() { _ = listener.Close() })
+					server := grpc.NewServer()
+					namespacesapi.RegisterNamespacesServer(server, &deferredNamespaces{})
+					containersapi.RegisterContainersServer(server, service)
+					go func() { _ = server.Serve(listener) }()
+					t.Cleanup(server.Stop)
+					engine, err := newContainerdEngine(context.Background(), slog.Default(), socket)
+					require.NoError(t, err)
+					t.Cleanup(func() { _ = engine.(*containerdEngine).client.Close() })
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					evts, err := engine.List(ctx)
+					require.NoError(t, ctx.Err(), "the RPC error must precede caller cancellation")
+					t.Logf("caller error=%v; List error=%v; events=%d", ctx.Err(), err, len(evts))
+					for _, evt := range evts {
+						t.Logf("id=%s image=%q labels=%v privileged=%v user=%s", evt.ID, evt.Image, evt.Labels, evt.Privileged, evt.User)
+					}
+					if code == codes.NotFound {
+						// Keep the existing best-effort fallback for non-context errors.
+						require.NoError(t, err)
+						require.Len(t, evts, 2)
+						idx := 0
+						if namespace == "beta" {
+							idx = 1
+						}
+						require.Equal(t, phase.name == "info", evts[idx].Privileged)
+						if phase.get == 1 {
+							require.Empty(t, evts[idx].Labels)
+						} else {
+							require.Equal(t, namespace, evts[idx].Labels["namespace"])
+						}
+						return
+					}
+					var incomplete *ListIncompleteError
+					require.ErrorAs(t, err, &incomplete)
+					cause := context.DeadlineExceeded
+					if code == codes.Canceled {
+						cause = context.Canceled
+					}
+					require.ErrorIs(t, err, cause)
+					require.Empty(t, incomplete.NotEnumerated)
+					wantNamespaces := []string{"alpha", "beta"}
+					if namespace == "beta" {
+						wantNamespaces = []string{"beta"}
+						require.Len(t, evts, 1)
+						require.Equal(t, "alpha", evts[0].Labels["namespace"])
+						require.True(t, evts[0].Privileged)
+					} else {
+						require.Empty(t, evts)
+					}
+					require.Len(t, incomplete.NotInspected, len(wantNamespaces))
+					// A deferred lookup first loads the container, then repeats the
+					// inspection. Do not publish incomplete metadata as a success.
+					service.mu.Lock()
+					service.calls = -1 // allow LoadContainer before Info and Spec
+					service.mu.Unlock()
+					evt, getErr := engine.(*containerdEngine).getInNamespace(ctx, namespace, service.containers[namespace].ID)
+					require.ErrorIs(t, getErr, cause)
+					require.Nil(t, evt)
+					service.mu.Lock()
+					service.failAt = 0
+					service.mu.Unlock()
+					for i, ref := range incomplete.NotInspected {
+						require.Equal(t, wantNamespaces[i], ref.Namespace)
+						require.Equal(t, service.containers[ref.Namespace].ID, ref.ID)
+						// Exercise the same full-ID lookup used by deferred recovery.
+						evt, err := engine.(*containerdEngine).getInNamespace(ctx, ref.Namespace, ref.ID)
+						require.NoError(t, err)
+						require.Equal(t, ref.ID, evt.FullID)
+						require.Equal(t, ref.Namespace, evt.Labels["namespace"])
+						require.True(t, evt.Privileged)
+						require.Equal(t, "123", evt.User)
+					}
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugins

**What this PR does / why we need it**:

During startup inspection, containerd can return `DeadlineExceeded` or `Canceled` before `ctx.Err()` observes cancellation. We were discarding those errors from `Info` and `Spec`, so `List` could return success with incomplete metadata.

That metadata enters the container cache. Later process events do not request it again, since the container is already cached. Missing labels or an incorrect `container.privileged=false` can therefore persist until another event replaces or removes the entry.

This change preserves both inspection errors and treats deadline/cancellation as an interrupted listing. The current container and remaining full IDs are deferred for recovery. Deferred lookups also return a failure on these errors, so they can retry. The fallback for other errors remains unchanged.

**Which issue(s) this PR fixes**:

- Follow-up to #1534.
- Found while testing #1536.

**Special notes for your reviewer**:

The regression test injects RPC errors while the caller context is still live. It covers separate `Info` and `Spec` failures, both failing, and the existing `NotFound` fallback. It fails on unpatched `main`.

Validated on `main` at `5a803b1`, with containerd `2.2.8`:

- `TestContainerdDeferredRecovery` and the new regression test passed 50 runs each with `-race`.
- The full Go worker suite and `go vet` passed. Docker integration tests ran; the six native containerd/CRI/Podman integration tests self-skipped due to unavailable runtime access.
- The Go worker C archive builds successfully.

**Release note**:

```release-note
fix(container): recover container metadata after interrupted containerd startup inspections
```
