### PR TITLE
fix(plugins/container): bound each steady-state lookup with the engine timeout

### DIFF
--- a/plugins/container/go-worker/pkg/container/fetcher.go
+++ b/plugins/container/go-worker/pkg/container/fetcher.go
@@ -395,14 +395,20 @@ func (f *fetcher) forgetFailedDeferred(id string) {
 
 // lookup uses the known runtime identity of a deferred container, or probes
 // the engines for an unknown ID. Success publishes the event and releases
-// any deferred identity.
+// any deferred identity. Each engine answers within the engine timeout, as
+// at bootstrap, so a socket that hangs after startup cannot block the
+// serving goroutine for good.
 func (f *fetcher) lookup(ctx context.Context, containerId string, outCh chan<- event.Event) bool {
 	var evt *event.Event
 	if d, ok := f.deferredLookups[containerId]; ok {
-		evt, _ = d.get(f.ctx)
+		lctx, cancel := WithEngineTimeout(ctx)
+		evt, _ = d.get(lctx)
+		cancel()
 	} else {
 		for _, e := range f.getters {
-			evt, _ = e.get(f.ctx, containerId)
+			lctx, cancel := WithEngineTimeout(ctx)
+			evt, _ = e.get(lctx, containerId)
+			cancel()
 			if evt != nil {
 				break
 			}

--- a/plugins/container/go-worker/pkg/container/fetcher_lookup_timeout_test.go
+++ b/plugins/container/go-worker/pkg/container/fetcher_lookup_timeout_test.go
@@ -1,0 +1,97 @@
+package container
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/event"
+)
+
+// hangingGetter accepts a lookup and never answers it until its context is
+// done, like a runtime socket that hangs after startup.
+type hangingGetter struct {
+	mu      sync.Mutex
+	lookups int
+}
+
+func (g *hangingGetter) get(ctx context.Context, _ string) (*event.Event, error) {
+	g.mu.Lock()
+	g.lookups++
+	g.mu.Unlock()
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (g *hangingGetter) count() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.lookups
+}
+
+// newTestFetcherGetters is newTestFetcher with an explicit getter list.
+func newTestFetcherGetters(getters []getter, fetchCh chan string, backoff []time.Duration, maxPending int, deferred []string) *fetcher {
+	f := &fetcher{
+		getters:         getters,
+		ctx:             context.Background(),
+		fetcherChan:     fetchCh,
+		retryBackoff:    backoff,
+		maxPending:      maxPending,
+		deferred:        append([]string(nil), deferred...),
+		deferredLookups: make(map[string]deferredFetch, len(deferred)),
+	}
+	for _, id := range deferred {
+		f.deferredLookups[id] = deferredFetch{engine: getters[0], ref: ContainerRef{ID: id}, queued: true}
+	}
+	return f
+}
+
+// TestFetcherRequestLookupHonoursEngineTimeout feeds the fetcher a request
+// that a hanging engine never answers: the lookup must give way once the
+// engine timeout expires and consult the next engine with a fresh bound,
+// instead of blocking the fetcher goroutine for good.
+func TestFetcherRequestLookupHonoursEngineTimeout(t *testing.T) {
+	setEngineTimeout(t, 1)
+	hanging := &hangingGetter{}
+	healthy := newCountingGetter(1)
+	fetchCh := make(chan string)
+	f := newTestFetcherGetters([]getter{hanging, healthy}, fetchCh, fastBackoff, maxPendingFetches, nil)
+	outCh := runFetcher(t, f)
+
+	start := time.Now()
+	fetchCh <- "late"
+	evt := waitOnChannelOrTimeout(t, outCh)
+	assert.Equal(t, "late", evt.ID)
+	// The hanging engine burned its whole engine timeout before the healthy
+	// one answered, but no more.
+	elapsed := time.Since(start)
+	assert.GreaterOrEqual(t, elapsed, time.Second)
+	assert.Less(t, elapsed, 5*time.Second)
+}
+
+// TestFetcherDeferredLookupHonoursEngineTimeout defers a startup container
+// to a hanging engine, then asks for a live container: the deferred lookup
+// must return once the engine timeout expires so the request can be served,
+// instead of stalling the single fetcher goroutine.
+func TestFetcherDeferredLookupHonoursEngineTimeout(t *testing.T) {
+	setEngineTimeout(t, 1)
+	hanging := &hangingGetter{}
+	healthy := newCountingGetter(1)
+	fetchCh := make(chan string)
+	f := newTestFetcherGetters([]getter{hanging, healthy}, fetchCh, fastBackoff, maxPendingFetches, []string{"aabbccddeeff"})
+	outCh := runFetcher(t, f)
+
+	start := time.Now()
+	fetchCh <- "late"
+	evt := waitOnChannelOrTimeout(t, outCh)
+	assert.Equal(t, "late", evt.ID)
+	elapsed := time.Since(start)
+	assert.GreaterOrEqual(t, elapsed, time.Second)
+	assert.Less(t, elapsed, 5*time.Second)
+	// The deferred startup lookup and the live request both consulted the
+	// hanging engine, each within the engine timeout.
+	assert.Eventually(t, func() bool { return hanging.count() >= 2 }, 5*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
## Summary

The fetcher's `lookup` passed its background context to every engine probe, so a runtime socket that accepts connections but never answers **after startup** blocked the single serving goroutine for good: live requests, retries and the deferred startup lookups all stalled, and `StopWorker` could not reap the goroutine.

This is the **"Steady-state lookups have no deadline"** follow-up of #1535. The fix bounds each engine probe with the configured `engine_timeout`, the same `WithEngineTimeout` the bootstrap listing (`bootstrapEngines`) and the deferred namespace enumeration (`enumerateNamespace`) already use, so a hanging engine only costs its own timeout and the next engine is consulted with a fresh bound. A zero timeout keeps the previous unbounded behavior, as elsewhere.

Closes the steady-state lookup item of #1535.

## Testing

Regression test (`TestFetcherRequestLookupHonoursEngineTimeout`, `TestFetcherDeferredLookupHonoursEngineTimeout`): a hanging engine never answers; the lookup must give way at the engine timeout and the next engine must serve the container. On main the first test wedges forever (fetcher goroutine stuck in `lookup`, cleanup blocked in `wg.Wait()`); with the fix:

```
=== RUN   TestFetcherRequestLookupHonoursEngineTimeout
--- PASS: TestFetcherRequestLookupHonoursEngineTimeout (1.00s)
=== RUN   TestFetcherDeferredLookupHonoursEngineTimeout
--- PASS: TestFetcherDeferredLookupHonoursEngineTimeout (1.00s)
ok    github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/container    2.015s
```

Focused regression run with upstream's flags (Linux, `-tags containers_image_openpgp -race`):

```
go test -tags containers_image_openpgp -race -count=1 -run 'TestFetcher|TestBootstrap|TestDockerList|TestContainerdList' ./pkg/container/
ok    github.com/falcosecurity/plugins/plugins/container/go-worker/pkg/container    6.168s
```

Note: the full `make test` suite includes `TestContainerd`, which needs a live containerd socket; it fails identically on clean main in the rootless container used for local verification, so it is environmental, not a regression of this change. The new tests and all fetcher/bootstrap/timeout tests pass with `-race`.